### PR TITLE
ABNF: match reserved keywords before identifiers in primitive-expr

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -25,6 +25,7 @@
 ; Third, if there are multiple valid parses then prefer the first parse
 ; according to the ordering of alternatives. That is, the order of evaluation
 ; of the alternatives is left-to-right.
+;
 ; For example, the grammar for single quoted string literals is:
 ;
 ;     single-quote-continue =
@@ -121,47 +122,6 @@ DIGIT = %x30-39  ; 0-9
 
 HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 
-; NOTE: If your parser requires explicit backtracking then you must add logic
-; to reject any labels that match any of the following reserved keywords:
-;
-; * if
-; * then
-; * else
-; * let
-; * in
-; * as
-; * using
-; * merge
-; * constructors
-; * Natural/fold
-; * Natural/build
-; * Natural/isZero
-; * Natural/even
-; * Natural/odd
-; * Natural/toInteger
-; * Natural/show
-; * Integer/show
-; * Double/show
-; * List/build
-; * List/fold
-; * List/length
-; * List/head
-; * List/last
-; * List/indexed
-; * List/reverse
-; * Optional/fold
-; * Optional/build
-; * Bool
-; * Optional
-; * Natural
-; * Integer
-; * Double
-; * Text
-; * List
-; * True
-; * False
-; * Type
-; * Kind
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
 quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / ".")
@@ -258,7 +218,8 @@ text-literal = (double-quote-literal / single-quote-literal) whitespace
 ; hex instead for case-sensitive strings
 ;
 ; If you don't feel like reading hex, these are all the same as the rule name,
-; except converting dashes in the rule name to forward slashes
+; except without the '-raw' ending, and converting dashes in the rule name
+; to forward slashes
 if-raw                = %x69.66
 then-raw              = %x74.68.65.6e
 else-raw              = %x65.6c.73.65
@@ -340,47 +301,22 @@ reserved-namespaced-raw =
   / Optional-fold-raw
   / Optional-build-raw
 
-reserved = reserved-raw whitespace
+reserved            = reserved-raw            whitespace
 reserved-namespaced = reserved-namespaced-raw whitespace
 
-if                = if-raw whitespace
-then              = then-raw whitespace
-else              = else-raw whitespace
-let               = let-raw whitespace
-in                = in-raw whitespace
-as                = as-raw whitespace
-using             = using-raw whitespace
-merge             = merge-raw whitespace
-constructors      = constructors-raw whitespace
-Natural-fold      = Natural-fold-raw whitespace
-Natural-build     = Natural-build-raw whitespace
-Natural-isZero    = Natural-isZero-raw whitespace
-Natural-even      = Natural-even-raw whitespace
-Natural-odd       = Natural-odd-raw whitespace
-Natural-toInteger = Natural-toInteger-raw whitespace
-Natural-show      = Natural-show-raw whitespace
-Integer-show      = Integer-show-raw whitespace
-Double-show       = Double-show-raw whitespace
-List-build        = List-build-raw whitespace
-List-fold         = List-fold-raw whitespace
-List-length       = List-length-raw whitespace
-List-head         = List-head-raw whitespace
-List-last         = List-last-raw whitespace
-List-indexed      = List-indexed-raw whitespace
-List-reverse      = List-reverse-raw whitespace
-Optional-fold     = Optional-fold-raw whitespace
-Optional-build    = Optional-build-raw whitespace
-Bool              = Bool-raw whitespace
-Optional          = Optional-raw whitespace
-Natural           = Natural-raw whitespace
-Integer           = Integer-raw whitespace
-Double            = Double-raw whitespace
-Text              = Text-raw whitespace
-List              = List-raw whitespace
-True              = True-raw whitespace
-False             = False-raw whitespace
-Type              = Type-raw whitespace
-Kind              = Kind-raw whitespace
+; Whitespaced rules for reserved words, to be used when matching expressions
+if           = if-raw           whitespace
+then         = then-raw         whitespace
+else         = else-raw         whitespace
+let          = let-raw          whitespace
+in           = in-raw           whitespace
+as           = as-raw           whitespace
+using        = using-raw        whitespace
+merge        = merge-raw        whitespace
+constructors = constructors-raw whitespace
+Optional     = Optional-raw     whitespace
+Text         = Text-raw         whitespace
+List         = List-raw         whitespace
 
 equal         = "="  whitespace
 or            = "||" whitespace
@@ -678,6 +614,15 @@ selector-expression = primitive-expression *(dot label)
 
 ; NOTE: Backtrack when parsing the first three alternatives (i.e. the numeric
 ; literals).  This is because they share leading characters in common
+
+; NOTE: The reason why we have three different types of identifiers (that is:
+; identifier, identifier-reserved-prefix, identifier-reserved-namespaced-prefix)
+; is that it's the only way to parse correctly identifiers that start with reserved
+; words, other than using a lexer and use the longest match rule.
+;
+; Since reserved words can include themselves (e.g. 'List/build' includes 'List'),
+; we have to match the "namespaced" reserved words before the identifiers prefixed
+; by a reserved word.
 primitive-expression =
     ; "2.0"
       double-literal

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -258,44 +258,128 @@ text-literal = (double-quote-literal / single-quote-literal) whitespace
 ;
 ; If you don't feel like reading hex, these are all the same as the rule name,
 ; except converting dashes in the rule name to forward slashes
-if                = %x69.66                                              whitespace
-then              = %x74.68.65.6e                                        whitespace
-else              = %x65.6c.73.65                                        whitespace
-let               = %x6c.65.74                                           whitespace
-in                = %x69.6e                                              whitespace
-as                = %x61.73                                              whitespace
-using             = %x75.73.69.6e.67                                     whitespace
-merge             = %x6d.65.72.67.65                                     whitespace
-constructors      = %x63.6f.6e.73.74.72.75.63.74.6f.72.73                whitespace
-Natural-fold      = %x4e.61.74.75.72.61.6c.2f.66.6f.6c.64                whitespace
-Natural-build     = %x4e.61.74.75.72.61.6c.2f.62.75.69.6c.64             whitespace
-Natural-isZero    = %x4e.61.74.75.72.61.6c.2f.69.73.5a.65.72.6f          whitespace
-Natural-even      = %x4e.61.74.75.72.61.6c.2f.65.76.65.6e                whitespace
-Natural-odd       = %x4e.61.74.75.72.61.6c.2f.6f.64.64                   whitespace
-Natural-toInteger = %x4e.61.74.75.72.61.6c.2f.74.6f.49.6e.74.65.67.65.72 whitespace
-Natural-show      = %x4e.61.74.75.72.61.6c.2f.73.68.6f.77                whitespace
-Integer-show      = %x49.6e.74.65.67.65.72.2f.73.68.6f.77                whitespace
-Double-show       = %x44.6f.75.62.6c.65.2f.73.68.6f.77                   whitespace
-List-build        = %x4c.69.73.74.2f.62.75.69.6c.64                      whitespace
-List-fold         = %x4c.69.73.74.2f.66.6f.6c.64                         whitespace
-List-length       = %x4c.69.73.74.2f.6c.65.6e.67.74.68                   whitespace
-List-head         = %x4c.69.73.74.2f.68.65.61.64                         whitespace
-List-last         = %x4c.69.73.74.2f.6c.61.73.74                         whitespace
-List-indexed      = %x4c.69.73.74.2f.69.6e.64.65.78.65.64                whitespace
-List-reverse      = %x4c.69.73.74.2f.72.65.76.65.72.73.65                whitespace
-Optional-fold     = %x4f.70.74.69.6f.6e.61.6c.2f.66.6f.6c.64             whitespace
-Optional-build    = %x4f.70.74.69.6f.6e.61.6c.2f.62.75.69.6c.64          whitespace
-Bool              = %x42.6f.6f.6c                                        whitespace
-Optional          = %x4f.70.74.69.6f.6e.61.6c                            whitespace
-Natural           = %x4e.61.74.75.72.61.6c                               whitespace
-Integer           = %x49.6e.74.65.67.65.72                               whitespace
-Double            = %x44.6f.75.62.6c.65                                  whitespace
-Text              = %x54.65.78.74                                        whitespace
-List              = %x4c.69.73.74                                        whitespace
-True              = %x54.72.75.65                                        whitespace
-False             = %x46.61.6c.73.65                                     whitespace
-Type              = %x54.79.70.65                                        whitespace
-Kind              = %x4b.69.6e.64                                        whitespace
+if-raw                = %x69.66
+then-raw              = %x74.68.65.6e
+else-raw              = %x65.6c.73.65
+let-raw               = %x6c.65.74
+in-raw                = %x69.6e
+as-raw                = %x61.73
+using-raw             = %x75.73.69.6e.67
+merge-raw             = %x6d.65.72.67.65
+constructors-raw      = %x63.6f.6e.73.74.72.75.63.74.6f.72.73
+Natural-fold-raw      = %x4e.61.74.75.72.61.6c.2f.66.6f.6c.64
+Natural-build-raw     = %x4e.61.74.75.72.61.6c.2f.62.75.69.6c.64
+Natural-isZero-raw    = %x4e.61.74.75.72.61.6c.2f.69.73.5a.65.72.6f
+Natural-even-raw      = %x4e.61.74.75.72.61.6c.2f.65.76.65.6e
+Natural-odd-raw       = %x4e.61.74.75.72.61.6c.2f.6f.64.64
+Natural-toInteger-raw = %x4e.61.74.75.72.61.6c.2f.74.6f.49.6e.74.65.67.65.72
+Natural-show-raw      = %x4e.61.74.75.72.61.6c.2f.73.68.6f.77
+Integer-show-raw      = %x49.6e.74.65.67.65.72.2f.73.68.6f.77
+Double-show-raw       = %x44.6f.75.62.6c.65.2f.73.68.6f.77
+List-build-raw        = %x4c.69.73.74.2f.62.75.69.6c.64
+List-fold-raw         = %x4c.69.73.74.2f.66.6f.6c.64
+List-length-raw       = %x4c.69.73.74.2f.6c.65.6e.67.74.68
+List-head-raw         = %x4c.69.73.74.2f.68.65.61.64
+List-last-raw         = %x4c.69.73.74.2f.6c.61.73.74
+List-indexed-raw      = %x4c.69.73.74.2f.69.6e.64.65.78.65.64
+List-reverse-raw      = %x4c.69.73.74.2f.72.65.76.65.72.73.65
+Optional-fold-raw     = %x4f.70.74.69.6f.6e.61.6c.2f.66.6f.6c.64
+Optional-build-raw    = %x4f.70.74.69.6f.6e.61.6c.2f.62.75.69.6c.64
+Bool-raw              = %x42.6f.6f.6c
+Optional-raw          = %x4f.70.74.69.6f.6e.61.6c
+Natural-raw           = %x4e.61.74.75.72.61.6c
+Integer-raw           = %x49.6e.74.65.67.65.72
+Double-raw            = %x44.6f.75.62.6c.65
+Text-raw              = %x54.65.78.74
+List-raw              = %x4c.69.73.74
+True-raw              = %x54.72.75.65
+False-raw             = %x46.61.6c.73.65
+Type-raw              = %x54.79.70.65
+Kind-raw              = %x4b.69.6e.64
+
+reserved-raw =
+    if-raw
+  / then-raw
+  / else-raw
+  / let-raw
+  / in-raw
+  / as-raw
+  / using-raw
+  / merge-raw
+  / constructors-raw
+  / Bool-raw
+  / Optional-raw
+  / Natural-raw
+  / Integer-raw
+  / Double-raw
+  / Text-raw
+  / List-raw
+  / True-raw
+  / False-raw
+  / Type-raw
+  / Kind-raw
+
+reserved-namespaced-raw =
+    Natural-fold-raw
+  / Natural-build-raw
+  / Natural-isZero-raw
+  / Natural-even-raw
+  / Natural-odd-raw
+  / Natural-toInteger-raw
+  / Natural-show-raw
+  / Integer-show-raw
+  / Double-show-raw
+  / List-build-raw
+  / List-fold-raw
+  / List-length-raw
+  / List-head-raw
+  / List-last-raw
+  / List-indexed-raw
+  / List-reverse-raw
+  / Optional-fold-raw
+  / Optional-build-raw
+
+reserved = reserved-raw whitespace
+reserved-namespaced = reserved-namespaced-raw whitespace
+
+if                = if-raw whitespace
+then              = then-raw whitespace
+else              = else-raw whitespace
+let               = let-raw whitespace
+in                = in-raw whitespace
+as                = as-raw whitespace
+using             = using-raw whitespace
+merge             = merge-raw whitespace
+constructors      = constructors-raw whitespace
+Natural-fold      = Natural-fold-raw whitespace
+Natural-build     = Natural-build-raw whitespace
+Natural-isZero    = Natural-isZero-raw whitespace
+Natural-even      = Natural-even-raw whitespace
+Natural-odd       = Natural-odd-raw whitespace
+Natural-toInteger = Natural-toInteger-raw whitespace
+Natural-show      = Natural-show-raw whitespace
+Integer-show      = Integer-show-raw whitespace
+Double-show       = Double-show-raw whitespace
+List-build        = List-build-raw whitespace
+List-fold         = List-fold-raw whitespace
+List-length       = List-length-raw whitespace
+List-head         = List-head-raw whitespace
+List-last         = List-last-raw whitespace
+List-indexed      = List-indexed-raw whitespace
+List-reverse      = List-reverse-raw whitespace
+Optional-fold     = Optional-fold-raw whitespace
+Optional-build    = Optional-build-raw whitespace
+Bool              = Bool-raw whitespace
+Optional          = Optional-raw whitespace
+Natural           = Natural-raw whitespace
+Integer           = Integer-raw whitespace
+Double            = Double-raw whitespace
+Text              = Text-raw whitespace
+List              = List-raw whitespace
+True              = True-raw whitespace
+False             = False-raw whitespace
+Type              = Type-raw whitespace
+Kind              = Kind-raw whitespace
 
 equal         = "="  whitespace
 or            = "||" whitespace
@@ -337,6 +421,12 @@ integer-literal = [ "-" ] natural-raw whitespace
 natural-literal = "+" natural-raw whitespace
 
 identifier = label [ at natural-raw ] whitespace
+
+identifier-reserved-prefix =
+    reserved-raw 1*(ALPHA / DIGIT / "-" / "/" / "_") whitespace [ at natural-raw ] whitespace
+
+identifier-reserved-namespaced-prefix =
+    reserved-namespaced-raw 1*(ALPHA / DIGIT / "-" / "/" / "_") whitespace [ at natural-raw ] whitespace
 
 ; Printable characters other than " ()[]{}<>/\,"
 ;
@@ -616,42 +706,19 @@ primitive-expression =
     ; "env:FOO"
     / import
 
-    ; Built-in functions
-    / Natural-fold
-    / Natural-build
-    / Natural-isZero
-    / Natural-even
-    / Natural-odd
-    / Natural-toInteger
-    / Natural-show
-    / Integer-show
-    / Double-show
-    / List-build
-    / List-fold
-    / List-length
-    / List-head
-    / List-last
-    / List-indexed
-    / List-reverse
-    / Optional-fold
-    / Optional-build
+    ; "List/foldWith"
+    / identifier-reserved-namespaced-prefix
 
-    ; Built-in types
-    / Bool
-    / Optional
-    / Natural
-    / Integer
-    / Double
-    / Text
-    / List
+    ; "List/head"
+    / reserved-namespaced
 
-    ; Built-in values
-    / True
-    / False
+    ; "List/map"
+    ; "TypeDefinition"
+    / identifier-reserved-prefix
 
-    ; Built-in type-checking constants
-    / Type
-    / Kind
+    ; "List"
+    ; "if"
+    / reserved
 
     ; "x"
     ; "x@2"

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -23,8 +23,9 @@
 ; `./MyType` can instead be correctly interpreted as a relative path
 ;
 ; Third, if there are multiple valid parses then prefer the first parse
-; according to the ordering of alternatives.  For example, the  grammar for
-; single quoted string literals is:
+; according to the ordering of alternatives. That is, the order of evaluation
+; of the alternatives is left-to-right.
+; For example, the grammar for single quoted string literals is:
 ;
 ;     single-quote-continue =
 ;           "'''"               single-quote-continue

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -616,10 +616,6 @@ primitive-expression =
     ; "env:FOO"
     / import
 
-    ; "x"
-    ; "x@2"
-    / identifier
-
     ; Built-in functions
     / Natural-fold
     / Natural-build
@@ -656,6 +652,10 @@ primitive-expression =
     ; Built-in type-checking constants
     / Type
     / Kind
+
+    ; "x"
+    ; "x@2"
+    / identifier
 
     ; "( e )"
     / open-parens expression close-parens


### PR DESCRIPTION
The context about this PR is that I've started working on a `dhall-clojure` project - compiling to and from Clojure. (The current status is "almost working PoC", but not that relevant here).

To get started I grabbed Dhall's ABNF and the nice [Instaparse library](https://github.com/Engelberg/instaparse), which supports ABNF (detailed instructions about the support [here](https://github.com/Engelberg/instaparse/blob/master/docs/ABNF.md), everything looks alright).

Apparently - as per `the internet`'s opinion, I wasn't able to find much on this - ABNF alternative (`/`) represents "unordered choice" (even though I cannot find anything more about this in RFC 5234, except for this in the Astract: "The differences between standard BNF and ABNF involve naming rules, repetition, alternatives, order-independence, and value ranges."; if you have more info please let me know).
However, it looks like _a lot_ of grammars (even many IETF ones) rely on left-to-right semantics for evaluating alternatives. To avoid relying on this left-to-right semantics, Instaparse's ABNF alternative operator evaluates right-to-left. This is a problem for those grammars that make that assumption, you can find some examples [here in this issue](https://github.com/Engelberg/instaparse/issues/136) (TL;DR: SPF, DKIM, SMTP..)

It looks like also Dhall's ABNF does rely on this left-to-right-alternative assumption. In fact if I parse `foo.bar` with Instaparse default behaviour (right-to-left), I get an interesting parse tree:
```clojure
dhall-clojure.core> (dhall-parser "foo.bar")

[:complete-expression
 [:whitespace]
 [:expression
  [:annotated-expression
   [:operator-expression
    [:or-expression
     [:plus-expression
      [:text-append-expression
       [:list-append-expression
        [:and-expression
         [:combine-expression
          [:prefer-expression
           [:times-expression
            [:equal-expression
             [:not-equal-expression
              [:application-expression
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "f"]] [:whitespace]]
                  [:whitespace]]]]
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "o"]] [:whitespace]]
                  [:whitespace]]]]
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "o"]] [:whitespace]]
                  [:whitespace]]]
                [:dot "." [:whitespace]]
                [:label [:simple-label [:ALPHA "b"]] [:whitespace]]]
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "a"]] [:whitespace]]
                  [:whitespace]]]]
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "r"]] [:whitespace]]
                  [:whitespace]]]]]]]]]]]]]]]]]]]
```

As you can see, the `application-expression` alternative descends too quickly and splits the single characters into selector expressions. This is not correct.

However, if I switch to left-to-right evaluation, `foo.bar` gets recognized correctly as a single `selector-expression`:
```clojure
dhall-clojure.core> (dhall-parser "foo.bar")

[:complete-expression
 [:whitespace]
 [:expression
  [:annotated-expression
   [:operator-expression
    [:or-expression
     [:plus-expression
      [:text-append-expression
       [:list-append-expression
        [:and-expression
         [:combine-expression
          [:prefer-expression
           [:times-expression
            [:equal-expression
             [:not-equal-expression
              [:application-expression
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label [:simple-label [:ALPHA "f"] [:ALPHA "o"] [:ALPHA "o"]] [:whitespace]]
                  [:whitespace]]]
                [:dot "." [:whitespace]]
                [:label [:simple-label [:ALPHA "b"] [:ALPHA "a"] [:ALPHA "r"]] [:whitespace]]]]]]]]]]]]]]]]]]
```
Very good.
However, if I want to parse a reserved word, it gets recognized as a simple label:
```clojure
dhall-clojure.core> (dhall-parser "Natural/build 2")

[:complete-expression
 [:whitespace]
 [:expression
  [:annotated-expression
   [:operator-expression
    [:or-expression
     [:plus-expression
      [:text-append-expression
       [:list-append-expression
        [:and-expression
         [:combine-expression
          [:prefer-expression
           [:times-expression
            [:equal-expression
             [:not-equal-expression
              [:application-expression
               [:selector-expression
                [:primitive-expression
                 [:identifier
                  [:label
                   [:simple-label
                    [:ALPHA "N"]
                    [:ALPHA "a"]
                    [:ALPHA "t"]
                    [:ALPHA "u"]
                    [:ALPHA "r"]
                    [:ALPHA "a"]
                    [:ALPHA "l"]
                    "/"
                    [:ALPHA "b"]
                    [:ALPHA "u"]
                    [:ALPHA "i"]
                    [:ALPHA "l"]
                    [:ALPHA "d"]]
                   [:whitespace]]
                  [:whitespace [:whitespace-chunk " "]]]]]
               [:selector-expression
                [:primitive-expression
                 [:integer-literal [:natural-raw [:DIGIT "2"]] [:whitespace]]]]]]]]]]]]]]]]]]]
```

This behaviour is mentioned in the ABNF file, which says that if the parser doesn't allow backtracking (which Instaparse does actually, so it shouldn't be an issue) the reserved keywords should be treated differently.
However, if we move the reserved further up the alternatives matching (which is the commit in this PR), they get parsed correctly:
```clojure
dhall-clojure.core> (dhall-parser "Natural/build 2")

[:complete-expression
 [:whitespace]
 [:expression
  [:annotated-expression
   [:operator-expression
    [:or-expression
     [:plus-expression
      [:text-append-expression
       [:list-append-expression
        [:and-expression
         [:combine-expression
          [:prefer-expression
           [:times-expression
            [:equal-expression
             [:not-equal-expression
              [:application-expression
               [:selector-expression
                [:primitive-expression
                 [:Natural-build               ;; <-- This is now correct 
                  "N"
                  "a"
                  "t"
                  "u"
                  "r"
                  "a"
                  "l"
                  "/"
                  "b"
                  "u"
                  "i"
                  "l"
                  "d"
                  [:whitespace [:whitespace-chunk " "]]]]]
               [:selector-expression
                [:primitive-expression
                 [:integer-literal [:natural-raw [:DIGIT "2"]] [:whitespace]]]]]]]]]]]]]]]]]]]
``` 

So, for consistency, we should:
1. Specify this left-to-right assumption in the ABNF
2. Find all the other cases this assumption saves us from doing some special casing (e.g. things like treating reserved words after the fact) - this one might be the only one case, but it might also not be.

Thank you for making Dhall :)

PS:
for context, this is how I get the `dhall-parser` function - no manual combinators fiddling required, everything comes from the ABNF file:
```clojure
(def grammar (slurp "dhall-lang/standard/dhall.abnf"))

(def dhall-parser
  (insta/parser grammar
                :input-format :abnf
                :start :complete-expression
                :output-format :hiccup))
``` 