### PR TITLE
Disallow labels that match builtins or keywords

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -141,6 +141,52 @@ DIGIT = %x30-39  ; 0-9
 
 HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 
+; A simple label cannot be one of the following reserved names:
+;
+; * Bool
+; * Optional
+; * None
+; * Natural
+; * Integer
+; * Double
+; * Text
+; * List
+; * True
+; * False
+; * NaN
+; * Infinity
+; * Type
+; * Kind
+; * Sort
+; * Natural/fold
+; * Natural/build
+; * Natural/isZero
+; * Natural/even
+; * Natural/odd
+; * Natural/toInteger
+; * Natural/show
+; * Integer/toDouble
+; * Integer/show
+; * Double/show
+; * List/build
+; * List/fold
+; * List/length
+; * List/head
+; * List/last
+; * List/indexed
+; * List/reverse
+; * Optional/fold
+; * Optional/build
+; * if
+; * then
+; * else
+; * let
+; * in
+; * as
+; * using
+; * merge
+; * constructors
+; * Some
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
 quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / "." / "$")

--- a/tests/parser/failure/incompleteIf.dhall
+++ b/tests/parser/failure/incompleteIf.dhall
@@ -1,0 +1,10 @@
+-- This test verifies that an implementation rejects the following expression at
+-- parse time (i.e. due to an incomplete `if` expression) rather than at
+-- type-checking time (i.e. due to an unbound variable named `if` or `else`)
+--
+-- This ensures that implementations are not treating keywords as potential
+-- identifier names.  In other words, if they fail to parse an incomplete
+-- `if` expression they don't try to alternatively parse the expression as
+-- function application instead.
+
+if a then b else


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/683

Before this change the grammar allowed variables to be named after
builtins or keywords, such as:

```haskell
let if = 1 in if
```

However, permitting this deteriorates error messages since an expression
like this:

```haskell
if a then b else
```

... becomes a type error ("Unbound variable: if") instead of a parse
error due to an incomplete `if` expression.

The solution is to disallow these sorts of variable names.  Given that
we don't have a good way to do that in the grammar, we just specify it
as a comment for now.