### PR TITLE
Require non-empty whitespace after keywords

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -114,6 +114,8 @@ whitespace-chunk =
 
 whitespace = *whitespace-chunk
 
+nonempty-whitespace = 1*whitespace-chunk
+
 ; Uppercase or lowercase ASCII letter
 ALPHA = %x41-5A / %x61-7A
 
@@ -299,17 +301,17 @@ reserved            = reserved-raw            whitespace
 reserved-namespaced = reserved-namespaced-raw whitespace
 
 ; Whitespaced rules for reserved words, to be used when matching expressions
-if           = if-raw           whitespace-chunk
-then         = then-raw         whitespace-chunk
-else         = else-raw         whitespace-chunk
-let          = let-raw          whitespace-chunk
-in           = in-raw           whitespace-chunk
-as           = as-raw           whitespace-chunk
-using        = using-raw        whitespace-chunk
-merge        = merge-raw        whitespace-chunk
-constructors = constructors-raw whitespace-chunk
-Optional     = Optional-raw     whitespace-chunk
+if           = if-raw           nonempty-whitespace
+then         = then-raw         nonempty-whitespace
+else         = else-raw         nonempty-whitespace
+let          = let-raw          nonempty-whitespace
+in           = in-raw           nonempty-whitespace
+as           = as-raw           nonempty-whitespace
+using        = using-raw        nonempty-whitespace
+merge        = merge-raw        nonempty-whitespace
+constructors = constructors-raw nonempty-whitespace
 
+Optional     = Optional-raw     whitespace
 Text         = Text-raw         whitespace
 List         = List-raw         whitespace
 

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -262,16 +262,7 @@ Type-raw              = %x54.79.70.65
 Kind-raw              = %x4b.69.6e.64
 
 reserved-raw =
-    if-raw
-  / then-raw
-  / else-raw
-  / let-raw
-  / in-raw
-  / as-raw
-  / using-raw
-  / merge-raw
-  / constructors-raw
-  / Bool-raw
+    Bool-raw
   / Optional-raw
   / Natural-raw
   / Integer-raw
@@ -308,16 +299,17 @@ reserved            = reserved-raw            whitespace
 reserved-namespaced = reserved-namespaced-raw whitespace
 
 ; Whitespaced rules for reserved words, to be used when matching expressions
-if           = if-raw           whitespace
-then         = then-raw         whitespace
-else         = else-raw         whitespace
-let          = let-raw          whitespace
-in           = in-raw           whitespace
-as           = as-raw           whitespace
-using        = using-raw        whitespace
-merge        = merge-raw        whitespace
-constructors = constructors-raw whitespace
-Optional     = Optional-raw     whitespace
+if           = if-raw           whitespace-chunk
+then         = then-raw         whitespace-chunk
+else         = else-raw         whitespace-chunk
+let          = let-raw          whitespace-chunk
+in           = in-raw           whitespace-chunk
+as           = as-raw           whitespace-chunk
+using        = using-raw        whitespace-chunk
+merge        = merge-raw        whitespace-chunk
+constructors = constructors-raw whitespace-chunk
+Optional     = Optional-raw     whitespace-chunk
+
 Text         = Text-raw         whitespace
 List         = List-raw         whitespace
 
@@ -685,7 +677,6 @@ primitive-expression =
     / identifier-reserved-prefix
 
     ; "List"
-    ; "if"
     / reserved
 
     ; "x"


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/547

This change requires at least one space after keywords (that are not
built-ins), in order to support identifiers that have a prefix matching
a keyword (such as `mergedRec`)

This is a breaking change since expressions such as the following were valid
before the change and disallowed after the change:

```haskell
if(True) then 1 else 2
```

```haskell
merge{ x = λ(_ : {}) → 1 } < x = {=} >
```

While fixing this I noticed an error in the grammar that allowed parsing
naked keywords (such as a standalone `if`), which I fixed.