### PR TITLE
Remove `''${` escape sequence for double-quoted strings

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -205,7 +205,6 @@ label = ("`" quoted-label "`" / simple-label) whitespace
 ; > "\uD834\uDD1E".
 double-quote-chunk =
       "${" expression "}"  ; Interpolation
-    / "''${"               ; Escape interpolation
     / %x5C                 ; '\'    Beginning of escape sequence
       ( %x22               ; '"'    quotation mark  U+0022
       / %x24               ; '$'    dollar sign     U+0024


### PR DESCRIPTION
The `''${` escape sequence doesn't make sense for double-quoted
strings.  First off, it already has an escape sequence for interpolation,
which is `\${`.  Second, escape sequences beginning with `''` are
reserved for single-quoted strings