### PR TITLE
Allow type-level `if` expressions

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2885,14 +2885,25 @@ An `if` expression takes a predicate of type `Bool` and returns either the
     Γ ⊢ if t then l else r : L
 
 
-Note that an `if` expression can only return a term.  More generally, if the
-`if` expression returns a value whose type is not a `Type` then that is a type
-error.
+... or kind:
+
+
+    Γ ⊢ t :⇥ Bool
+    Γ ⊢ l : L
+    Γ ⊢ r : R
+    Γ ⊢ L :⇥ Kind
+    Γ ⊢ R :⇥ Kind
+    L ≡ R
+    ──────────────────────────
+    Γ ⊢ if t then l else r : L
+
+
+If the type of each branch is not a `Type` or `Kind` then that is a type error.
 
 If the predicate is not a `Bool` then that is a type error.
 
-If the two branches of the `if` expression do not have the same type then that
-is a type error.
+If the two branches of the `if` expression do not have the same type or kind
+then that is a type error.
 
 All of the logical operators take arguments of type `Bool` and return a result
 of type `Bool`:


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/327

This is mainly for consistency with support for type-valued fields in
records because type-valued fields can be used to bypass the restriction
on `if` expressions only returning terms.

There is no harm in genernalizing `if` expressions to return types
since type-level `if` expressions still satisfy the four soundness
criteria:

*   Type inference won't diverge

    Both arguments of the judgmental equality check are type-checked,
    therefore they are safe to normalize

*   If an expression type-checks, normalizing that expression won't
    diverge

    This is true since we know that each branch won't diverge by
    induction

*   Normalizing an inferred type won't diverge

    This is also true by induction since the returned type is derived
    directly from inferring the type of the left branch

*   Normalizing an expression doesn't change its type

    There are three scenarios to consider:

    * `t` is `True`, where this is trivially true since the normalized
      expression is `l` whose type matches the type of the un-normalized
      `if` expression

    * `t` is `False`, where this is still true since the normalized
      expression if `r` whose type is judgmentally equal to the type of
      the un-normalized expression

    * `t` is some other expression (i.e. a bound variable), in which
      case this is true by induction since normalizing the left branch
      doesn't change its type