### PR TITLE
Serve the new website at `dhall-lang.org`

### DIFF
--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/dhall-lang/dhall-haskell.git",
+  "rev": "60accef002b265531b97b2a633d706be32e6540a",
+  "date": "2018-12-13T08:53:34-08:00",
+  "sha256": "0mbv0yj3pyjlmdm6bwf0npd833ivgj39p4g4sq6dknpyxm7073gl",
+  "fetchSubmodules": false
+}

--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "60accef002b265531b97b2a633d706be32e6540a",
-  "date": "2018-12-13T08:53:34-08:00",
+  "rev": "21d70b338354f4fb9fce43b6fa08170dc9b30847",
+  "date": "2018-12-14T18:50:21-08:00",
   "sha256": "0mbv0yj3pyjlmdm6bwf0npd833ivgj39p4g4sq6dknpyxm7073gl",
   "fetchSubmodules": false
 }

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -136,7 +136,7 @@
             inherit (dhall-haskell-derivations) try-dhall;
 
           in
-            { addSSL = true;
+            { forceSSL = true;
 
               default = true;
 
@@ -150,7 +150,7 @@
         };
 
         virtualHosts."cache.dhall-lang.org" = {
-          addSSL = true;
+          forceSSL = true;
 
           enableACME = true;
 
@@ -158,7 +158,7 @@
         };
 
         virtualHosts."hydra.dhall-lang.org" = {
-          addSSL = true;
+          forceSSL = true;
 
           extraConfig = ''
             proxy_set_header Host $host;
@@ -176,7 +176,7 @@
         };
 
         virtualHosts."prelude.dhall-lang.org" = {
-          addSSL = true;
+          forceSSL = true;
 
           enableACME = true;
 
@@ -251,6 +251,16 @@
             '';
 
         serviceConfig.Type = "oneshot";
+
+        wantedBy = [ "multi-user.target" ];
+      };
+
+      kick-hydra-evaluator = {
+        script = ''
+          ${pkgs.systemd}/bin/systemctl restart hydra-evaluator
+        '';
+
+        startAt = "*:0/5";
 
         wantedBy = [ "multi-user.target" ];
       };


### PR DESCRIPTION
This changes `https://dhall-lang.org` to serve the new website for the
language instead of redirecting to the GitHub project

I've already deployed this change, so you can try it right now:

https://dhall-lang.org/

... and I have a tweet scheduled to announce it on Dec. 17th, which
gives us some more time to continue polishing it