### PR TITLE
Add new `⩓` operator for merging record types

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -320,11 +320,12 @@ close-parens  = ")"  whitespace
 colon         = ":"  whitespace
 at            = "@"  whitespace
 
-combine = ( %x2227 / "/\"                ) whitespace
-prefer  = ( %x2AFD / "//"                ) whitespace
-lambda  = ( %x3BB  / "\"                 ) whitespace
-forall  = ( %x2200 / %x66.6f.72.61.6c.6c ) whitespace
-arrow   = ( %x2192 / "->"                ) whitespace
+combine       = ( %x2227 / "/\"                ) whitespace
+combine-types = ( %x2A53 / "//\\"              ) whitespace
+prefer        = ( %x2AFD / "//"                ) whitespace
+lambda        = ( %x3BB  / "\"                 ) whitespace
+forall        = ( %x2200 / %x66.6f.72.61.6c.6c ) whitespace
+arrow         = ( %x2192 / "->"                ) whitespace
 
 exponent = "e" [ "+" / "-" ] 1*DIGIT
 
@@ -566,16 +567,17 @@ non-empty-optional = expression close-bracket colon Optional selector-expression
 
 operator-expression = or-expression
 
-or-expression          = plus-expression        *(or           plus-expression       )
-plus-expression        = text-append-expression *(plus         text-append-expression)
-text-append-expression = list-append-expression *(text-append  list-append-expression)
-list-append-expression = and-expression         *(list-append  and-expression        )
-and-expression         = combine-expression     *(and          combine-expression    )
-combine-expression     = prefer-expression      *(combine      prefer-expression     )
-prefer-expression      = times-expression       *(prefer       times-expression      )
-times-expression       = equal-expression       *(times        equal-expression      )
-equal-expression       = not-equal-expression   *(double-equal not-equal-expression  )
-not-equal-expression   = application-expression *(not-equal    application-expression)
+or-expression            = plus-expression          *(or            plus-expression         )
+plus-expression          = text-append-expression   *(plus          text-append-expression  )
+text-append-expression   = list-append-expression   *(text-append   list-append-expression  )
+list-append-expression   = and-expression           *(list-append   and-expression          )
+and-expression           = combine-expression       *(and           combine-expression      )
+combine-expression       = prefer-expression        *(combine       prefer-expression       )
+prefer-expression        = combine-types-expression *(prefer        combine-types-expression)
+combine-types-expression = times-expression         *(combine-types times-expression        )
+times-expression         = equal-expression         *(times         equal-expression        )
+equal-expression         = not-equal-expression     *(double-equal  not-equal-expression    )
+not-equal-expression     = application-expression   *(not-equal     application-expression  )
 
 application-expression = [ constructors ] 1*selector-expression
 

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3306,34 +3306,61 @@ Non-recursive right-biased merge also requires that both arguments are records:
 If the operator arguments are not records then that is a type error.
 
 Recursive record type merge requires that both arguments are record type
-literals.  Similarly, any conflicting fields but be safe to recursively merge:
+literals.  Any conflicting fields must be safe to recursively merge:
 
 
-    Γ ⊢ l : T₀
+    Γ ⊢ l :⇥ Type
     l ⇥ { ls… }
-    Γ ⊢ r : T₁
+    Γ ⊢ r :⇥ Type
     r ⇥ {}
     ────────────────
     Γ ⊢ l ⩓ r : Type
 
 
-    Γ ⊢ l : T₀
+    Γ ⊢ l :⇥ Type
     l ⇥ { ls… }
-    Γ ⊢ r : T₁
+    Γ ⊢ r :⇥ Type
     r ⇥ { a : A, rs… }
-    Γ ⊢ { ls… } ⩓ { rs… } : T₂
-    ──────────────────────────  ; a ∉ ls
+    Γ ⊢ { ls… } ⩓ { rs… } : T
+    ─────────────────────────────  ; a ∉ ls
     Γ ⊢ l ⩓ r : Type
 
 
-    Γ ⊢ l : T₀
+    Γ ⊢ l :⇥ Type
     l ⇥ { a : A₀, ls… }
-    Γ ⊢ r : T₁
+    Γ ⊢ r :⇥ Type
     r ⇥ { a : A₁, rs… }
-    Γ ⊢ l.a ⩓ r.a : T₂
-    Γ ⊢ { ls… } ⩓ { rs… } : T₃
-    ──────────────────────────
+    Γ ⊢ l.a ⩓ r.a : T₀
+    Γ ⊢ { ls… } ⩓ { rs… } : T₁
+    ─────────────────────────────
     Γ ⊢ l ⩓ r : Type
+
+
+    Γ ⊢ l :⇥ Kind
+    l ⇥ { ls… }
+    Γ ⊢ r :⇥ Kind
+    r ⇥ { a : A }
+    ────────────────
+    Γ ⊢ l ⩓ r : Kind
+
+
+    Γ ⊢ l :⇥ Kind
+    l ⇥ { ls… }
+    Γ ⊢ r :⇥ Kind
+    r ⇥ { a : A, rs… }
+    Γ ⊢ { ls… } ⩓ { rs… } : T
+    ─────────────────────────────  ; a ∉ ls
+    Γ ⊢ l ⩓ r : Kind
+
+
+    Γ ⊢ l :⇥ Kind
+    l ⇥ { a : A₀, ls… }
+    Γ ⊢ r :⇥ Kind
+    r ⇥ { a : A₁, rs… }
+    Γ ⊢ l.a ⩓ r.a : T₀
+    Γ ⊢ { ls… } ⩓ { rs… } : T₁
+    ─────────────────────────────
+    Γ ⊢ l ⩓ r : Kind
 
 
 If the operator arguments are not record types then that is a type error.


### PR DESCRIPTION
Fixes #92

This is the type-level analog of `∧`, which allows you to do:

```
{ foo : Text } ⩓ { bar : Bool } = { foo : Text, bar : Bool }
```

The motivation for this is to allow reusing the same field types between
several related records

The ASCII representation of the operator is `//\\`