### PR TITLE
Parenthesize import argument to `using`

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -475,7 +475,9 @@ unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 
 sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 
-http = http-raw whitespace [ using import-hashed ]
+http =
+    http-raw whitespace
+    [ using (import-hashed / open-parens import-hashed close-parens) ]
 
 ; Dhall supports unquoted environment variables that are Bash-compliant or
 ; quoted environment variables that are POSIX-compliant


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/441

Before this change the following code leads to an ambiguous parse:

```haskell
https://example.com/foo.dhall using ./headers.dhall sha256:...
```

This code would be parsed in two ways, one of which interprets the semantic
integrity check as applying to `https://example.com/foo.dhall` and another which
treats the semantic integrity check as applying to `./headers.dhall`.

This is the first of two proposed changes to the grammar:

* The first non-breaking change (this one) will add a new way to parenthesize
  the expression that would eliminate the ambiguity
* The second breaking change would make the parentheses mandatory

There are multiple ways to add parentheses to the grammar that would eliminate
the ambiguity.  This proposes adding optional parentheses around the header
import since that is the easiest to parse; there are no other valid
interpretations for those parentheses that would require the parser to
backtrack at point in the grammar.

After some time, this would entail following up with another change to make the
rule:

```abnf
http = http-raw whitespace [ using open-parens import-hashed close-parens ]
```

... which would make parentheses mandatory around the headers import.  Until
then, the interpretation of a trailing semantic integrity check is
implementation-defined and users are advised to use explicit parentheses to
avoid ambiguity.

The purpose of this intermediate period to support the ambiguous parse is to
provide a migration path for users to use the new syntax with parentheses.