### PR TITLE
Restrict records with type-valued fields

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3131,6 +3131,8 @@ The built-in functions on `Optional` values have the following types:
 Record types are "anonymous", meaning that they are uniquely defined by the
 names and types of their fields and the order of fields does not matter:
 
+A record can either store term-level values and functions:
+
 
     ─────────────
     Γ ⊢ {} : Type
@@ -3141,14 +3143,23 @@ names and types of their fields and the order of fields does not matter:
     Γ ⊢ { x : T, xs… } : Type
 
 
-    Γ ⊢ T :⇥ Kind   Γ ⊢ { xs… } :⇥ Type
-    ───────────────────────────────────  ; x ∉ { xs… }
-    Γ ⊢ { x : T, xs… } : Type
+... or store types (if it is non-empty):
 
 
-Note that the above rule allows storing both values, types, and type-level
-functions in records.  However, if the type of the field is not `Type` or `Kind`
-then that is a type error.
+    Γ ⊢ T :⇥ Kind   T ≡ Type
+    ────────────────────────
+    Γ ⊢ { x : T } : Kind
+
+
+    Γ ⊢ T :⇥ Kind   T ≡ Type   Γ ⊢ { xs… } :⇥ Kind
+    ──────────────────────────────────────────────  ; x ∉ { xs… }
+    Γ ⊢ { x : T, xs… } : Kind
+
+
+... but not both.  If one field is a term-level value or function and another
+field is a type-level value or function then that is a type error.
+
+If the type of a field is not `Type` or `Kind` then that is a type error.
 
 If two fields have the same name, then that is a type error.
 
@@ -3159,13 +3170,18 @@ Record values are also anonymous:
     Γ ⊢ {=} : {}
 
 
-    Γ ⊢ t : T   Γ ⊢ T :⇥ Type   Γ ⊢ { xs… } :⇥ { ts… }
-    ──────────────────────────────────────────────────
+    Γ ⊢ t : T   Γ ⊢ T :⇥ Type   Γ ⊢ { xs… } :⇥ { ts… }   Γ ⊢ { ts… } :⇥ Type
+    ────────────────────────────────────────────────────────────────────────
     Γ ⊢ { x = t, xs… } : { x : T, ts… }
 
 
-    Γ ⊢ t : T   Γ ⊢ T :⇥ Kind   Γ ⊢ { xs… } :⇥ { ts… }
-    ──────────────────────────────────────────────────
+    Γ ⊢ t : T   Γ ⊢ T :⇥ Kind
+    ─────────────────────────
+    Γ ⊢ { x = t } : { x : T }
+
+
+    Γ ⊢ t : T   Γ ⊢ T :⇥ Kind   Γ ⊢ { xs… } :⇥ { ts… }   Γ ⊢ { ts… } :⇥ Kind
+    ────────────────────────────────────────────────────────────────────────
     Γ ⊢ { x = t, xs… } : { x : T, ts… }
 
 
@@ -3173,6 +3189,11 @@ You can only select a field from the record if the field is present:
 
 
     Γ ⊢ e :⇥ { a : A, as… }   Γ ⊢ { a : A, as… } :⇥ Type
+    ────────────────────────────────────────────────────
+    Γ ⊢ e.a : A
+
+
+    Γ ⊢ e :⇥ { a : A, as… }   Γ ⊢ { a : A, as… } :⇥ Kind
     ────────────────────────────────────────────────────
     Γ ⊢ e.a : A
 


### PR DESCRIPTION
The motivation behind this change is to fix records with type-valued
fields from being used as an unintentional dependent-types backdoor.

The motivating example for this change is the following expression which
builds a record of N elements from a statically known natural number N:

```haskell
    let succ = λ(x : { t : Type }) → { t = { head : Integer, tail : x.t } }

in  Natural/fold +10 { t : Type } succ { t = {} }
```

While this is technically not dependently-typed (you can't parametrize
this on an unknown N) it's not an expected use case.

The underlying issue is that there is no clear mapping to System Fω for
records with both type-level and term-level fields.

For example, the standard System Fω encoding for a record literal with only
term-level fields such as:

```haskell
{ x = "ABC", y = +0 }
```

... would be:

```haskell
  λ(Record : Type)
→ λ(MakeRecord : ∀(x : Text) → ∀(y : Natural) → Record)
→ MakeRecord "ABC" +0
```

The corresponding type of that record literal would be:

```haskell
{ x : Text, y : Natural }
```

... which you would encode as:

```haskell
  ∀(Record : Type)
→ ∀(MakeRecord : ∀(x : Text) → ∀(y : Natural) → Record)
→ Record
```

Accessing a field:

```haskell
λ(r : { x : Text, y : Natural}) → r.x
```

... translates to this:

```haskell
  λ ( r
    :   ∀(Record : Type)
      → ∀(MakeRecord : ∀(x : Text) → ∀(y : Natural) → Record)
      → Record
    )
→ r Text (λ(x : Text) → λ(y : Natural) → x)
```

You can also encode a record with only type-valued fields such as:

```haskell
{ x = Text, y = Integer }
```

... in System Fω like this:

```haskell
  λ(MakeRecord : ∀(x : Type) → ∀(y : Type) → Type)
→ MakeRecord Text Integer
```

The corresponding type of that record literal would be:

```haskell
{ x : Type, y : Type }
```

... which encodes to:

```haskell
∀(MakeRecord : ∀(x : Type) → ∀(y : Type) → Type) → Type
```

Accessing a field of that type-valued record:

```haskell
λ(r : { x : Type, y : Type }) → r.x
```

... translate to:

```haskell
  λ(r : ∀(MakeRecord : ∀(x : Type) → ∀(y : Type) → Type) → Type)
→ r (λ(x : Type) → λ(y : Type) → x)
```

However, note that there is no way to encode a record in System Fω that
stores both terms and types.  The reason why is that the System
Fω-encoding requires you to specify ahead of time whether the field(s) that
you plan to extract from the record are terms are types.  Furthermore,
if they are types then you must specify exactly what kind they are since
System Fω provides no kind-level abstraction.

So this change updates the semantics to match a subset of the System Fω
encoding.  If we were to implement the full encoding then the rules
would be:

*   The type of a record with type-valued fields is now a kind whose
    type is `Kind`

*   Records cannot store both terms and types

    This implies that if you want your package to export both terms and
    types you will need to do so in at least two imports

*   Records that store type-valued fields can only store types of the
    same kind

    This implies that your package would need to provide one export set per
    unique kind

However, for simplicity, this change narrows the third rule to:

*   Records that store type-valued fields only store types of kind `Type`

Later on I might generalize this restriction to support storing
higher-kinded types but for now I just want to plug the hole in the
type-checker.

This also fixes the original issues that motivated this since you could
no longer wrap a type in a record to hide inside of a term.  Going back
to the original example:

```haskell
    let succ = λ(x : { t : Type }) → { t = { head : Integer, tail : x.t } }

in  Natural/fold +10 { t : Type } succ { t = {} }
```

... this would now be a type error because the type of `{ t : Type }` is
`Kind`.

Similarly, this would now forbid using the record wrapping trick to
trick an `if` expression into returning a type as documented in
https://github.com/dhall-lang/dhall-haskell/issues/327:

```haskell
(if True then { t = Natural } else { t = Bool }).t
```

This would now be rejected because the type of `{ t = Natural }` would
be `{ t : Natural }` and the type of that would be `Kind` which would be
rejected by the type-checking judgment for `if` expressions.