### PR TITLE
Fix parsing of Unicode comments

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -21,7 +21,7 @@ not-brace =
         ; %x7B = "{"
     / %x7C
         ; %x7D = "}"
-    / %x10FFFF
+    / %x7E-10FFFF
     / tab
     / end-of-line
 


### PR DESCRIPTION
The `not-brace` parser was missing characters ranging over `0x7E-10FFFE`