### PR TITLE
Update README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that while Dhall is programmable, Dhall is not Turing-complete.  Many
 of Dhall's features take advantage of this restriction to provider stronger
 safety guarantees and more powerful tooling.
 
-You can try the language live in your brower by visiting the official website:
+You can try the language live in your browser by visiting the official website:
 
 * [https://dhall-lang.org](http://dhall-lang.org/)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
   <meta charset="UTF-8">
 </head> 
 
-Dhall is a programmable configuration language that is not Turing-complete
+Dhall is a programmable configuration language that provides a
+non-repetitive alternative to YAML.
 
 You can think of Dhall as: JSON + functions + types + imports
+
+Note that while Dhall is programmable, Dhall is not Turing-complete.  Many
+of Dhall's features take advantage of this restriction to provider stronger
+safety guarantees and more powerful tooling.
+
+You can try the language live in your brower by visiting the official website:
+
+* [https://dhall-lang.org](http://dhall-lang.org/)
 
 ## Table of contents
 


### PR DESCRIPTION
This updates the README to mention `dhall-lang.org` and to
also incorporate the new emphasis around displacing YAML.

Fixes https://github.com/dhall-lang/dhall-lang/pull/196