### PR TITLE
Fix type-checking judgement for `merge`

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3543,17 +3543,19 @@ between the fields of the handler record and the alternatives of the union:
 
     Γ ⊢ t :⇥ { y : ∀(x : A₀) → T₀, ts… }
     Γ ⊢ u :⇥ < y : A₁ | us… >
-    Γ ⊢ (merge { ts… } < us… > : T₁) : T₂
+    Γ ⊢ (merge { ts… } < us… > : T₂) : T₃
     A₀ ≡ A₁
-    T₀ ≡ T₁
+    ↑(-1, x, 0, T₀) = T₁
+    T₁ ≡ T₂
     ────────────────────────────────────  ; `x` not free in `T₀`
-    Γ ⊢ (merge t u : T₁) : T₁
+    Γ ⊢ (merge t u : T₂) : T₂
 
 
     Γ ⊢ t :⇥ { y : ∀(x : A₀) → T₀, ts… }
     Γ ⊢ u :⇥ < y : A₁ | us… >
-    Γ ⊢ (merge { ts… } < us… > : T₀) : T₁
+    Γ ⊢ (merge { ts… } < us… > : T₁) : T₂
     A₀ ≡ A₁
+    ↑(-1, x, 0, T₀) = T₁
     ────────────────────────────────────  ; `x` not free in `T₀`
     Γ ⊢ merge t u : T₀
 


### PR DESCRIPTION
Related to https://github.com/dhall-lang/dhall-haskell/issues/391

The easiest way to describe this fix is that before this change the
following code does not type-check:

```haskell
    let Foo = < Bar : {} | Baz : {} >

in    λ(a : Type)
    → λ(f : {} → a)
    → λ(ts : Foo)
    → merge { Bar = λ(a : {}) → f a, Baz = f } ts
```

... but after this change the code is valid.

The root of the problem was that the type-checking judgment for `merge`
was stripping the `∀` from the inferred type of each handler without
shifting the bound variable that was stripped in this way.  This led to
expressions such as the above failing.

For example, in the above expression the inferred type of the `Bar`
field of the handlers record is:

```
∀(a : {}) → a@1
```

... which is α-equivalent to the inferred type of the `Baz` field:

```haskell
∀(_ : {}) → a
```

In fact, the `Baz` field is the α-normalized form of the `Bar` field,
therefore they must be α-equivalent.

However, if you strip the quantifier from each one without shifting then
they are no longer α-equivalent because the first type becomes:

```haskell
a@1
```

... whereas the second type becomes:

```haskell
a
```

However, if you shift both expressions correctly then they both produce
`a` as the inferred type of the handler's result, which is the correct
type.