### PR TITLE
Allow nested records of types

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3681,12 +3681,12 @@ A record can either store term-level values and functions:
 
     Γ ⊢ T :⇥ Kind
     ────────────────────
-    Γ ⊢ { x : T } : Sort
+    Γ ⊢ { x : T } : Kind
 
 
-    Γ ⊢ T :⇥ Kind   Γ ⊢ { xs… } :⇥ Sort
+    Γ ⊢ T :⇥ Kind   Γ ⊢ { xs… } :⇥ Kind
     ───────────────────────────────────  ; x ∉ { xs… }
-    Γ ⊢ { x : T, xs… } : Sort
+    Γ ⊢ { x : T, xs… } : Kind
 
 
 ... or store kinds (if it is non-empty):

--- a/tests/typecheck/success/encodedRecordOfTypesA.dhall
+++ b/tests/typecheck/success/encodedRecordOfTypesA.dhall
@@ -1,3 +1,0 @@
-  λ(k : Kind)
-→ λ(makeRecord : ∀(x : Type) → ∀(y : Type → Type) → k)
-→ makeRecord Text List

--- a/tests/typecheck/success/encodedRecordOfTypesB.dhall
+++ b/tests/typecheck/success/encodedRecordOfTypesB.dhall
@@ -1,1 +1,0 @@
-∀(k : Kind) → ∀(makeRecord : ∀(x : Type) → ∀(y : Type → Type) → k) → k

--- a/tests/typecheck/success/recordOfRecordOfTypesA.dhall
+++ b/tests/typecheck/success/recordOfRecordOfTypesA.dhall
@@ -1,0 +1,3 @@
+let types = { Scopes = < Public : {} | Private : {} >}
+let prelude = { types = types }
+in  prelude.types.Scopes.Public {=}

--- a/tests/typecheck/success/recordOfRecordOfTypesB.dhall
+++ b/tests/typecheck/success/recordOfRecordOfTypesB.dhall
@@ -1,0 +1,1 @@
+< Public : {} | Private : {} >


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-haskell/issues/692

The motivation for this change is to permit nested records of types.

This changes a record of types to be treated as a type instead of a
kind, as suggested by @phadej in
https://github.com/dhall-lang/dhall-haskell/issues/692#issuecomment-441236251

The original encoding of a record of types used kind polymorphism, which
meant that a record of types behaved like a kind instead of a type.

However, there's another way to encode records which takes advantage of
the fact that they have a finite number of fields of of known type by
desugaring them to a finite number of function arguments.

In other words, a function of this type:

```haskell
∀(r : { x : Type, y : Type → Type }) → …
```

... desugars to a function of this type:

```haskell
∀(x : Type) → ∀(y : Type → Type) → …
```

Similarly, the following anonymous function:

```haskell
∀(r : { x : Type, y : Type → Type }) → …
```

... desugars to:

```haskell
λ(x : Type) → λ(y : Type → Type) → …
```

Accessing a field from an abstract record:

```haskell
λ(r : { x : Type, y : Type → Type }) → … r.x …
```

... translates to referencing the correct parameter:

```haskell
λ(x : Type) → λ(y : Type → Type) → … x …
```

Function application where the record is an argument:

```haskell
f { x = Bool, y = List }

-- or:

λ(r : { x : Type, y : Type → Type }) → … f r …
```

... desugars to applying the function to each field:

```haskell
f Bool List

-- or:

λ(x : Type) → λ(y : Type → Type) → … f x y …
```

If you encode things this way then a record of types behaves like a
type.  To be precise, a record is a valid function argument if and only if its
constituent fields are also valid function arguments, so if its fields
are types then you can treat a record of them as a type, too.