### PR TITLE
Add `$` as an allowed character in quoted labels

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -124,7 +124,7 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
-quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / ".")
+quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / "." / "$")
 
 ; NOTE: Dhall does not support Unicode labels, mainly to minimize the potential
 ; for code obfuscation


### PR DESCRIPTION
As suggested/agreed in https://github.com/dhall-lang/dhall-kubernetes/issues/19

/cc @geigerzaehler