### PR TITLE
Additional fixes to grammar

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -336,7 +336,7 @@ natural-literal = "+" natural-raw whitespace
 
 identifier = label [ at natural-raw ]
 
-; Printable characters other than " ()[]{}<>/\"
+; Printable characters other than " ()[]{}<>/\,"
 ;
 ; Excluding those characters ensures that paths don't have to end with trailing
 ; whitespace most of the time
@@ -345,7 +345,9 @@ head-path-character =
       %x21-27
         ; %x28 = "("
         ; %x29 = ")"
-    / %x2A-2E
+    / %x2A-2B
+        ; %x2C = ","
+    / %x2D-2E
         ; %x2F = "/"
     / %x30-3B
         ; %x3C = "<"
@@ -397,6 +399,7 @@ IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
 
 IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
 
+; NOTE: Backtrack when parsing each alternative
 IPv6address =                            6( h16 ":" ) ls32
             /                       "::" 5( h16 ":" ) ls32
             / [               h16 ] "::" 4( h16 ":" ) ls32
@@ -413,6 +416,7 @@ ls32 = ( h16 ":" h16 ) / IPv4address
 
 IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
 
+; NOTE: Backtrack when parsing these alternatives and try them in reverse order
 dec-octet = DIGIT              ; 0-9
           / %x31-39 DIGIT      ; 10-99
           / "1" 2DIGIT         ; 100-199


### PR DESCRIPTION
This removes the comma from the set of allowed path characters so that
this is legal:

```haskell
[ ./path, ./path ]
```

This also adds two additional backtracking hints for parsing IPv4 and IPv6