### PR TITLE
Fix canonicalization of ../../foo

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3909,9 +3909,14 @@ Canonicalizing a path component named ".." removes that path component along
 with the parent path component:
 
 
+    canonicalize(directory₀) = directory₁/..
+    ──────────────────────────────────────────────
+    canonicalize(directory₀/..) = directory₁/../..
+
+
     canonicalize(directory₀) = directory₁/component
-    ───────────────────────────────────────────────
-    canonicalize(directory₀/..) = directory₁
+    ───────────────────────────────────────────────  ; If "component" is not
+    canonicalize(directory₀/..) = directory₁         ; ".."
 
 
 ... unless there is no path component left to remove:


### PR DESCRIPTION
Before this change, a path like `../../foo` would canonicalize incorrectly
to `./foo`.  This change fixes the standard so that `..` path components
do not annihilate one another

This was caught as a bug in the Haskell implementation:

https://github.com/dhall-lang/dhall-haskell/issues/402