### PR TITLE
Add simplifications that take advantage of associativity

### DIFF
--- a/tests/normalization/success/simplifications/associativityA.dhall
+++ b/tests/normalization/success/simplifications/associativityA.dhall
@@ -1,0 +1,3 @@
+{ example0 = λ(x : Bool) → False == x == True == x
+, example1 = λ(x : Natural) → 1 + 2 + x + 4 + 5
+}

--- a/tests/normalization/success/simplifications/associativityB.dhall
+++ b/tests/normalization/success/simplifications/associativityB.dhall
@@ -1,0 +1,3 @@
+{ example0 = λ(x : Bool) → False
+, example1 = λ(x : Natural) → 3 + x + 9
+}


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/652

This change updates the language to exploit associativity to expose more
simplifications.

The test suite contains a non-trivial example of how this would work:

    λ(x : Bool) → ((False == x) == True) == x

... which should simplify to:

    λ(x : Bool) → False

I chose this test case because my original attempt to standardize this
did not handle this case correctly because it didn't normalize
`(False == x) == True` to `(False == x)` before attempting to detect an
opportunity to simplify `(False == x) == x` via associativity.

The second test case exercises reordering a pathological set of parentheses,
which would not reduce without this change:

    λ(x : Natural) → 1 + ((2 + (x + 4)) + 5)

... but after this change would simplify to:

    λ(x : Natural) → 3 + x + 9