### PR TITLE
fix link to versioning.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Dhall language standard will be documented in this
 file.
 
-For more info about our versioning policy, see [VERSIONING.md](VERSIONING.md).
+For more info about our versioning policy, see [versioning.md](standard/versioning.md).
 
 ## `v4.0.0`
 


### PR DESCRIPTION
The link in the CHANGELOG to versioning.md is broken.  This fixes it.