### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+standard/dhall.abnf text=auto


### PR DESCRIPTION
This initial `.gitattributes` configuration ensures that the `\r\n` newlines
are correctly preserved for `dhall.abnf` since that line ending is
technically required for the ABNF format.