### PR TITLE
Disable sandbox for CI

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -37,6 +37,8 @@
       autoOptimiseStore = true;
 
       gc.automatic = true;
+
+      useSandbox = false;
     };
 
     nixpkgs.overlays =


### PR DESCRIPTION
The Dhall tests need to make outbound connections in order to import
code from `prelude.dhall-lang.org`