### PR TITLE
Fix tokens missing trailing whitespace

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -328,7 +328,7 @@ arrow   = ( %x2192 / "->"                ) whitespace
 
 exponent = "e" [ "+" / "-" ] 1*DIGIT
 
-double-literal = [ "-" ] 1*DIGIT ( "." 1*DIGIT [ exponent ] / exponent)
+double-literal = [ "-" ] 1*DIGIT ( "." 1*DIGIT [ exponent ] / exponent) whitespace
 
 natural-raw = 1*DIGIT
 
@@ -336,7 +336,7 @@ integer-literal = [ "-" ] natural-raw whitespace
 
 natural-literal = "+" natural-raw whitespace
 
-identifier = label [ at natural-raw ]
+identifier = label [ at natural-raw ] whitespace
 
 ; Printable characters other than " ()[]{}<>/\,"
 ;


### PR DESCRIPTION
Fixes #94 and #95

The bottom of the grammar requires that all tokens end with
trailing whitespace, but two tokens from the grammar (`double-literal`
and `identifier`) were missing trailing `whitespace`, which this
change fixes