### PR TITLE
Don't mark failing tests green

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -157,7 +157,7 @@
 
         extraConfig = ''
           <githubstatus>
-            jobs = .*
+            jobs = .*:.*:dhall.*
             inputs = src
             authorization = dhall-lang
             context = hydra

--- a/release.nix
+++ b/release.nix
@@ -52,8 +52,8 @@ let
   pwd = pkgs.runCommand "pwd" { here = ./.; } "touch $out";
 
 in
-  { all = pkgs.releaseTools.aggregate {
-      name = "all";
+  { dhall-lang = pkgs.releaseTools.aggregate {
+      name = "dhall-lang";
 
       constituents = [
         pkgs.dhall-grammar

--- a/release.nix
+++ b/release.nix
@@ -25,7 +25,7 @@ let
         (println "Grammar is syntactically correct."))
     '';
 
-    instaparse-accepts-grammar =
+    dhall-grammar =
       pkgsNew.runCommand
         "instaparse-accepts-grammar"
         { nativeBuildInputs = [
@@ -56,7 +56,7 @@ in
       name = "all";
 
       constituents = [
-        pkgs.instaparse-accepts-grammar
+        pkgs.dhall-grammar
         pwd
       ];
     };


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/487

This changes the Hydra configuration to only post success status for build
products beginning with `dhall`.  This prevents `pwd` derivations from
masking failing builds