### PR TITLE
Add additional type-checking tests for unions

### DIFF
--- a/tests/typecheck/failure/mixedUnions.dhall
+++ b/tests/typecheck/failure/mixedUnions.dhall
@@ -1,0 +1,1 @@
+< Left : Natural | Right : Type >

--- a/tests/typecheck/success/simple/unionsOfTypesA.dhall
+++ b/tests/typecheck/success/simple/unionsOfTypesA.dhall
@@ -1,0 +1,1 @@
+< Left = List | Right : Type >

--- a/tests/typecheck/success/simple/unionsOfTypesB.dhall
+++ b/tests/typecheck/success/simple/unionsOfTypesB.dhall
@@ -1,0 +1,1 @@
+< Left : Type → Type | Right : Type >


### PR DESCRIPTION
These tests are inspired by mistakes in the Haskell implementation:

https://github.com/dhall-lang/dhall-haskell/pull/763