### PR TITLE
Configure Hydra to support the "builtin" system

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -100,7 +100,7 @@
             "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
             "hydra/machines".text = ''
-              hydra-queue-runner@hydra x86_64-linux /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 1 1 local
+              hydra-queue-runner@hydra x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 1 1 local
             '';
           };
 


### PR DESCRIPTION
Some newer Nix derivations set the `system` to "builtin", which requires
this change to Hydra to permit those builds