### PR TITLE
Fix grammar for `Natural` numbers

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -205,9 +205,11 @@ exponent = "e" [ "+" / "-" ] 1*DIGIT
 
 double-literal = [ "-" ] 1*DIGIT ( "." 1*DIGIT [ exponent ] / exponent)
 
-integer-literal = [ "-" ] 1*DIGIT whitespace
+natural-raw = 1*DIGIT
 
-natural-literal = "+" integer-literal whitespace
+integer-literal = [ "-" ] natural-raw whitespace
+
+natural-literal = "+" natural-raw whitespace
 
 identifier = label [ at natural-literal ]
 

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -211,7 +211,7 @@ integer-literal = [ "-" ] natural-raw whitespace
 
 natural-literal = "+" natural-raw whitespace
 
-identifier = label [ at natural-literal ]
+identifier = label [ at natural-raw ]
 
 ; Printable characters other than " ()[]{}<>/\"
 ;


### PR DESCRIPTION
The `Natural` number grammar was defined in terms of the `Integer` parser, which
meant that `Natural` numbers could incorrectly have minus signs in them.  This
change fixes that