### PR TITLE
Restrict the set of permissible environment variable imports

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -256,7 +256,12 @@ scheme = %x68.74.74.70 [ %x73 ]  ; "http" [ "s" ]
 url = scheme "://" *path-character whitespace [ using path-type ]
 
 ; TODO: Possibly restrict permissible environment variable names
-env = "env:" 1*pathChar whitespace
+; The grammar for environment variable imports is based on the set of
+; environment variable names that Bash accepts.  From the Bash `man` page:
+;
+; > A word consisting only of  alphanumeric  characters  and  under-scores,  and
+; > beginning with an alphabetic character or an under-score
+env = "env:" (ALPHA / "_") *(ALPHA / DIGIT / "_")
 
 path-type = file / url / env
 

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -255,7 +255,6 @@ scheme = %x68.74.74.70 [ %x73 ]  ; "http" [ "s" ]
 ; TODO: Parse URLs more precisely
 url = scheme "://" *path-character whitespace [ using path-type ]
 
-; TODO: Possibly restrict permissible environment variable names
 ; The grammar for environment variable imports is based on the set of
 ; environment variable names that Bash accepts.  From the Bash `man` page:
 ;


### PR DESCRIPTION
This changes the grammar for environment variable imports to match the set of
names accepted by Bash