### PR TITLE
Add `constructors` to reserved keywords

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -131,6 +131,7 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 ; * as
 ; * using
 ; * merge
+; * constructors
 ; * Natural/fold
 ; * Natural/build
 ; * Natural/isZero


### PR DESCRIPTION
This technically doesn't change the grammar since
parsing `constructors` takes precedence over parsing
variable names, but it's good to keep the list of
reserved keywords up to date