### PR TITLE
Update `prelude.dhall-lang.org`

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -152,7 +152,7 @@
 
           locations."/".extraConfig = ''
             rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/master/Prelude redirect;
-            rewrite ^/(.+)$ https://github.com/dhall-lang/dhall-lang/blob/1bc66b345c8e93579e16ac6f697c3473bb846baa/Prelude/$1 redirect;
+            rewrite ^/(.+)$ https://raw.githubusercontent.com/dhall-lang/dhall-lang/1bc66b345c8e93579e16ac6f697c3473bb846baa/Prelude/$1 redirect;
           '';
         };
       };

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -151,8 +151,8 @@
           enableACME = true;
 
           locations."/".extraConfig = ''
-            rewrite ^/?$ https://github.com/dhall-lang/Prelude redirect;
-            rewrite ^/(.+)$ https://raw.githubusercontent.com/dhall-lang/Prelude/master/$1 redirect;
+            rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/master/Prelude redirect;
+            rewrite ^/(.+)$ https://github.com/dhall-lang/dhall-lang/blob/1bc66b345c8e93579e16ac6f697c3473bb846baa/Prelude/$1 redirect;
           '';
         };
       };


### PR DESCRIPTION
Now it points to the `./Prelude` subdirectory of `dhall-lang` instead of
the `Prelude` repository

Normally I would use the release tag to pin the Prelude version, but
the Prelude was migrated after release 3.0.0 was cut, so I just used the
revision where the Prelude was merged in instead.