### PR TITLE
Clarify the binary encoding of text literals

### DIFF
--- a/standard/binary.md
+++ b/standard/binary.md
@@ -688,9 +688,10 @@ interpolated expressions:
     ───────────────────────────────────────────────────────────────────────────────────
     encode("a${b₀}c${d}e…x${y₀}z") = [ 18, "a", b₁, "c", d₁, "e", …, "x", y₁, "z" ]
 
-
-Note that the encoding of a text literal always begins and ends with a string,
-even if the first or last chunk is the empty string.
+In other words: the amount of encoded elements is always an odd number, with the
+odd elements being strings and the even ones being interpolated expressions.  
+Note: this means that the first and the last encoded elements are always strings,
+even if they are empty strings.
 
 ### Imports
 


### PR DESCRIPTION
I just implemented the binary serialization in the Clojure compiler just by following the spec, except for the encoding of text literals, which was the only part I had to go look at the Haskell implementation.

I think my issue with the existing text is that it doesn't really specify how the encoding should look like, which I hope the new text makes explicit enough.
