### PR TITLE
Begin standardizing Dhall grammar

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -182,7 +182,7 @@ head-path-character =
         ; %x29 = ")"
     / %x2A-2E
         ; %x2F = "/"
-    / %x2G-3B
+    / %x30-3B
         ; %x3C = "<"
     / %x3D
         ; %x3E = ">"

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -52,10 +52,10 @@ simple-label = (letter / "_") *(letter / digit / "-" / "/" / "_")
 label = ("`" simple-label "`" / simple-label) white-space
 
 double-quote-chunk =
-      "${" expression "}"     ; Interpolation
-    / "''${"                  ; Escape interpolation
+      "${" expression "}"  ; Interpolation
+    / "''${"               ; Escape interpolation
     / "\\"
-    / '\"'
+    / %x5C.22              ;'\"'
     / "\n"
     / "\r"
     / "\t"
@@ -83,7 +83,7 @@ single-quote-chunk =
     / not-a-single-quote
 
 text-literal-raw =
-      '"'  *double-quote-chunk '"'
+      %x22 *double-quote-chunk %x22
     / "''" *single-quote-chunk "''"
 
 text-literal = text-literal-raw whitespace

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -1,0 +1,379 @@
+; ABNF syntax based on RFC 5234
+
+; NOTE: There are many line endings in the wild
+;
+; See: https://en.wikipedia.org/wiki/Newline
+;
+; For simplicity this supports Unix and Windows line-endings, which are the most
+; common
+end-of-line
+    = %x0A     ; "\n"
+    / %x0D.0A  ; "\r\n"
+
+tab = %x09  ; "\t"
+
+not-end-of-line = %x20-%7E / tab
+
+not-brace
+    = %x20-7A
+        ; %x7B = "{"
+    / %x7C
+        ; %x7D = "}"
+    / %x7E
+    / tab
+    / end-of-line
+
+block-comment = "{" *not-brace *(block-comment *not-brace) "}"
+
+; TODO: Support Unicode in comments?
+comment
+    ; NOTE: Slightly different from Haskell-style single-line comments because this
+    ; does not require a space after the dashes
+    = "--" *(not-end-of-line) end-of-line
+    / block-comment
+
+whitespace-chunk
+    = " "
+    / tab
+    / end-of-line
+    / comment
+
+whitespace = *whitespace-chunk
+
+; Uppercase or lowercase ASCII letter
+letter = %x41-5A / %x61-7A
+
+; ASCII digit
+digit = %x30-39  ; 0-9
+
+simple-label = (letter / "_") *(letter / digit / "-" / "/" / "_")
+
+; TODO: Support Unicode for labels?
+label = ("`" simple-label "`" / simple-label) white-space
+
+double-quote-chunk
+    = "${" expression "}"     ; Interpolation
+    / "''${"                  ; Escape interpolation
+    / "\\"
+    / '\"'
+    / "\n"
+    / "\r"
+    / "\t"
+    ; Printable characters except double quote and backslash
+    / %x20-21
+        ; %x22 = '"'
+    / %x23-5B
+        ; %x5C = "\"
+    / %x5D-7E
+
+; All printable characters except single quote, and newlines and tabs
+not-a-single-quote
+    = %x20-26
+        ; %x27 = "'"
+    / %x27-7E
+    / tab
+    / end-of-line
+
+; NOTE: You cannot end a "double-single-quote" string literal with a single quote
+single-quote-chunk
+    = "'''"                   ; Escape two single quotes
+    / "${" expression "}"     ; Interpolation
+    / "''${"                  ; Escape interpolation
+    / "'" not-a-single-quote
+    / not-a-single-quote
+
+text-literal-raw
+    = '"'  *double-quote-chunk '"'
+    / "''" *single-quote-chunk "''"
+
+text-literal = text-literal-raw whitespace
+
+; RFC 5234 interprets string literals as case-insensitive and recommends using hex
+; instead for case-sensitive strings
+;
+; If you don't feel like reading hex, these are all the same as the rule name, except
+; converting dashes in the rule name to forward slashes
+if                = %x69.66                                              whitespace
+then              = %x74.68.65.6e                                        whitespace
+else              = %x65.6c.73.65                                        whitespace
+let               = %x6c.65.74                                           whitespace
+in                = %x69.6e                                              whitespace
+as                = %x61.73                                              whitespace
+using             = %x75.73.69.6e.67                                     whitespace
+merge             = %x6d.65.72.67.65                                     whitespace
+Natural-fold      = %x4e.61.74.75.72.61.6c.2f.66.6f.6c.64                whitespace
+Natural-build     = %x4e.61.74.75.72.61.6c.2f.62.75.69.6c.64             whitespace
+Natural-isZero    = %x4e.61.74.75.72.61.6c.2f.69.73.5a.65.72.6f          whitespace
+Natural-even      = %x4e.61.74.75.72.61.6c.2f.65.76.65.6e                whitespace
+Natural-odd       = %x4e.61.74.75.72.61.6c.2f.6f.64.64                   whitespace
+Natural-toInteger = %x4e.61.74.75.72.61.6c.2f.74.6f.49.6e.74.65.67.65.72 whitespace
+Natural-show      = %x4e.61.74.75.72.61.6c.2f.73.68.6f.77                whitespace
+Integer-show      = %x49.6e.74.65.67.65.72.2f.73.68.6f.77                whitespace
+Double-show       = %x44.6f.75.62.6c.65.2f.73.68.6f.77                   whitespace
+List-build        = %x4c.69.73.74.2f.62.75.69.6c.64                      whitespace
+List-fold         = %x4c.69.73.74.2f.66.6f.6c.64                         whitespace
+List-length       = %x4c.69.73.74.2f.6c.65.6e.67.74.68                   whitespace
+List-head         = %x4c.69.73.74.2f.68.65.61.64                         whitespace
+List-last         = %x4c.69.73.74.2f.6c.61.73.74                         whitespace
+List-indexed      = %x4c.69.73.74.2f.69.6e.64.65.78.65.64                whitespace
+List-reverse      = %x4c.69.73.74.2f.72.65.76.65.72.73.65                whitespace
+Optional-fold     = %x4f.70.74.69.6f.6e.61.6c.2f.66.6f.6c.64             whitespace
+Optional-build    = %x4f.70.74.69.6f.6e.61.6c.2f.62.75.69.6c.64          whitespace
+Bool              = %x42.6f.6f.6c                                        whitespace
+Optional          = %x4f.70.74.69.6f.6e.61.6c                            whitespace
+Natural           = %x4e.61.74.75.72.61.6c                               whitespace
+Integer           = %x49.6e.74.65.67.65.72                               whitespace
+Double            = %x44.6f.75.62.6c.65                                  whitespace
+Text              = %x54.65.78.74                                        whitespace
+List              = %x4c.69.73.74                                        whitespace
+True              = %x54.72.75.65                                        whitespace
+False             = %x46.61.6c.73.65                                     whitespace
+Type              = %x54.79.70.65                                        whitespace
+Kind              = %x4b.69.6e.64                                        whitespace
+
+equal         = "="  whitespace
+or            = "||" whitespace
+plus          = "+"  whitespace
+text-append   = "++" whitespace
+list-append   = "#"  whitespace
+and           = "&&" whitespace
+times         = "*"  whitespace
+double-equal  = "==" whitespace
+not-equal     = "!=" whitespace
+dot           = "."  whitespace
+open-brace    = "{"  whitespace
+close-brace   = "}"  whitespace
+open-bracket  = "["  whitespace
+close-bracket = "]"  whitespace
+open-angle    = "<"  whitespace
+close-angle   = ">"  whitespace
+bar           = "|"  whitespace
+comma         = ","  whitespace
+open-parens   = "("  whitespace
+close-parens  = ")"  whitespace
+colon         = ":"  whitespace
+at            = "@"  whitespace
+
+combine = ( %xE2.88.A7 / "/\"               ) whitespace  ; UTF8 "∧" (U+2227)
+prefer  = ( %xE2.AB.BD / "//"               ) whitespace  ; UTF8 "⫽" (U+2AFD)
+lambda  = ( %xCE.BB    / "\"                ) whitespace  ; UTF8 "λ" (U+03BB)
+forall  = ( %xE2.88.80 / %x66.6f.72.61.6c.6c) whitespace  ; UTF8 "∀" (U+2200)
+arrow   = ( %xE2.86.92 / "->"               ) whitespace  ; UTF8 "→" (U+2192)
+
+exponent = ("e" / "E") [ "+" / "-" ] 1*digit
+
+double-literal = 1*digit ( "." 1*digit [ exponent ] / exponent)
+
+; TODO: Perhaps this should require a non-zero starting digit
+integer-literal = 1*digit whitespace
+
+natural-literal = "+" integer-literal whitespace
+
+var = label [ at natural-literal ]
+
+; Printable characters other than " ()[]{}<>/\"
+;
+; Excluding those characters ensures that paths don't have to end with trailing
+; whitespace most of the time
+head-path-character
+        ; %x20 = " "
+    = %x21-27
+        ; %x28 = "("
+        ; %x29 = ")"
+    / %x2A-2E
+        ; %x2F = "/"
+    / %x2G-3B
+        ; %x3C = "<"
+    / %x3D
+        ; %x3E = ">"
+    / %x3F-5A
+        ; %x5B = "["
+        ; %x5C = "\"
+        ; %x5D = "]"
+    / %x5E-7A
+        ; %x7B = "{"
+    / %x7C
+        ; %x7D = "}"
+    / %x7E
+
+path-character = head-path-character / "\" / "/"
+
+; The first character of an absolute path cannot be a forward slash or
+; back-slash since that conflicts with the "/\" and "//" operators
+file-raw
+    = "/" head-path-character *path-character
+    / "./" *path-character
+    / "~/" *path-character
+
+file = file-raw whitespace
+
+scheme = %x68.74.74.70 [ %x73 ]  ; "http" [ "s" ]
+
+; TODO: Parse URLs more precisely
+url = scheme "://" *path-character whitespace [ using path-type ]
+
+; TODO: Possibly restrict permissible environment variable names
+env = "env:" 1*pathChar whitespace
+
+path-type = file / url / env
+
+import = path-type [ as Text ]
+
+; NOTE: Every rule past this point should only reference rules that end with
+; whitespace in order to ensure consistent handling of whitespace
+
+expression
+    ; "λ(x : a) → b"
+    = lambda open-parens label colon expression close-parens arrow expression
+
+    ; "if a then b else c"
+    / if expression then expression else expression
+
+    ; "let x : t = e1 in e2"
+    ; "let x     = e1 in e2"
+    / let label [ colon expression ] equal expression in expression
+
+    ; "∀(x : a) → b"
+    / forall open-parens label colon expression close-parens arrow expression
+
+    ; "a → b"
+    / operator-expression arrow expression
+
+    / annotated-expression
+
+annotated-expression
+    ; "merge e1 e2 : t"
+    ; "merge e1 e2"
+    = merge selector-expression selector-expression [ colon application-expression ]
+
+    ; "[]  : List     t"
+    ; "[]  : Optional t"
+    ; "[x] : Optional t"
+    / open-bracket (empty-collection / non-empty-optional)
+
+    ; "x : t"
+    / operator-expression (colon expression / "")
+
+empty-collection = close-bracket colon (List / Optional) selector-expression
+
+non-empty-optional = expression close-bracket colon Optional selector-expression
+
+operator-expression = or-expression
+
+or-expression          = plus-expression        *(or          plus-expression       )
+plus-expression        = text-append-expression *(plus        text-append-expression)
+text-append-expression = list-append-expression *(text-append list-append-expression)
+list-append-expression = and-expression         *(list-append and-expression        )
+and-expression         = combine-expression     *(and         combine-expression    )
+combine-expression     = prefer-expression      *(combine     prefer-expression     )
+prefer-expression      = times-expression       *(prefer      times-expression      )
+times-expression       = equal-expression       *(times       equal-expression      )
+equal-expression       = not-equal-expression   *(equal       not-equal-expression  )
+not-equal-expression   = application-expression *(not-equal   application-expression)
+
+application-expression = 1*selector-expression
+
+selector-expression = primitive-expression *(dot label)
+
+primitive-expression
+    ; "2.0"
+    = double-literal
+
+    ; "+2"
+    / natural-literal
+
+    ; "2"
+    / integer-literal
+
+    ; '"ABC"'
+    / text-literal
+
+    ; "{ foo = 1, bar = True }"
+    ; "{ foo : Integer, bar : Bool }"
+    / open-brace record-type-or-literal close-brace
+
+    ; "< Foo : Integer | Bar : Bool >"
+    ; "< Foo : Integer | Bar = True >"
+    / open-angle union-type-or-literal  close-angle
+
+    ; "[1, 2, 3]"
+    / non-empty-list-literal  ; `annotated-expression` handles empty lists
+
+    ; "http://example.com"
+    ; "./foo/bar"
+    ; "env:FOO"
+    / import
+
+    ; Built-in functions
+    / Natural-fold
+    / Natural-build
+    / Natural-isZero
+    / Natural-even
+    / Natural-odd
+    / Natural-toInteger
+    / Natural-show
+    / Integer-show
+    / Double-show
+    / List-build
+    / List-fold
+    / List-length
+    / List-head
+    / List-last
+    / List-indexed
+    / List-reverse
+    / Optional-fold
+    / Optional-build
+
+    ; Built-in types
+    / Bool
+    / Optional
+    / Natural
+    / Integer
+    / Double
+    / Text
+    / List
+
+    ; Built-in values
+    / True
+    / False
+
+    ; Built-in type-checking constants
+    / Type
+    / Kind
+
+    ; "x"
+    ; "x@2"
+    / var
+
+    ; "( e )"
+    / open-parens expression close-parens
+
+; TODO: This doesn't support trailing commas
+record-type-or-literal
+    = equal                             ; Empty record literal
+    / non-empty-record-type-or-literal
+    / ""                                ; Empty record type
+
+non-empty-record-type-or-literal
+    = label (non-empty-record-literal / non-empty-record-type)
+
+non-empty-record-type    = colon expression *(comma label colon expression)
+non-empty-record-literal = equal expression *(comma label equal expression)
+
+; TODO: This doesn't support trailing bars
+union-type-or-literal
+    = non-empty-union-type-or-literal
+    / ""                               ; Empty union type
+
+non-empty-union-type-or-literal
+    = label
+      ( equal expression *(bar label colon expression)
+      / colon expression (bar non-empty-union-type-or-literal / "")
+      )
+
+; TODO: This doesn't support trailing commas
+non-empty-list-literal = open-bracket expression *(comma expression) close-bracket
+
+; All expressions end with trailing whitespace.  This just adds a final
+; whitespace prefix for the top-level of the program
+complete-expression = whitespace expression

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -162,10 +162,10 @@ arrow   = ( %xE2.86.92 / "->"               ) whitespace  ; U+2192
 
 exponent = ("e" / "E") [ "+" / "-" ] 1*digit
 
-double-literal = 1*digit ( "." 1*digit [ exponent ] / exponent)
+double-literal = [ "-" ] 1*digit ( "." 1*digit [ exponent ] / exponent)
 
 ; TODO: Perhaps this should require a non-zero starting digit
-integer-literal = 1*digit whitespace
+integer-literal = [ "-" ] 1*digit whitespace
 
 natural-literal = "+" integer-literal whitespace
 

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -154,11 +154,11 @@ close-parens  = ")"  whitespace
 colon         = ":"  whitespace
 at            = "@"  whitespace
 
-combine = ( %xE2.88.A7 / "/\"               ) whitespace  ; UTF8 "∧" (U+2227)
-prefer  = ( %xE2.AB.BD / "//"               ) whitespace  ; UTF8 "⫽" (U+2AFD)
-lambda  = ( %xCE.BB    / "\"                ) whitespace  ; UTF8 "λ" (U+03BB)
-forall  = ( %xE2.88.80 / %x66.6f.72.61.6c.6c) whitespace  ; UTF8 "∀" (U+2200)
-arrow   = ( %xE2.86.92 / "->"               ) whitespace  ; UTF8 "→" (U+2192)
+combine = ( %xE2.88.A7 / "/\"               ) whitespace  ; U+2227
+prefer  = ( %xE2.AB.BD / "//"               ) whitespace  ; U+2AFD
+lambda  = ( %xCE.BB    / "\"                ) whitespace  ; U+03BB
+forall  = ( %xE2.88.80 / %x66.6f.72.61.6c.6c) whitespace  ; U+2200
+arrow   = ( %xE2.86.92 / "->"               ) whitespace  ; U+2192
 
 exponent = ("e" / "E") [ "+" / "-" ] 1*digit
 
@@ -223,7 +223,7 @@ import = path-type [ as Text ]
 ; whitespace in order to ensure consistent handling of whitespace
 
 expression =
-    ; "λ(x : a) → b"
+    ; "\(x : a) -> b"
       lambda open-parens label colon expression close-parens arrow expression
 
     ; "if a then b else c"
@@ -233,10 +233,10 @@ expression =
     ; "let x     = e1 in e2"
     / let label [ colon expression ] equal expression in expression
 
-    ; "∀(x : a) → b"
+    ; "forall (x : a) -> b"
     / forall open-parens label colon expression close-parens arrow expression
 
-    ; "a → b"
+    ; "a -> b"
     / operator-expression arrow expression
 
     / annotated-expression

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -6,16 +6,16 @@
 ;
 ; For simplicity this supports Unix and Windows line-endings, which are the most
 ; common
-end-of-line
-    = %x0A     ; "\n"
+end-of-line =
+      %x0A     ; "\n"
     / %x0D.0A  ; "\r\n"
 
 tab = %x09  ; "\t"
 
-not-end-of-line = %x20-%7E / tab
+not-end-of-line = %x20-7E / tab
 
-not-brace
-    = %x20-7A
+not-brace =
+      %x20-7A
         ; %x7B = "{"
     / %x7C
         ; %x7D = "}"
@@ -26,14 +26,14 @@ not-brace
 block-comment = "{" *not-brace *(block-comment *not-brace) "}"
 
 ; TODO: Support Unicode in comments?
-comment
+comment =
     ; NOTE: Slightly different from Haskell-style single-line comments because this
     ; does not require a space after the dashes
-    = "--" *(not-end-of-line) end-of-line
+      "--" *(not-end-of-line) end-of-line
     / block-comment
 
-whitespace-chunk
-    = " "
+whitespace-chunk =
+      " "
     / tab
     / end-of-line
     / comment
@@ -51,8 +51,8 @@ simple-label = (letter / "_") *(letter / digit / "-" / "/" / "_")
 ; TODO: Support Unicode for labels?
 label = ("`" simple-label "`" / simple-label) white-space
 
-double-quote-chunk
-    = "${" expression "}"     ; Interpolation
+double-quote-chunk =
+      "${" expression "}"     ; Interpolation
     / "''${"                  ; Escape interpolation
     / "\\"
     / '\"'
@@ -67,23 +67,23 @@ double-quote-chunk
     / %x5D-7E
 
 ; All printable characters except single quote, and newlines and tabs
-not-a-single-quote
-    = %x20-26
+not-a-single-quote =
+      %x20-26
         ; %x27 = "'"
     / %x27-7E
     / tab
     / end-of-line
 
 ; NOTE: You cannot end a "double-single-quote" string literal with a single quote
-single-quote-chunk
-    = "'''"                   ; Escape two single quotes
+single-quote-chunk =
+      "'''"                   ; Escape two single quotes
     / "${" expression "}"     ; Interpolation
     / "''${"                  ; Escape interpolation
     / "'" not-a-single-quote
     / not-a-single-quote
 
-text-literal-raw
-    = '"'  *double-quote-chunk '"'
+text-literal-raw =
+      '"'  *double-quote-chunk '"'
     / "''" *single-quote-chunk "''"
 
 text-literal = text-literal-raw whitespace
@@ -175,9 +175,9 @@ var = label [ at natural-literal ]
 ;
 ; Excluding those characters ensures that paths don't have to end with trailing
 ; whitespace most of the time
-head-path-character
+head-path-character =
         ; %x20 = " "
-    = %x21-27
+      %x21-27
         ; %x28 = "("
         ; %x29 = ")"
     / %x2A-2E
@@ -200,8 +200,8 @@ path-character = head-path-character / "\" / "/"
 
 ; The first character of an absolute path cannot be a forward slash or
 ; back-slash since that conflicts with the "/\" and "//" operators
-file-raw
-    = "/" head-path-character *path-character
+file-raw =
+      "/" head-path-character *path-character
     / "./" *path-character
     / "~/" *path-character
 
@@ -222,9 +222,9 @@ import = path-type [ as Text ]
 ; NOTE: Every rule past this point should only reference rules that end with
 ; whitespace in order to ensure consistent handling of whitespace
 
-expression
+expression =
     ; "λ(x : a) → b"
-    = lambda open-parens label colon expression close-parens arrow expression
+      lambda open-parens label colon expression close-parens arrow expression
 
     ; "if a then b else c"
     / if expression then expression else expression
@@ -241,10 +241,10 @@ expression
 
     / annotated-expression
 
-annotated-expression
+annotated-expression =
     ; "merge e1 e2 : t"
     ; "merge e1 e2"
-    = merge selector-expression selector-expression [ colon application-expression ]
+      merge selector-expression selector-expression [ colon application-expression ]
 
     ; "[]  : List     t"
     ; "[]  : Optional t"
@@ -275,9 +275,9 @@ application-expression = 1*selector-expression
 
 selector-expression = primitive-expression *(dot label)
 
-primitive-expression
+primitive-expression =
     ; "2.0"
-    = double-literal
+      double-literal
 
     ; "+2"
     / natural-literal
@@ -349,27 +349,27 @@ primitive-expression
     / open-parens expression close-parens
 
 ; TODO: This doesn't support trailing commas
-record-type-or-literal
-    = equal                             ; Empty record literal
+record-type-or-literal =
+      equal                             ; Empty record literal
     / non-empty-record-type-or-literal
     / ""                                ; Empty record type
 
-non-empty-record-type-or-literal
-    = label (non-empty-record-literal / non-empty-record-type)
+non-empty-record-type-or-literal =
+    label (non-empty-record-literal / non-empty-record-type)
 
 non-empty-record-type    = colon expression *(comma label colon expression)
 non-empty-record-literal = equal expression *(comma label equal expression)
 
 ; TODO: This doesn't support trailing bars
-union-type-or-literal
-    = non-empty-union-type-or-literal
+union-type-or-literal =
+      non-empty-union-type-or-literal
     / ""                               ; Empty union type
 
-non-empty-union-type-or-literal
-    = label
-      ( equal expression *(bar label colon expression)
-      / colon expression (bar non-empty-union-type-or-literal / "")
-      )
+non-empty-union-type-or-literal =
+    label
+    ( equal expression *(bar label colon expression)
+    / colon expression (bar non-empty-union-type-or-literal / "")
+    )
 
 ; TODO: This doesn't support trailing commas
 non-empty-list-literal = open-bracket expression *(comma expression) close-bracket

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -55,7 +55,7 @@ double-quote-chunk =
       "${" expression "}"  ; Interpolation
     / "''${"               ; Escape interpolation
     / "\\"
-    / %x5C.22              ;'\"'
+    / %x5C.22              ; '\"'
     / "\n"
     / "\r"
     / "\t"
@@ -79,8 +79,8 @@ single-quote-chunk =
       "'''"                   ; Escape two single quotes
     / "${" expression "}"     ; Interpolation
     / "''${"                  ; Escape interpolation
-    / "'" not-a-single-quote
-    / not-a-single-quote
+    / "'" 1*not-a-single-quote
+    / 1*not-a-single-quote
 
 text-literal-raw =
       %x22 *double-quote-chunk %x22
@@ -154,11 +154,11 @@ close-parens  = ")"  whitespace
 colon         = ":"  whitespace
 at            = "@"  whitespace
 
-combine = ( %xE2.88.A7 / "/\"               ) whitespace  ; U+2227
-prefer  = ( %xE2.AB.BD / "//"               ) whitespace  ; U+2AFD
-lambda  = ( %xCE.BB    / "\"                ) whitespace  ; U+03BB
-forall  = ( %xE2.88.80 / %x66.6f.72.61.6c.6c) whitespace  ; U+2200
-arrow   = ( %xE2.86.92 / "->"               ) whitespace  ; U+2192
+combine = ( %xE2.88.A7 / "/\"                ) whitespace  ; U+2227
+prefer  = ( %xE2.AB.BD / "//"                ) whitespace  ; U+2AFD
+lambda  = ( %xCE.BB    / "\"                 ) whitespace  ; U+03BB
+forall  = ( %xE2.88.80 / %x66.6f.72.61.6c.6c ) whitespace  ; U+2200
+arrow   = ( %xE2.86.92 / "->"                ) whitespace  ; U+2192
 
 exponent = ("e" / "E") [ "+" / "-" ] 1*digit
 
@@ -169,7 +169,7 @@ integer-literal = [ "-" ] 1*digit whitespace
 
 natural-literal = "+" integer-literal whitespace
 
-var = label [ at natural-literal ]
+identifier = label [ at natural-literal ]
 
 ; Printable characters other than " ()[]{}<>/\"
 ;
@@ -288,7 +288,7 @@ primitive-expression =
     ; '"ABC"'
     / text-literal
 
-    ; "{ foo = 1, bar = True }"
+    ; "{ foo = 1      , bar = True }"
     ; "{ foo : Integer, bar : Bool }"
     / open-brace record-type-or-literal close-brace
 
@@ -343,7 +343,7 @@ primitive-expression =
 
     ; "x"
     ; "x@2"
-    / var
+    / identifier
 
     ; "( e )"
     / open-parens expression close-parens


### PR DESCRIPTION
This change includes a first pass at standardizing Dhall's grammar using ABNF
notation from RFC 5234.  There are still some open questions and deviations from
the Haskell parser documented in the comments as `TODO`s

cc: @jmitchell