### PR TITLE
Require whitespace when parsing the + operator

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -608,18 +608,18 @@ non-empty-optional = expression close-bracket colon Optional import-expression
 
 operator-expression = import-alt-expression
 
-import-alt-expression    = or-expression            *(import-alt    or-expression)
-or-expression            = plus-expression          *(or            plus-expression         )
-plus-expression          = text-append-expression   *(plus          text-append-expression  )
-text-append-expression   = list-append-expression   *(text-append   list-append-expression  )
-list-append-expression   = and-expression           *(list-append   and-expression          )
-and-expression           = combine-expression       *(and           combine-expression      )
-combine-expression       = prefer-expression        *(combine       prefer-expression       )
-prefer-expression        = combine-types-expression *(prefer        combine-types-expression)
-combine-types-expression = times-expression         *(combine-types times-expression        )
-times-expression         = equal-expression         *(times         equal-expression        )
-equal-expression         = not-equal-expression     *(double-equal  not-equal-expression    )
-not-equal-expression     = application-expression   *(not-equal     application-expression  )
+import-alt-expression    = or-expression            *(import-alt            or-expression)
+or-expression            = plus-expression          *(or                    plus-expression         )
+plus-expression          = text-append-expression   *(plus whitespace-chunk text-append-expression  )
+text-append-expression   = list-append-expression   *(text-append           list-append-expression  )
+list-append-expression   = and-expression           *(list-append           and-expression          )
+and-expression           = combine-expression       *(and                   combine-expression      )
+combine-expression       = prefer-expression        *(combine               prefer-expression       )
+prefer-expression        = combine-types-expression *(prefer                combine-types-expression)
+combine-types-expression = times-expression         *(combine-types         times-expression        )
+times-expression         = equal-expression         *(times                 equal-expression        )
+equal-expression         = not-equal-expression     *(double-equal          not-equal-expression    )
+not-equal-expression     = application-expression   *(not-equal             application-expression  )
 
 ; Import expressions need to be separated by some whitespace, otherwise there
 ; would be ambiguity: `./ab` could be interpreted as "import the file `./ab`",


### PR DESCRIPTION
Fix #199 

We require the whitespace when parsing the `NaturalPlus` operator, so it's not ambiguous with the `+` symbol for `Integer`