### PR TITLE
Extend valid set of quoted labels

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -163,7 +163,7 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
 ; Identical to simple-label except that reserved keywords are allowed
-quoted-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
+quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":")
 
 ; NOTE: Dhall does not support Unicode labels, mainly to minimize the potential
 ; for code obfuscation


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-lang/issues/64

This adds `:` to the list of supported characters for Dhall labels and
no longer treats the initial character of a quoted label differently