### PR TITLE
Specify CBOR encoding of Double and grammar rules for NaN and Infinity values

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -669,6 +669,9 @@ primitive-expression =
     ; "+2"
     / integer-literal
 
+    ; "-Infinity"
+    / "-" Infinity-raw
+
     ; '"ABC"'
     / text-literal
 
@@ -695,9 +698,6 @@ primitive-expression =
 
     ; "List"
     / reserved
-
-    ; "-Infinity"
-    / "-" Infinity-raw
 
     ; "x"
     ; "x@2"

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -266,6 +266,8 @@ Text-raw              = %x54.65.78.74
 List-raw              = %x4c.69.73.74
 True-raw              = %x54.72.75.65
 False-raw             = %x46.61.6c.73.65
+NaN-raw               = %x4e.61.4e
+Infinity-raw          = %x49.6e.66.69.6e.69.74.79
 Type-raw              = %x54.79.70.65
 Kind-raw              = %x4b.69.6e.64
 Sort-raw              = %x53.6f.72.74
@@ -281,6 +283,8 @@ reserved-raw =
   / List-raw
   / True-raw
   / False-raw
+  / NaN-raw
+  / Infinity-raw
   / Type-raw
   / Kind-raw
   / Sort-raw
@@ -691,6 +695,9 @@ primitive-expression =
 
     ; "List"
     / reserved
+
+    ; "-Infinity"
+    / "-" Infinity-raw
 
     ; "x"
     ; "x@2"

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2854,12 +2854,11 @@ An `Integer` literal is in normal form:
     ─────────────────────────────
     f a ⇥ ±n.0
 
-Note that if `n` is greater than 2^53, `Integer/toDouble n` may result in loss
-of precision. The closest `Double` will be chosen even it is not an integer.
-When the magnitude of `n` is greater than or equal to a cutoff value it will
-round to `±Infinity`. This cutoff value is `DBL_MAX + 2^971 ≈ 1.8e308` where
-`DBL_MAX` is the largest number which can be represented by a 64-bit floating
-point value.
+Note that if the magnitude of `a` is greater than 2^53, `Integer/toDouble a`
+may result in loss of precision. A `Double` will be selected by rounding `a` to
+the nearest `Double`. Ties go to the `Double` with an even least significant
+bit. When the magnitude of `a` is greater than or equal to `c`, the magnitude
+will round to `Infinity`, where `c = 2^1024 - 2^970 ≈ 1.8e308`.
 
 `Integer/show` transforms an `Integer` into a `Text` literal representing valid
 Dhall code for representing that `Integer` number:

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2854,6 +2854,12 @@ An `Integer` literal is in normal form:
     ─────────────────────────────
     f a ⇥ ±n.0
 
+Note that if `n` is greater than 2^53, `Integer/toDouble n` may result in loss
+of precision. The closest `Double` will be chosen even it is not an integer.
+When the magnitude of `n` is greater than or equal to a cutoff value it will
+round to `±Infinity`. This cutoff value is `DBL_MAX + 2^971 ≈ 1.8e308` where
+`DBL_MAX` is the largest number which can be represented by a 64-bit floating
+point value.
 
 `Integer/show` transforms an `Integer` into a `Text` literal representing valid
 Dhall code for representing that `Integer` number:
@@ -2910,6 +2916,19 @@ The `Double/show` function is in normal form:
 
     ─────────────────────────
     Double/show ⇥ Double/show
+
+
+The following 2 properties must hold for `Double/show`:
+
+```
+show (read (show (X : Double))) = show X
+
+read (show (read (Y : Text))) = read Y
+```
+
+where `show : Double → Text` is shorthand for `Double/show` and `read : Text →
+Double` is the function in the implementation of Dhall which takes a correctly
+formated text representation of a `Double` as input and outputs a `Double`.
 
 
 ### Functions

--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -2850,7 +2850,7 @@ An `Integer` literal is in normal form:
 `Integer/toDouble` transforms an `Integer` into the corresponding `Double`:
 
 
-    f ⇥ Natural/toDouble   a ⇥ ±n
+    f ⇥ Integer/toDouble   a ⇥ ±n
     ─────────────────────────────
     f a ⇥ ±n.0
 


### PR DESCRIPTION
See the discussion in issue #252. [RFC 7049 section 3.9](https://tools.ietf.org/html/rfc7049#section-3.9) gives an example of a canonical representation for a floating point number using the smallest encoding which does not lose precision. I copied that idea here except chose the NaN value used in the cborg haskell library. And I purposefully omit the grammar rule for "+Infinity" because it doesn't play nice with addition of variables with the prefix "Infinity". I'm guessing that fixing that would be non-trivial.