### PR TITLE
Fix newline stripping example

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -57,7 +57,7 @@ True, False : Bool
       ''
       ```
 
-      is `"\nfoo\nbar\n"`
+      is `"foo\nbar\n"`
 
     * no newlines & escaping `''`
 


### PR DESCRIPTION
The latest version of Dhall strips the leading newline