### PR TITLE
Increase precedence of parsing variable names

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -615,6 +615,10 @@ primitive-expression =
     ; "env:FOO"
     / import
 
+    ; "x"
+    ; "x@2"
+    / identifier
+
     ; Built-in functions
     / Natural-fold
     / Natural-build
@@ -651,10 +655,6 @@ primitive-expression =
     ; Built-in type-checking constants
     / Type
     / Kind
-
-    ; "x"
-    ; "x@2"
-    / identifier
 
     ; "( e )"
     / open-parens expression close-parens


### PR DESCRIPTION
The purpose of this change is to permit identifiers that begin with
reserved keywords.  Here are some example issues due to Dhall
previously not supporting that:

* https://github.com/dhall-lang/dhall-haskell/issues/250
* https://github.com/dhall-lang/dhall-lang/issues/59

After this change, names like `List/map` or `TypeSynonym`
would become legal.  However, this should not break any
existing code because variable names will still reject reserved
identifiers.