### PR TITLE
Enable CORS for `prelude.dhall-lang.org`

### DIFF
--- a/nixops/no-restrict-eval.patch
+++ b/nixops/no-restrict-eval.patch
@@ -1,12 +1,11 @@
-diff --git a/src/hydra-eval-jobs/hydra-eval-jobs.cc b/src/hydra-eval-jobs/hydra-eval-jobs.cc
-index 1e17e99d..449121a1 100644
---- a/src/hydra-eval-jobs/hydra-eval-jobs.cc
-+++ b/src/hydra-eval-jobs/hydra-eval-jobs.cc
-@@ -186,7 +186,7 @@ int main(int argc, char * * argv)
-
-         /* Prevent access to paths outside of the Nix search path and
-            to the environment. */
--        settings.restrictEval = true;
-+        settings.restrictEval = false;
-
-         if (releaseExpr == "") throw UsageError("no expression specified");
+diff -Naur source.old/src/hydra-eval-jobs/hydra-eval-jobs.cc source.new/src/hydra-eval-jobs/hydra-eval-jobs.cc
+--- source.old/src/hydra-eval-jobs/hydra-eval-jobs.cc	1970-01-01 00:00:01.000000000 +0000
++++ source.new/src/hydra-eval-jobs/hydra-eval-jobs.cc	2018-12-09 19:12:29.170888722 +0000
+@@ -275,7 +275,7 @@
+ 
+                 /* Prevent access to paths outside of the Nix search path and
+                    to the environment. */
+-                evalSettings.restrictEval = true;
++                evalSettings.restrictEval = false;
+ 
+                 if (releaseExpr == "") throw UsageError("no expression specified");


### PR DESCRIPTION
The motivation for this is so that the upcoming "Try Dhall" page can
import from the Prelude without being blocked by the browser as a
forbidden Cross-Origin request.

This requires several changes:

First, `prelude.dhall-lang.org` needs to no longer be a redirect and
should instead act as a reverse proxy using the `proxy_pass` directive.
This is necessary for CORS to work since a redirect to
`raw.githubusercontent.com` will cause the browser to check
`raw.githubusercontent.com` for CORS support instead of consulting
`prelude.dhall-lang.org` for CORS support.

Second, the recommended proxy settings have to be selectively inlined
to just `hydra.dhall-lang.org` because they interfere with the
`prelude.dhall-lang.org` reverse proxy.  Specifically, the `Host: $host`
directive added by the recommended proxy settings becomes
`Host: prelude.dhall-lang.org` and this confuses GitHub since
GitHub treats any unrecognized `Host` header as a request to its GitHub
pages functionality.

Third, we need to enable CORS with the correct `Access-Control-*`
headers.

This also includes a fix to the Hydra patch to work with Nixpkgs 18.09.