### PR TITLE
Disallow `?` and `#` characters from paths

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -372,7 +372,9 @@ identifier-reserved-namespaced-prefix =
 ; whitespace most of the time
 path-character =
         ; %x20 = " "
-      %x21-27
+      %x21-22
+        ; %x23 = "#"
+    / %x24-27
         ; %x28 = "("
         ; %x29 = ")"
     / %x2A-2B
@@ -383,7 +385,8 @@ path-character =
         ; %x3C = "<"
     / %x3D
         ; %x3E = ">"
-    / %x3F-5A
+        ; %x3F = "?"
+    / %x40-5A
         ; %x5B = "["
         ; %x5C = "\"
         ; %x5D = "]"


### PR DESCRIPTION
I discovered this issue in the grammar when updating the Haskell
implementation to match the standard import system.

The standardized import system changed the grammar of URLs so that the
path of a URL used the same grammar as a file path.  However, file paths
permitted `#` and `?` characters, leading to an ambiguity in how to
intepret those characters.

For example, in the following URL:

```
https://example.com/foo?bar=baz
```

... the grammar allowed the `?bar=baz` to be parsed as part of the
path instead of as a query parameter.

This change updates the grammar of paths (both for file paths and URLs)
to disallow the `?` and `#`.  This allows URLs and file paths to still
share the same grammar without leading to ambiguity when parsing query
parameters or fragments in a URL.