### PR TITLE
Fix dangling rule ref after import standardization

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -472,7 +472,7 @@ unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 
 sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 
-http = http-raw whitespace [ using path-hashed ]
+http = http-raw whitespace [ using import-hashed ]
 
 ; Dhall supports unquoted environment variables that are Bash-compliant or
 ; quoted environment variables that are POSIX-compliant


### PR DESCRIPTION
Just a rule that didn't get renamed alongside with the others in [this commit](https://github.com/dhall-lang/dhall-lang/commit/2f93b7f74b56eda99ed97bf56c76616527546524).