### PR TITLE
Standardize semantics for hashing and caching

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4266,10 +4266,14 @@ expression protected by a semantic integrity check:
 * Check if there is a Dhall expression stored at either
   `"${XDG_CACHE_HOME}/dhall/${base16Hash}"` or
   `"${HOME}/.cache/dhall/${base16Hash}"`
-* If the file exists and is readable, decode the locally cached expression using
-  the `decode-1.0` judgment instead of importing the expression
-    * Verify the decoded expression's actual hash matches the expected hash
+* If the file exists and is readable, verify the file's byte contents match the
+  hash and then decode the expression from the bytes using the `decode-1.0`
+  judgment instead of importing the expression
 * Otherwise, import the expression as normal
+
+An implementation MUST fail and alert the user if hash verification fails,
+either when importing an expression for the first time or importing from the
+local cache.
 
 Or in judgment form:
 

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4266,8 +4266,8 @@ expression protected by a semantic integrity check:
 * Check if there is a Dhall expression stored at either
   `"${XDG_CACHE_HOME}/dhall/${base16Hash}"` or
   `"${HOME}/.cache/dhall/${base16Hash}"`
-* If the file exists, decode the locally cached expression using the
-  `decode-1.0` judgment instead of importing the expression
+* If the file exists and is readable, decode the locally cached expression using
+  the `decode-1.0` judgment instead of importing the expression
     * Verify the decoded expression's actual hash matches the expected hash
 * Otherwise, import the expression as normal
 

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4295,8 +4295,8 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
-    e₁ ↦ e₂
-    e₂ ⇥ e₃
+    e₁ ⇥ e₂
+    e₂ ↦ e₃
     encode-1.0(e₃) = binary
     sha256(binary) = byteHash
     base16Encode(byteHash) = base16Hash  ; Verify the hash
@@ -4305,8 +4305,8 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
-    e₁ ↦ e₂
-    e₂ ⇥ e₃
+    e₁ ⇥ e₂
+    e₂ ↦ e₃
     encode-1.0(e₃) = binary
     sha256(binary) = byteHash
     base16Encode(byteHash) = base16Hash  ; Verify the hash
@@ -4315,8 +4315,8 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
-    e₁ ↦ e₂
-    e₂ ⇥ e₃
+    e₁ ⇥ e₂
+    e₂ ↦ e₃
     encode-1.0(e₃) = binary
     sha256(binary) = byteHash
     base16Encode(byteHash) = base16Hash              ; Verify the hash

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4243,9 +4243,9 @@ If the import is protected with a `sha256:base64Hash` integrity check, then:
 * the SHA-256 hash is base16-encoded
 * the base16-encoded result has to match the integrity check
 
-An implementation MUST cache imports protected with an integrity check using the
-hash as the lookup key.  An implementation that caches imports in this way so
-MUST:
+An implementation MUST attempt to cache imports protected with an integrity
+check using the hash as the lookup key.  An implementation that caches imports
+in this way so MUST:
 
 * Cache the fully resolved, αβ-normalized expression, and encoded expression
 * Store the cached expression in `"${XDG_CACHE_HOME}/dhall/${base16Hash}"` if
@@ -4256,8 +4256,12 @@ MUST:
   defined and the path is readable and writeable
 * Otherwise, not cache the expression at all
 
-Similarly, MUST follow these steps when importing an expression protected by a
-semantic integrity check:
+An implementation SHOULD warn the user if the interpreter is unable to cache the
+expression due to the environment variables being unset or the filesystem paths
+not being readable or writeable.
+
+Similarly, an implementation MUST follow these steps when importing an
+expression protected by a semantic integrity check:
 
 * Check if there is a Dhall expression stored at either
   `"${XDG_CACHE_HOME}/dhall/${base16Hash}"` or

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4236,7 +4236,7 @@ resolve imports within the retrieved expression:
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁    ; import and `import₀` is not `missing`
 
 
-If the import is protected with a `sha256:base64Hash` integrity check, then:
+If the import is protected with a `sha256:base16Hash` integrity check, then:
 
 * the import's normal form is encoded to a binary representation
 * the binary representation is hashed using SHA-256

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -4295,6 +4295,7 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
+    ε ⊢ e₁ : T
     e₁ ⇥ e₂
     e₂ ↦ e₃
     encode-1.0(e₃) = binary
@@ -4305,6 +4306,7 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
+    ε ⊢ e₁ : T
     e₁ ⇥ e₂
     e₂ ↦ e₃
     encode-1.0(e₃) = binary
@@ -4315,6 +4317,7 @@ Or in judgment form:
 
 
     Γ₀ ⊢ import₀ @ here ⇒ e₁ ⊢ Γ₁
+    ε ⊢ e₁ : T
     e₁ ⇥ e₂
     e₂ ↦ e₃
     encode-1.0(e₃) = binary


### PR DESCRIPTION
Fixes #129

This specifies both how to verify and how to cache imports protected by
semantic integrity checks