### PR TITLE
Allow unparenthesized imports in a few places

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -581,7 +581,7 @@ expression =
 annotated-expression =
     ; "merge e1 e2 : t"
     ; "merge e1 e2"
-      merge selector-expression selector-expression [ colon application-expression ]
+      merge import-expression import-expression [ colon application-expression ]
 
     ; "[]  : List     t"
     ; "[]  : Optional t"
@@ -595,9 +595,9 @@ annotated-expression =
     ; "x : t"
     / operator-expression (colon expression / "")
 
-empty-collection = close-bracket colon (List / Optional) selector-expression
+empty-collection = close-bracket colon (List / Optional) import-expression
 
-non-empty-optional = expression close-bracket colon Optional selector-expression
+non-empty-optional = expression close-bracket colon Optional import-expression
 
 operator-expression = or-expression
 


### PR DESCRIPTION
This changes the grammar to replace a few occurrences of `selector-expression`
with `import-expression`.  The main impact this has on end users is that:

* They no longer have to parenthesize an import used in a type annotation for a collection
* They no longer have to parenthesize an import used in `merge` expression

This is primarily motivated by: https://github.com/dhall-lang/dhall-haskell/issues/462