### PR TITLE
Do not require variable shadowing support in unrelated test

### DIFF
--- a/tests/typecheck/success/simple/mergeEquivalenceA.dhall
+++ b/tests/typecheck/success/simple/mergeEquivalenceA.dhall
@@ -3,4 +3,4 @@
 in    λ(a : Type)
     → λ(f : {} → a)
     → λ(ts : Foo)
-    → merge { Bar = λ(a : {}) → f a, Baz = f } ts
+    → merge { Bar = λ(b : {}) → f b, Baz = f } ts


### PR DESCRIPTION
This patch makes test, which verifies `merge` expression typechecking, insensitive to flaws in variable shadowing mechanics.