### PR TITLE
Disable restricted evaluation for Hydra

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -92,7 +92,10 @@
       let
         secureHydra = packagesNew: packagesOld: {
           hydra = packagesOld.hydra.overrideAttrs (oldAttributes: {
-              patches = (oldAttributes.patches or []) ++ [ ./hydra.patch ];
+              patches = (oldAttributes.patches or []) ++ [
+                ./hydra.patch
+                ./no-restrict-eval.patch
+              ];
             }
           );
         };

--- a/nixops/no-restrict-eval.patch
+++ b/nixops/no-restrict-eval.patch
@@ -1,0 +1,12 @@
+diff --git a/src/hydra-eval-jobs/hydra-eval-jobs.cc b/src/hydra-eval-jobs/hydra-eval-jobs.cc
+index 1e17e99d..449121a1 100644
+--- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
++++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
+@@ -186,7 +186,7 @@ int main(int argc, char * * argv)
+
+         /* Prevent access to paths outside of the Nix search path and
+            to the environment. */
+-        settings.restrictEval = true;
++        settings.restrictEval = false;
+
+         if (releaseExpr == "") throw UsageError("no expression specified");


### PR DESCRIPTION
Hydra's pull request builder support fails on Nix 2.0 when restricted
evaluation is on