### PR TITLE
Upgrade size of EC2 instance used to mirror Prelude

### DIFF
--- a/nixops/physical.nix
+++ b/nixops/physical.nix
@@ -11,7 +11,7 @@ in
 
           inherit (resources.ec2KeyPairs) keyPair;
 
-          instanceType = "t2.nano";
+          instanceType = "t2.micro";
         };
       };
     };


### PR DESCRIPTION
The `t2.nano` size was not sufficiently reliable to mirror the Prelude
so this upgrades to a `t2.micro` size