### PR TITLE
Add referential sanity check

### DIFF
--- a/tests/import/data/referentiallyOpaque.dhall
+++ b/tests/import/data/referentiallyOpaque.dhall
@@ -1,0 +1,20 @@
+{- This is a "referentially opaque" import (i.e. an import that is not
+   globally addressable), which cannot be imported by a "referentially
+   transparent" import (i.e. an import that is globally addressable).
+
+   This test file is used in a failing test to verify that referentially
+   transparent imports cannot import referentially opaque imports.  In the test
+   suite this file is actually imported via its GitHub URL (not its local file
+   path), so it plays the role of the referentially transparent import.  Then,
+   this file attempts to import a referentially opaque import (an environment
+   variable in this case) to verify that the import fails.
+
+   For this test file we need to select a referentially opaque import that would
+   likely succeed if imported on its own, so that a non-compliant implementation
+   doesn't fail this test for the wrong reason (i.e. due to the referentially
+   opaque not being present).  In general, we can't guarantee that referentially
+   opaque imports exist (because they are referentially opaque!), but the
+   `HOME` environment variable has a high likelihood of bring present on a POSIX
+   system.
+-}
+env:HOME as Text

--- a/tests/import/failure/referentiallyInsane.dhall
+++ b/tests/import/failure/referentiallyInsane.dhall
@@ -1,0 +1,13 @@
+{- The following remote import attempts to import an environment variable, which
+   must be disallowed by the referential sanity check
+
+   One reason for doing this is to protect against remote imports exfiltrating
+   environment variables (such as via custom headers).  Only referentially
+   opaque imports (i.e. local imports) have permission to refer to other
+   referentially opaque imports in order to protect against this attack.
+
+   The referential sanity check also ensures that remote imports are
+   referentially transparent.  Or in other words, any import that is globally
+   addressable must have a meaning that is not context-sensitive.
+-}
+https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/tests/import/data/referentiallyOpaque.dhall


### PR DESCRIPTION
This is a security check upstreamed from the Haskell implementation into the
standard.  This protects against data exfiltration through custom headers and
also is a useful sanity check so that globally addressable (i.e.
"referentially transparent") imports can't refer to non-globally-addressable
(i.e "referentially opaque") imports.