### PR TITLE
Don't support Unicode labels

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -52,7 +52,6 @@ hex = digit / "A" / "B" / "C" / "D" / "E" / "F"
 
 simple-label = (letter / "_") *(letter / digit / "-" / "/" / "_")
 
-; TODO: Support Unicode for labels?
 label = ("`" simple-label "`" / simple-label) white-space
 
 ; Dhall's double-quoted strings are equivalent to JSON strings except with support; for string interpolation (and escaping string interpolation)


### PR DESCRIPTION
The primary reasons for not supporting Unicode labels are:

* They are semantically meaningful and therefore a security risk if confused
* They are difficult to implement safely (see: http://unicode.org/reports/tr31/)
  which increases the implementation cost for Dhall language bindings