### PR TITLE
Force Hydra to always posts a build status

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -47,6 +47,17 @@ let
 
   pkgs = import nixpkgs { config = {}; overlays = [ overlay ]; };
 
+  # Derivation that trivially depends on the current directory so that Hydra's
+  # pull request builder always posts a GitHub status on each revision
+  pwd = pkgs.runCommand "pwd" { here = ./.; } "touch $out";
+
 in
-  { inherit (pkgs) instaparse-accepts-grammar;
+  { all = pkgs.releaseTools.aggregate {
+      name = "all";
+
+      constituents = [
+        pkgs.instaparse-accepts-grammar
+        pwd
+      ];
+    };
   }


### PR DESCRIPTION
Hydra won't post a build status if the derivation never changed since
the last revision, so this changes `./release.nix` to add a new composite `all`
derivation that trivially depends on the current directory to force a
build status on every revision.