### PR TITLE
Define semantics of text literals

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -145,8 +145,7 @@ label = ("`" quoted-label "`" / simple-label) whitespace
 ; > quotation mark, reverse solidus, and the control characters (U+0000
 ; > through U+001F).
 ; > 
-; > Any character may be escaped.  If the character is in the Basic
-; > Multilingual Plane (U+0000 through U+FFFF), then it may be
+; > Any character in the Basic Multilingual Plane may be escaped.  It can be
 ; > represented as a six-character sequence: a reverse solidus, followed
 ; > by the lowercase letter u, followed by four hexadecimal digits that
 ; > encode the character's code point.  The hexadecimal letters A though
@@ -158,12 +157,6 @@ label = ("`" quoted-label "`" / simple-label) whitespace
 ; > representations of some popular characters.  So, for example, a
 ; > string containing only a single reverse solidus character may be
 ; > represented more compactly as "\\".
-; > 
-; > To escape an extended character that is not in the Basic Multilingual
-; > Plane, the character is represented as a 12-character sequence,
-; > encoding the UTF-16 surrogate pair.  So, for example, a string
-; > containing only the G clef character (U+1D11E) may be represented as
-; > "\uD834\uDD1E".
 double-quote-chunk =
       "${" expression "}"  ; Interpolation
     / %x5C                 ; '\'    Beginning of escape sequence

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2942,7 +2942,57 @@ points surrounded by double quotes (`"`).
     ────────────  ; Single-quote text literals normalize to double-quote.
     ''"'' ⇥ "\""
 
+
 ### Single-quote text literals
+
+Single-quote text literals (surrounded by `''`) are subject to indentation
+stripping after interpreting escape codes. The sequence of code points that the
+literal represents is the one after stripping indents, and after removing a
+leading newline, if one exists. The canonical encoding of a single-quote text
+literal is the canonical double-quote encoding of the sequence of code points it
+represents.
+
+The *content start* of a sequence of code points is the first code point that is
+not a newline (U+000A) or a space (U+0020).
+
+The *indent* of a sequence of code points, is the subsequence of code points
+between the last newline before the content start, and the content start itself.
+The newline and content start are not included in the indent. If no newline
+occurs before the content start, the indent is empty.
+
+Stripping indents is done by, after every newline (U+000A), removing code points
+that form a prefix of the indent.
+
+
+    ────────────  ; The indent is empty, nothing is stripped.
+    ''...
+    '' ⇥ "...\n"
+
+
+    ────────────  ; The leading newline is stripped. The indent is empty.
+    ''
+    1
+    2'' ⇥ "1\n2"
+
+
+    ────────────  ; The leading newline is stripped. The indent is two spaces.
+    ''
+      1
+      2'' ⇥ "1\n2"
+
+
+    ────────────  ; The leading newline is stripped. The indent is two spaces.
+    ''
+      1
+        2
+    '' ⇥ "1\n  2\n"
+
+
+    ────────────  ; The leading newline is stripped. The indent is four spaces.
+    ''
+        1
+      2
+    '' ⇥ "1\n2\n" ; The two spaces in front of "2" were a prefix of the indent.
 
 
 ## Equivalence

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2962,13 +2962,12 @@ The *content start* of a sequence of code points is the first code point that is
 not a newline (U+000A) or a space (U+0020). For the purposes of indentation,
 string interpolation counts as content.
 
-The *indent* of a sequence of code points, is the subsequence of code points
-between the last newline before the content start, and the content start itself.
-The newline and content start are not included in the indent. If no newline
-occurs before the content start, the indent is empty.
+The *indent* of a sequence of code points, is the shortest subsequence of spaces
+(U+0020) points after a newline (U+000A), or after the content start, across the
+text literal. The newline is not included in the indent. The indent might be
+empty.
 
-Stripping indents is done by, after every newline (U+000A), removing code points
-that form a prefix of the indent.
+Stripping indents is done by, after every newline (U+000A), removing the indent.
 
 
     ────────────  ; The indent is empty, nothing is stripped.
@@ -2995,11 +2994,11 @@ that form a prefix of the indent.
     '' ⇥ "1\n  2\n"
 
 
-    ────────────  ; The leading newline is stripped. The indent is four spaces.
+    ────────────  ; The leading newline is stripped. The indent is two spaces.
     ''
         1
       2
-    '' ⇥ "1\n2\n" ; The two spaces in front of "2" were a prefix of the indent.
+    '' ⇥ "  1\n2\n" ; The two spaces in front of "2" were a prefix of the indent.
 
 
 ## Equivalence

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2931,8 +2931,8 @@ The canonical encoding of a sequence of code points is that sequence of code
 points surrounded by double quotes (`"`).
 
 
-    ────────────────────  ; Example of normalizing a \uXXXX escape sequence.
-    "\uD834\uDD1E" ⇥ "𝄞"
+    ──────────────  ; Example of normalizing a \uXXXX escape sequence.
+    "\u00E9" ⇥ "é"
 
 
     ───────────────  ; Newlines still need to be escaped.

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -42,6 +42,7 @@ expressions.
     * [Type annotations](#type-annotations)
     * [Imports](#imports-3)
 * [Text literals](#text-literals)
+    * [Interpolation](#interpolation)
     * [Canonicalization of text](#canonicalization-of-text)
     * [Single-quote text literals](#single-quote-text-literals)
 * [Equivalence](#equivalence)
@@ -2911,6 +2912,11 @@ An expression with unresolved imports cannot be β-normalized.
 
 ## Text literals
 
+### Interpolation
+
+Dhall supports text `"${expr}"`-style text interpolation. Text interpolation is
+a primitive language feature that survives normalization.
+
 ### Canonicalization of text
 
 Multiple text literals can encode the same sequence of code points, but every
@@ -2946,14 +2952,15 @@ points surrounded by double quotes (`"`).
 ### Single-quote text literals
 
 Single-quote text literals (surrounded by `''`) are subject to indentation
-stripping after interpreting escape codes. The sequence of code points that the
-literal represents is the one after stripping indents, and after removing a
-leading newline, if one exists. The canonical encoding of a single-quote text
-literal is the canonical double-quote encoding of the sequence of code points it
-represents.
+stripping after interpreting escape codes and before substituting interpolated
+values. The sequence of code points that the literal represents is the one after
+stripping indents, and after removing a leading newline, if one exists. The
+canonical encoding of a single-quote text literal is the canonical double-quote
+encoding of the sequence of code points it represents.
 
 The *content start* of a sequence of code points is the first code point that is
-not a newline (U+000A) or a space (U+0020).
+not a newline (U+000A) or a space (U+0020). For the purposes of indentation,
+string interpolation counts as content.
 
 The *indent* of a sequence of code points, is the subsequence of code points
 between the last newline before the content start, and the content start itself.

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -41,6 +41,9 @@ expressions.
     * [`let` expressions](#let-expressions)
     * [Type annotations](#type-annotations)
     * [Imports](#imports-3)
+* [Text literals](#text-literals)
+    * [Canonicalization of text](#canonicalization-of-text)
+    * [Single-quote text literals](#single-quote-text-literals)
 * [Equivalence](#equivalence)
 * [Function check](#function-check)
 * [Type inference](#type-inference)
@@ -2223,12 +2226,8 @@ The `Text` type is in normal form:
     Text ⇥ Text
 
 
-`Text` literals are in normal form:
-
-
-    ─────────
-    "…" ⇥ "…"
-
+`Text` literals normalize to their
+[canonical encoding](#canonicalization-of-text).
 
 Use machine concatenation to simplify the "text concatenation" operator if both
 arguments normalize to `Text` literals:
@@ -2909,6 +2908,42 @@ Simplify a type annotation by removing the annotation:
 ### Imports
 
 An expression with unresolved imports cannot be β-normalized.
+
+## Text literals
+
+### Canonicalization of text
+
+Multiple text literals can encode the same sequence of code points, but every
+sequence of code points can be encoded as one unique canonical text literal. The
+canonical encoding of a code point is that code point itself, apart from the
+following code points:
+
+ * U+0008 (backspace) encodes to U+005C, U+0062 (`\b`).
+ * U+0009 (tab) encodes to U+005C, U+0074 (`\t`).
+ * U+000C (form feed) encodes to U+005C, U+0066 (`\f`).
+ * U+000A (line feed) encodes to U+005C, U+006E (`\n`).
+ * U+000D (carriage return) encodes to U+005C, U+0072 (`\r`).
+ * U+0022 (`"`) encodes to U+005C, U+0022 (`\"`).
+ * U+0024 (`$`) encodes to U+005C, U+0024 (`\$`).
+ * U+005C (<code>\</code>) encodes to U+005C, U+005C (<code>\\</code>).
+
+The canonical encoding of a sequence of code points is that sequence of code
+points surrounded by double quotes (`"`).
+
+
+    ────────────────────  ; Example of normalizing a \uXXXX escape sequence.
+    "\uD834\uDD1E" ⇥ "𝄞"
+
+
+    ───────────────  ; Newlines still need to be escaped.
+    "\u000A" ⇥ "\n"
+
+
+    ────────────  ; Single-quote text literals normalize to double-quote.
+    ''"'' ⇥ "\""
+
+### Single-quote text literals
+
 
 ## Equivalence
 


### PR DESCRIPTION
## Summary

Here is a first attempt at defining the semantics of single and double-quote text literals, as suggested in https://github.com/dhall-lang/dhall-lang/issues/200#issuecomment-407285046.

## Approach

The standard previously only mentioned text literals, but defining equivalence in terms of text literals is awkward. Furthermore, I think it was wrong for all text literals to be in normal form. For example, a consequence of that was that the following expressions were not equivalent:

```
"\n"     "𝄞"
"\u000A" "\uD834\uDD1E"
```

Both equivalence between single and double-quoted text, and between different ways to escape the same text, can be defined with a canonical text literal encoding of a sequence of code points. The grammar already specifies how to interpret escape sequences. The only thing left after that, is to define how to convert the code points of a single-quoted text literal after parsing, to the sequence that it represents, by stripping indents.

For stripping indents, take the indent of the first line, and remove it from every line. If a line contains only a prefix of the indent, strip that part.

## Alternatives

The indent is currently detected from the first line. A downside of this is that you cannot make a single-quoted text literal where the first line is indented. For example:
```
''
    x
''
```
would be equivalent to `"x\n"`, and not to `"    x\n"`.

Alternatively, we could detect the indent from the *last* line. The indent would be all the characters between the final newline and the closing `''`. (I do this in [Pris](https://github.com/ruuda/pris/blob/4b3f7d7cc4095120e524abd8bc5853c1630b55d1/examples/raw_string.pris#L9-L17).) The advantage is that you get full control over indentation, but only if the closing `''` is on its own line. If you want to put it right after the last content to suppress the trailing newline, then this approach breaks down.

Yet another alternative would be to take the minimal indent across all lines of the literal, rather than looking only at the indent of the first or last line.