### PR TITLE
Fix grammar for interpolated expressions

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -202,7 +202,7 @@ single-quote-continue =
       ; Escape two single quotes (i.e. replace this sequence with "''")
       "'''"               single-quote-continue
       ; Interpolation
-    / "${" expression "}" single-quote-continue
+    / "${" complete-expression "}" single-quote-continue
       ; Escape interpolation (i.e. replace this sequence with "${")
     / "''${"              single-quote-continue
     / "''"                                       ; End of text literal


### PR DESCRIPTION
Fixes #131 

The existing grammar forbids interpolating expressions with preceding
whitespace, which this change fixes