### PR TITLE
Clarify how to decode variables named `_`

### DIFF
--- a/standard/binary.md
+++ b/standard/binary.md
@@ -969,9 +969,12 @@ Decode a naked CBOR string to a variable with an index of 0 if the string does
 not match a built-in identifier:
 
 
-    ─────────────────────  ; x ∉ reservedIdentifiers
+    ─────────────────────  ; x ∉ reservedIdentifiers, x ≠ "_"
     decode("x") = x@0
 
+
+A decoder MUST reject a variable named "_", which MUST instead be represented
+by its integer index according to the following decoding rules.
 
 Only variables named `_` encode to a naked CBOR integer, so decoding turns a
 naked CBOR integer back into a variable named `_`:


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/400

@singpolyma noted that the standard is inconsistent about whether or not
decoders should enforce that all variables named `_` were correctly encoded.
This changes the encoding logic to be consistently strict on this point.