### PR TITLE
NixOps specification for Dhall infrastructure

### DIFF
--- a/nixops/README.md
+++ b/nixops/README.md
@@ -1,0 +1,105 @@
+# Dhall infrastructure
+
+This directory contains a NixOps specification for hosting Dhall infrastructure,
+which currently consists of:
+
+* An IPFS mirror for the Dhall Prelude
+    * This can be deployed by anybody without any special credentials or
+      permissions as long as you're willing to pay for your own `t2.nano` AWS
+      instance
+* A Hydra server for Dhall CI
+    * This requires an account with read/write access to the Dhall repositories
+      and also requires access to the `hydra.dhall-lang.org` server.  This
+      exists mainly to document the current deployment, but you can adapt the
+      deployment to your own machines/projects/accounts if desired.
+
+You can deploy your own copy of this infrastructure using the following
+instructions:
+
+*   Installing Nix by following these instructions:
+
+    [https://nixos.org/nix/download.html](https://nixos.org/nix/download.html)
+
+*   Installing the necessary toolchain, either permanently:
+
+    ```bash
+    $ nix-env --install --attr nixops
+    $ nix-env --install --attr awscli
+    ```
+
+    ... or transiently:
+
+    ```bash
+    $ nix-shell --packages nixops awscli
+    ```
+
+*   Set up AWS credentials under the `default` profile:
+
+    ```bash
+    $ aws configure
+    ```
+
+*   Deploy the infrastructure using `nixops`:
+
+    First, create the deployment specification:
+
+    ```bash
+    $ nixops create -d dhall logical.nix physical.nix
+    ```
+
+    THen you can deploy the IPFS server by running:
+    ```bash
+    $ EC2_ACCESS_KEY=default nixops deploy -d dhall --include ipfs
+    ```
+
+    ... and deploy the Hydra server (if you have the credentials to do so) by
+    running:
+
+    ```bash
+    $ nixops deploy -d dhall --include hydra
+    ```
+
+*   Create an administrative user for `hydra`:
+
+    ```bash
+    $ nixops ssh -d dhall hydra hydra-create-user "${USERNAME}" --fullname "${FULL_NAME}" --email "${EMAIL}" --password "${PASSWORD}" --role admin
+    ```
+
+*   Get a personal access token for the
+    [`@dhall-bot`](https://github.com/dhall-bot) user with the `repo` permission
+
+*   Save the personal access token to `/etc/hydra/authorization` on the `hydra`
+    machine:
+
+    ```bash
+    $ nixops ssh -d dhall hydra 'cat > /etc/hydra/authorization/dhall-lang' <<< "${TOKEN}"
+    ```
+
+*   Add `hydra` to the `hydra-queue-runner` user's known hosts:
+
+    ```bash
+    $ nixops ssh -d dhall hydra 'sudo -u hydra-queue-runner ssh -i /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa hydra-queue-runner@hydra.dhall-lang.org'
+    ```
+
+*   Log into [Hydra](https://hydra.dhall-lang.org) with the account created
+    in the previous step
+
+*   Create one Hydra project for each Dhall project using the following
+    settings (replacing `${project}` with the project name, such as
+    `dhall-haskell`):
+
+    *   **Enabled**: True
+    *   **Visible in the list of projects**: True
+    *   **Identifier**: `${project}`
+    *   **Display name**: `${project}`
+    *   **Description**: `CI for for ${project}`
+    *   **Owner**: `${USERNAME}`
+    *   **Declarative spec file**: `${project}.json`
+    *   **Declarative input**:
+        *   **type**: `Local path`
+        *   **value**: `/etc/hydra`
+
+*   Restart any builds that fail due to "Output limit exceeded".  This is a
+    harmless error
+
+*   You're done!

--- a/nixops/dhall/2016-12-03.json
+++ b/nixops/dhall/2016-12-03.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/Gabriel439/Haskell-Dhall-Library.git",
+  "rev": "e19af8c7a88921909b47ac685fb772a21df2d402",
+  "date": "2016-12-03T19:35:47-08:00",
+  "sha256": "03191avxzgch7gxl97xyambp6l59bxq8i49m2rjis88281g4ip8m"
+}

--- a/nixops/dhall/2017-05-16.json
+++ b/nixops/dhall/2017-05-16.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/Gabriel439/Haskell-Dhall-Library.git",
+  "rev": "e0319ecaa5b1b8e582345f6e4281986f9fbabb2c",
+  "date": "2017-05-16T09:17:19-07:00",
+  "sha256": "134n6jz4pfm76lssydsi4rq8g9q2cnm1cg0ddjlxznfir9rk3jgr"
+}

--- a/nixops/dhall/2017-06-17.json
+++ b/nixops/dhall/2017-06-17.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/Gabriel439/Haskell-Dhall-Library.git",
+  "rev": "2d7fe03ae09f5ddf36eee33d861b06eeb7ef776b",
+  "date": "2017-06-17T09:44:42-07:00",
+  "sha256": "1vy12a4l069l4247drcizi7xdzmx9svdv4vs2nggh3i7s1lanh7f"
+}

--- a/nixops/dhall/2017-08-28.json
+++ b/nixops/dhall/2017-08-28.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/Gabriel439/Haskell-Dhall-Library.git",
+  "rev": "8987bc84ed4cb6ff6624b22ff7ab3743db4e28ee",
+  "date": "2017-08-28T22:54:31+03:00",
+  "sha256": "06jrwxiqqpjl0802y6z2mfm3fz0lgw6zampmq4yndznkvcz6pc6j"
+}

--- a/nixops/hydra.patch
+++ b/nixops/hydra.patch
@@ -1,0 +1,71 @@
+diff --git a/src/lib/Hydra/Plugin/GithubPulls.pm b/src/lib/Hydra/Plugin/GithubPulls.pm
+index be3ae53b..cf36b16b 100644
+--- a/src/lib/Hydra/Plugin/GithubPulls.pm
++++ b/src/lib/Hydra/Plugin/GithubPulls.pm
+@@ -6,6 +6,7 @@ use HTTP::Request;
+ use LWP::UserAgent;
+ use JSON;
+ use Hydra::Helper::CatalystUtils;
++use File::Slurp;
+ use File::Temp;
+ use POSIX qw(strftime);
+ 
+@@ -15,10 +16,10 @@ sub supportedInputTypes {
+ }
+ 
+ sub _iterate {
+-    my ($url, $auth, $pulls, $ua) = @_;
++    my ($url, $token, $pulls, $ua) = @_;
+     my $req = HTTP::Request->new('GET', $url);
+     $req->header('Accept' => 'application/vnd.github.v3+json');
+-    $req->header('Authorization' => $auth) if defined $auth;
++    $req->header('Authorization' => "token $token") if defined $token;
+     my $res = $ua->request($req);
+     my $content = $res->decoded_content;
+     die "Error pulling from the github pulls API: $content\n"
+@@ -38,7 +39,7 @@ sub _iterate {
+             last;
+         }
+     }
+-    _iterate($next, $auth, $pulls, $ua) unless $next eq "";
++    _iterate($next, $token, $pulls, $ua) unless $next eq "";
+ }
+ 
+ sub fetchInput {
+@@ -46,10 +47,10 @@ sub fetchInput {
+     return undef if $type ne "githubpulls";
+     # TODO Allow filtering of some kind here?
+     (my $owner, my $repo) = split ' ', $value;
+-    my $auth = $self->{config}->{github_authorization}->{$owner};
++    my $token = read_file("/etc/hydra/authorization/$owner");
+     my %pulls;
+     my $ua = LWP::UserAgent->new();
+-    _iterate("https://api.github.com/repos/$owner/$repo/pulls?per_page=100", $auth, \%pulls, $ua);
++    _iterate("https://api.github.com/repos/$owner/$repo/pulls?per_page=100", $token, \%pulls, $ua);
+     my $tempdir = File::Temp->newdir("github-pulls" . "XXXXX", TMPDIR => 1);
+     my $filename = "$tempdir/github-pulls.json";
+     open(my $fh, ">", $filename) or die "Cannot open $filename for writing: $!";
+diff --git a/src/lib/Hydra/Plugin/GithubStatus.pm b/src/lib/Hydra/Plugin/GithubStatus.pm
+index 08ba25bb..5b8742a3 100644
+--- a/src/lib/Hydra/Plugin/GithubStatus.pm
++++ b/src/lib/Hydra/Plugin/GithubStatus.pm
+@@ -2,6 +2,7 @@ package Hydra::Plugin::GithubStatus;
+ 
+ use strict;
+ use parent 'Hydra::Plugin';
++use File::Slurp;
+ use HTTP::Request;
+ use JSON;
+ use LWP::UserAgent;
+@@ -61,7 +62,10 @@ sub common {
+                     my $req = HTTP::Request->new('POST', "https://api.github.com/repos/$owner/$repo/statuses/$rev");
+                     $req->header('Content-Type' => 'application/json');
+                     $req->header('Accept' => 'application/vnd.github.v3+json');
+-                    $req->header('Authorization' => ($self->{config}->{github_authorization}->{$owner} // $conf->{authorization}));
++                    my $authorization = $self->{config}->{github_authorization}->{$owner} // $conf->{authorization};
++                    my $token = read_file("/etc/hydra/authorization/$authorization");
++                    $token =~ s/\s+//;
++                    $req->header('Authorization' => "token $token");
+                     $req->content($body);
+                     my $res = $ua->request($req);
+                     print STDERR $res->status_line, ": ", $res->decoded_content, "\n" unless $res->is_success;

--- a/nixops/jobsets.nix
+++ b/nixops/jobsets.nix
@@ -1,0 +1,60 @@
+{ pullRequestsJSON, nixpkgs, suffix, ... }:
+
+let
+  pkgs = import nixpkgs { config = {}; };
+
+  pullRequests = builtins.fromJSON (builtins.readFile pullRequestsJSON);
+
+  toJobset = num: info: {
+    enabled = 1;
+
+    hidden = false;
+
+    description = info.title;
+
+    nixexprinput = "src";
+
+    nixexprpath = "release.nix";
+
+    checkinterval = 20;
+
+    schedulingshares = 1;
+
+    enableemail = false;
+
+    emailoverride = "";
+
+    keepnr = 1;
+
+    inputs = {
+      src = {
+        type = "git";
+
+        value = "https://github.com/${info.base.repo.owner.login}/${info.base.repo.name}.git ${info.head.sha}";
+
+        emailresponsible = false;
+      };
+
+      nixpkgs = {
+        type = "git";
+
+        value = "https://github.com/NixOS/nixpkgs.git release-17.09";
+
+        emailresponsible = false;
+      };
+    };
+  };
+
+  master = toJobset "master" {
+    base.repo = { owner.login = "dhall-lang"; name = "dhall-${suffix}"; };
+
+    head.sha = "master";
+
+    title = "master";
+  };
+
+  jobsets = pkgs.lib.mapAttrs toJobset pullRequests // { inherit master; };
+
+in
+  { jobsets = pkgs.writeText "jobsets.json" (builtins.toJSON jobsets);
+  }

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -124,12 +124,6 @@
       in
         [ secureHydra fixSimple ];
 
-    security.acme.certs = {
-      "hydra.dhall-lang.org".email = "Gabriel439@gmail.com";
-
-      "cache.dhall-lang.org".email = "Gabriel439@gmail.com";
-    };
-
     services = {
       fail2ban.enable = true;
 
@@ -165,22 +159,38 @@
 
         recommendedTlsSettings = true;
 
-        virtualHosts."cache.dhall-lang.org" = {
+        virtualHosts."dhall-lang.org" = {
+          addSSL = true;
+
+          default = true;
+
           enableACME = true;
 
+          locations."/".extraConfig = ''
+            rewrite ^.*$ https://github.com/dhall-lang/dhall-lang/blob/master/README.md redirect;
+          '';
+        };
+
+        virtualHosts."cache.dhall-lang.org" = {
           addSSL = true;
+
+          enableACME = true;
 
           locations."/".proxyPass = "http://127.0.0.1:5000";
         };
 
         virtualHosts."hydra.dhall-lang.org" = {
-          default = true;
+          addSSL = true;
 
           enableACME = true;
 
-          addSSL = true;
-
           locations."/".proxyPass = "http://127.0.0.1:3000";
+        };
+
+        virtualHosts."prelude.dhall-lang.org" = {
+          locations."/".extraConfig = ''
+            rewrite ^/(.*)$ https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/$1 redirect;
+          '';
         };
       };
 

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -145,6 +145,8 @@
 
         listenHost = "127.0.0.1";
 
+        logo = ../img/dhall-logo.png;
+
         notificationSender = "noreply@dhall-lang.org";
       };
 

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -1,0 +1,216 @@
+{ ipfs = { pkgs, ... }:
+
+    let
+      pin = { name, path }:
+          { name = "pin-${name}";
+
+            value = {
+              path = [ pkgs.bash ];
+
+              script = ''
+                IPFS_PATH="/var/lib/ipfs/" ${pkgs.ipfs}/bin/ipfs add --quiet -w --recursive ${path}
+              '';
+
+              serviceConfig = {
+                Type = "oneshot";
+              };
+
+              wantedBy = [ "multi-user.target" ];
+            };
+          };
+
+      pinPrelude = { date }:
+        let
+          path = ./. + "/dhall/${date}.json";
+
+          json = builtins.fromJSON (builtins.readFile path);
+
+          src = pkgs.fetchgit { inherit (json) url rev sha256; };
+        in
+          pin { name = date; path = "${src}/Prelude"; };
+
+      services = [
+        (pinPrelude { date = "2016-12-03"; })
+        (pinPrelude { date = "2017-05-16"; })
+        (pinPrelude { date = "2017-06-17"; })
+        (pinPrelude { date = "2017-08-28"; })
+      ];
+
+    in
+      { networking.firewall.allowedTCPPorts = [ 22 4001 ];
+
+        services = {
+          fail2ban.enable = true;
+
+          ipfs = {
+            enable = true;
+
+            enableGC = true;
+          };
+        };
+
+        systemd.services = builtins.listToAttrs services // {
+          ipfs.environment.IPFS_LOW_MEM = "1";
+        };
+      };
+
+  hydra = { pkgs, ... }: {
+    environment = {
+      etc =
+        let
+          toProject = suffix: {
+            name = "hydra/dhall-${suffix}.json";
+
+            value = { text = builtins.toJSON (import ./project.nix suffix); };
+          };
+
+          suffixes = [ "bash" "haskell" "json" "nix" "text" ];
+
+        in
+          builtins.listToAttrs (builtins.map toProject suffixes) // {
+            "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
+
+            "hydra/machines".text = ''
+              hydra-queue-runner@hydra x86_64-linux /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 1 1 local
+            '';
+          };
+
+      systemPackages = [ pkgs.hydra ];
+    };
+
+    networking.firewall.allowedTCPPorts = [ 22 80 443 ];
+
+    nix = {
+      autoOptimiseStore = true;
+
+      gc.automatic = true;
+    };
+
+    nixpkgs.overlays =
+      let
+        secureHydra = packagesNew: packagesOld: {
+          hydra = packagesOld.hydra.overrideAttrs (oldAttributes: {
+              patches = (oldAttributes.patches or []) ++ [ ./hydra.patch ];
+            }
+          );
+        };
+
+        fixSimple = packagesNew: packagesOld: {
+          certbot = packagesOld.certbot.overrideAttrs (oldAttributes: rec {
+              version = "0.19.0";
+
+              src = packagesNew.fetchFromGitHub {
+                owner = "certbot";
+
+                repo = "certbot";
+
+                rev = "v${version}";
+
+                sha256 = "14i3q59v7j0q2pa1dri420fhil4h0vgl4vb471hp81f4y14gq6h7";
+              };
+            }
+          );
+
+          simp_le = packagesOld.simp_le.overrideAttrs (oldAttributes: {
+              version = "0.6.1";
+
+              src = oldAttributes.src.override {
+                sha256 = "0x4fky9jizs3xi55cdy217cvm3ikpghiabysan71b07ackkdfj6k";
+              };
+            }
+          );
+        };
+
+      in
+        [ secureHydra fixSimple ];
+
+    security.acme.certs."hydra.dhall-lang.org".email = "Gabriel439@gmail.com";
+
+    services = {
+      fail2ban.enable = true;
+
+      hydra = {
+        buildMachinesFiles = [ "/etc/hydra/machines" ];
+
+        enable = true;
+
+        extraConfig = ''
+          <githubstatus>
+            jobs = .*
+            inputs = src
+            authorization = dhall-lang
+            context = hydra
+          </githubstatus>
+        '';
+
+        hydraURL = "https://hydra.dhall-lang.org";
+
+        listenHost = "127.0.0.1";
+
+        notificationSender = "noreply@dhall-lang.org";
+      };
+
+      nginx = {
+        enable = true;
+
+        recommendedGzipSettings = true;
+
+        recommendedOptimisation = true;
+
+        recommendedProxySettings = true;
+
+        recommendedTlsSettings = true;
+
+        virtualHosts."hydra.dhall-lang.org" = {
+          default = true;
+
+          enableACME = true;
+
+          addSSL = true;
+
+          locations."/".proxyPass = "http://127.0.0.1:3000";
+        };
+      };
+
+      openssh.enable = true;
+    };
+
+    systemd.services.generate-hydra-queue-runner-key-pair = {
+      script =
+        let
+          keyDirectory = "/etc/keys/hydra-queue-runner";
+
+          user = "hydra-queue-runner";
+
+          group = "hydra";
+
+          privateKey = "${keyDirectory}/${user}_rsa";
+
+          publicKey = "${privateKey}.pub";
+
+          authorizedKeysDirectory = "/etc/ssh/authorized_keys.d";
+
+          authorizedKeysFile = "${authorizedKeysDirectory}/${user}";
+        in
+          ''
+            if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
+              mkdir -p ${keyDirectory}
+
+              ${pkgs.openssh}/bin/ssh-keygen -t rsa -N "" -f ${privateKey} -C "${user}@hydra" >/dev/null
+
+              chown -R ${user}:${group} ${keyDirectory}
+            fi
+
+            if ! [ -e ${authorizedKeysFile} ]; then
+              mkdir -p "${authorizedKeysDirectory}"
+
+              cp ${publicKey} ${authorizedKeysFile}
+            fi
+          '';
+
+      serviceConfig.Type = "oneshot";
+
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+}

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -124,7 +124,11 @@
       in
         [ secureHydra fixSimple ];
 
-    security.acme.certs."hydra.dhall-lang.org".email = "Gabriel439@gmail.com";
+    security.acme.certs = {
+      "hydra.dhall-lang.org".email = "Gabriel439@gmail.com";
+
+      "cache.dhall-lang.org".email = "Gabriel439@gmail.com";
+    };
 
     services = {
       fail2ban.enable = true;
@@ -161,6 +165,14 @@
 
         recommendedTlsSettings = true;
 
+        virtualHosts."cache.dhall-lang.org" = {
+          enableACME = true;
+
+          addSSL = true;
+
+          locations."/".proxyPass = "http://127.0.0.1:5000";
+        };
+
         virtualHosts."hydra.dhall-lang.org" = {
           default = true;
 
@@ -173,6 +185,8 @@
       };
 
       nix-serve = {
+        bindAddress = "127.0.0.1";
+
         enable = true;
 
         secretKeyFile = "/etc/nix-serve/nix-serve.sec";
@@ -236,7 +250,7 @@
               fi
 
               if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
-                ${pkgs.nix}/bin/nix-store --generate-binary-cache-key hydra.dhall-lang.org ${privateKey} ${publicKey}
+                ${pkgs.nix}/bin/nix-store --generate-binary-cache-key cache.dhall-lang.org ${privateKey} ${publicKey}
               fi
 
               chown -R nix-serve:hydra /etc/nix-serve

--- a/nixops/physical.nix
+++ b/nixops/physical.nix
@@ -1,0 +1,61 @@
+let
+  region = "us-west-1";
+
+in
+  { ipfs = { resources, ... }: {
+      deployment = {
+        targetEnv = "ec2";
+
+        ec2 = {
+          inherit region;
+
+          inherit (resources.ec2KeyPairs) keyPair;
+
+          instanceType = "t2.nano";
+        };
+      };
+    };
+
+    hydra = { ... }: {
+      deployment = {
+        targetEnv = "none";
+
+        targetHost = "hydra.dhall-lang.org";
+      };
+
+      imports = [ <nixpkgs/nixos/modules/profiles/qemu-guest.nix> ];
+
+      nixpkgs.system = "x86_64-linux";
+
+      boot = {
+        initrd.availableKernelModules =
+          [ "ata_piix" "virtio_pci" "floppy" "sd_mod" ];
+
+        kernelParams = [ "console=ttyS0,19200n8" ];
+
+        loader = {
+          grub = {
+            enable = true;
+
+            extraConfig = ''
+              serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
+              terminal_input serial;
+              terminal_output serial;
+            '';
+
+            device = "nodev";
+
+            timeout = 10;
+
+            version = 2;
+          };
+        };
+      };
+
+      fileSystems."/" = { device = "/dev/sda"; fsType = "ext4"; };
+
+      swapDevices = [ { device = "/dev/sdb"; } ];
+    };
+
+    resources.ec2KeyPairs.keyPair = { inherit region; };
+  }

--- a/nixops/project.nix
+++ b/nixops/project.nix
@@ -1,0 +1,55 @@
+suffix: {
+  enabled = 1;
+
+  hidden = false;
+
+  description = "dhall-${suffix} pull requests";
+
+  nixexprinput = "local";
+
+  nixexprpath = "jobsets.nix";
+
+  checkinterval = "20";
+
+  schedulingshares = 1;
+
+  enableemail = false;
+
+  emailoverride = "";
+
+  keepnr = 1;
+
+  inputs = {
+    local = {
+      type = "path";
+
+      value = "/etc/hydra/";
+
+      emailresponsible = false;
+    };
+
+    nixpkgs = {
+      type = "git";
+
+      value = "https://github.com/NixOS/nixpkgs.git 89acf89f6b214377de4fffdeca597d13241a0dd0";
+
+      emailresponsible = false;
+    };
+
+    pullRequestsJSON = {
+      type = "githubpulls";
+
+      value = "dhall-lang dhall-${suffix}";
+
+      emailresponsible = false;
+    };
+
+    suffix = {
+      type = "string";
+
+      value = suffix;
+
+      emailresponsible = false;
+    };
+  };
+}


### PR DESCRIPTION
This documents how to deploy the Hydra server and also how to set up an
IPFS mirror for the Prelude

This is an extension of the IPFS NixOps deployment that previously lived in
https://github.com/dhall-lang/dhall-haskell/tree/master/ipfs before there was
a central `dhall-lang` project, but now it makes more sense for infrastructure
code to live here

You can see the new Hydra server in action at https://hydra.dhall-lang.org/,
which builds pull requests for every Dhall project and also each project's
`master` branch