### PR TITLE
Update cheatsheet to reflect JSON-style escapes

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -41,7 +41,7 @@ True, False : Bool
 
 ### Text
 
-1. normal double-quoted strings, Haskell style escaping (`"\"abc\"\ndef"`)
+1. normal double-quoted strings, JSON-style escaping (`"\"abc\"\ndef"`)
 2. nix-style interpolated, multi-line strings
     * newline stripping
 


### PR DESCRIPTION
As part of standardizing the grammar the language now
uses JSON-style escape sequences instead of Haskell-style
escape sequences.  These are *mostly* the same for the
most common cases