### PR TITLE
Have `prelude.dhall-lang.org` track `master`

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -215,7 +215,7 @@
         virtualHosts."prelude.dhall-lang.org" = {
           locations."/".extraConfig = ''
             rewrite ^/?$ https://github.com/dhall-lang/Prelude redirect;
-            rewrite ^/(.+)$ https://raw.githubusercontent.com/dhall-lang/Prelude/35deff0d41f2bf86c42089c6ca16665537f54d75/$1 redirect;
+            rewrite ^/(.+)$ https://raw.githubusercontent.com/dhall-lang/Prelude/master/$1 redirect;
           '';
         };
       };


### PR DESCRIPTION
Once nice feature of switching from IPFS to GitHub is that we can have
`prelude.dhall-lang.org` redirect to whatever is the current `master`
instead of having to redeploy the proxy redirect for every change