### PR TITLE
Standardize protection against import cycles

### DIFF
--- a/tests/import/data/cycle.dhall
+++ b/tests/import/data/cycle.dhall
@@ -1,0 +1,1 @@
+../failure/cycle.dhall

--- a/tests/import/failure/cycle.dhall
+++ b/tests/import/failure/cycle.dhall
@@ -1,0 +1,1 @@
+../data/cycle.dhall


### PR DESCRIPTION
This extends the import resolution judgement to prevent import cycles
that would trivially allow non-termination.  There are still other ways
to induce non-termination (such as a server generating an infinite
import chain) but at least it's not easy to create an import cycle by
mistake.