### PR TITLE
Fix decoding of imports

### DIFF
--- a/standard/binary.md
+++ b/standard/binary.md
@@ -1336,20 +1336,20 @@ The decoding rules are the exact opposite of the encoding rules:
 
 
     ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-    decode([ 24, null, 0, 0, "authority" "path₀", "path₁", …, "file", "query", "fragment" ]) = http://authority/path₀/path₁/…/file?query#fragment
+    decode([ 24, null, 0, 0, null, "authority" "path₀", "path₁", …, "file", "query", "fragment" ]) = http://authority/path₀/path₁/…/file?query#fragment
 
 
     ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-    decode([ 24, null, 0, 0, "authority" "path₀", "path₁", …, "file", null, null ]) = http://authority/path₀/path₁/…/file
+    decode([ 24, null, 0, 0, null, "authority" "path₀", "path₁", …, "file", null, null ]) = http://authority/path₀/path₁/…/file
 
 
 
     ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-    decode([ 24, null, 0, 1, "authority" "path₀", "path₁", …, "file", "query", "fragment" ]) = https://authority/path₀/path₁/…/file?query#fragment
+    decode([ 24, null, 0, 1, null, "authority" "path₀", "path₁", …, "file", "query", "fragment" ]) = https://authority/path₀/path₁/…/file?query#fragment
 
 
     ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-    decode([ 24, null, 0, 1, "authority" "path₀", "path₁", …, "file", null, null ]) = https://authority/path₀/path₁/…/file
+    decode([ 24, null, 0, 1, null, "authority" "path₀", "path₁", …, "file", null, null ]) = https://authority/path₀/path₁/…/file
 
 
     ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/402

... as caught by @singpolyma

This fixes the decoding logic for imports to match the encoding logic.
The decoding logic was missing an expected `null` field when a URL import
had no custom headers.