### PR TITLE
Type synonym support

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2232,7 +2232,7 @@ the preceding function application rules apply:
 
 ### `let` expressions
 
-An expression of the form:
+For the purposes of normalization, an expression of the form:
 
     let x : A = a₀ in b₀
 
@@ -3023,50 +3023,48 @@ the function argument then that is a type error.
 
 ### `let` expressions
 
-An expression of the form:
+For the purposes of type-checking, an expression of the form:
 
     let x : A = a₀ in b₀
 
-... is semantically identical to:
+... is **not** semantically identical to:
 
     (λ(x : A) → b₀) a₀
 
-... and the type-checking rules for `let` expressions reflect that semantic
-equivalence:
+`let` differs in behavior in order to support "type synonyms", such as:
+
+    let t = Integer in 1 : t
+
+If you were to desugar that to:
+
+    (λ(t : Integer) → 1 : t) Integer
+
+... then that would not be a well-typed expression, even though the `let`
+expression would be well-typed.
 
 
-    Γ₀ ⊢ a₀ : A₁
-    Γ₀ ⊢ A₀ :⇥ i
+    Γ ⊢ a₀ : A₁
+    Γ ⊢ A₀ : i
     A₀ ≡ A₁
-    ↑(1, x, 0, (Γ₀, x : A₀)) = Γ₁
-    Γ₁ ⊢ b : B₀
-    Γ₁ ⊢ B₀ :⇥ o
-    i ↝ o
     ↑(1, x, 0, a₀) = a₁
-    B₀[x ≔ a₁]) = B₁
-    ↑(-1, x, 0, B₁) = B₂
-    ──────────────────────────────
-    Γ₀ ⊢ let x : A₀ = a₀ in b : B₂
+    b₀[x ≔ a₁] = b₁
+    ↑(-1, x, 0, b₁) = b₂
+    Γ ⊢ b₂ : B
+    ─────────────────────────────
+    Γ ⊢ let x : A₀ = a₀ in b₀ : B
 
 
-    Γ₀ ⊢ a₀ : A
-    Γ₀ ⊢ A :⇥ i
-    ↑(1, x, 0, (Γ₀, x : A)) = Γ₁
-    Γ₁ ⊢ b : B₀
-    Γ₁ ⊢ B₀ :⇥ o
-    i ↝ o
+    Γ ⊢ a₀ : A
     ↑(1, x, 0, a₀) = a₁
-    B₀[x ≔ a₁] = B₁
-    ↑(-1, x, 0, B₁) = B₂
-    ────────────────────────────
-    Γ₀ ⊢ let x = a₀ in b : B₂
+    b₀[x ≔ a₁] = b₁
+    ↑(-1, x, 0, b₁) = b₂
+    Γ ⊢ b₂ : B
+    ────────────────────────
+    Γ ⊢ let x = a₀ in b₀ : B
 
 
 If the `let` expression has a type annotation that doesn't match the type of
 the right-hand side of the assignment then that is a type error.
-
-If the `let` expression desugars to an anonymous function with a dependent
-function type, then that is a type error.
 
 ### Type annotations
 

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3033,11 +3033,11 @@ For the purposes of type-checking, an expression of the form:
 
 `let` differs in behavior in order to support "type synonyms", such as:
 
-    let t = Integer in 1 : t
+    let t : Type = Integer in 1 : t
 
 If you were to desugar that to:
 
-    (λ(t : Integer) → 1 : t) Integer
+    (λ(t : Type) → 1 : t) Integer
 
 ... then that would not be a well-typed expression, even though the `let`
 expression would be well-typed.

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3046,8 +3046,9 @@ expression would be well-typed.
     Γ ⊢ a₀ : A₁
     Γ ⊢ A₀ : i
     A₀ ≡ A₁
-    ↑(1, x, 0, a₀) = a₁
-    b₀[x ≔ a₁] = b₁
+    a₀ ⇥ a₁
+    ↑(1, x, 0, a₁) = a₂
+    b₀[x ≔ a₂] = b₁
     ↑(-1, x, 0, b₁) = b₂
     Γ ⊢ b₂ : B
     ─────────────────────────────
@@ -3055,8 +3056,9 @@ expression would be well-typed.
 
 
     Γ ⊢ a₀ : A
-    ↑(1, x, 0, a₀) = a₁
-    b₀[x ≔ a₁] = b₁
+    a₀ ⇥ a₁
+    ↑(1, x, 0, a₁) = a₂
+    b₀[x ≔ a₂] = b₁
     ↑(-1, x, 0, b₁) = b₂
     Γ ⊢ b₂ : B
     ────────────────────────


### PR DESCRIPTION
This changes the standard semantics to support type synonyms, which is one of
the most common feature requests.  Here are some example requests:

* https://github.com/dhall-lang/dhall-haskell/issues/10
* https://github.com/dhall-lang/dhall-haskell/issues/55
* https://github.com/dhall-lang/dhall-haskell/issues/92
* https://github.com/dhall-lang/dhall-haskell/issues/163
* https://github.com/dhall-lang/dhall-haskell/issues/176
* https://github.com/dhall-lang/dhall-haskell/issues/201
* https://github.com/dhall-lang/dhall-lang/issues/10

The change to the semantics is pretty simple: don't require that `let`
expressions type-check as an equivalent anonymous function.  Instead, just
perform substitution and type-check the substituted expression.  The semantics
are still sound and this behaves the way users expect.

For example, the following expression would be rejected before this change
and accepted after this change:

```haskell
let t = Integer in 1 : t
```