### PR TITLE
Extend valid set of quoted labels to period

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -162,7 +162,7 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 ; * Kind
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
-quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":")
+quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / ".")
 
 ; NOTE: Dhall does not support Unicode labels, mainly to minimize the potential
 ; for code obfuscation


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-lang/issues/76

This adds `.` to the list of supported characters for Dhall labels.