### PR TITLE
Sort fields/alternatives when β-normalizing records/unions

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2523,7 +2523,8 @@ All of the built-in functions on `Optional` values are in normal form:
 
 ### Records
 
-Normalizing a record type normalizes the type of each field:
+Normalizing a record type sorts the fields and normalizes the type of each
+field:
 
 
     ───────
@@ -2535,7 +2536,7 @@ Normalizing a record type normalizes the type of each field:
     { x : T₀, xs₀… } ⇥ { x : T₁, xs₁… }
 
 
-Normalizing a record value normalizes each field:
+Normalizing a record value sorts the fields and normalizes each field:
 
 
     ─────────
@@ -2676,7 +2677,8 @@ record types:
 
 ### Unions
 
-Normalizing a union type normalizes the type of each alternative:
+Normalizing a union type sorts the alternatives and normalizes the type of each
+alternative:
 
 
     ───────
@@ -2688,8 +2690,8 @@ Normalizing a union type normalizes the type of each alternative:
     < x : T₀ | xs₀… > ⇥ < x : T₁ | xs₁… >
 
 
-Normalizing a union value is the same as normalizing the specified value and
-the type of each alternative:
+Normalizing a union value sorts the alternatives, normalizes the specified
+value, and normalizes the type of each alternative:
 
 
     t₀ ⇥ t₁
@@ -3364,7 +3366,7 @@ The built-in functions on `Optional` values have the following types:
 ### Records
 
 Record types are "anonymous", meaning that they are uniquely defined by the
-names and types of their fields and the order of fields does not matter:
+names and types of their fields.
 
 A record can either store term-level values and functions:
 

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3629,7 +3629,7 @@ error.
 ### Unions
 
 Union types are "anonymous", meaning that they are uniquely defined by the names
-and types of their alternatives and the order of alternatives does not matter:
+and types of their alternatives:
 
 
     ─────────────


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/548

Previously the standard required that record and union comparisons were
insensitive to field order, but that meant that implementations could
potentially preserve field order even when serializing them.  Doing so
could lead to two different semantic integrity checks for records that
were semantically equivalent but with different field order.

A simpler approach is to not specify at all that records are order-insensitive.
Instead, specify that β-normalization sorts fields.  This has the nice
property that equivalence checks are still order-insensitive (since
equivalence checking β-normalizes both arguments) and that semantic
integrity checks are order-insensitive (since a semantic integrity check
β-normalizes the expression).