### PR TITLE
Expand character set for quoted labels

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -190,6 +190,10 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
 quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / "." / "$")
+quoted-label =
+      %x20-5F
+        ; %x60 = "\`"
+    / %x61-7E
 
 ; NOTE: Dhall does not support Unicode labels, mainly to minimize the potential
 ; for code obfuscation

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -189,7 +189,6 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 ; * Some
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
-quoted-label = 1*(ALPHA / DIGIT / "-" / "/" / "_" / ":" / "." / "$")
 quoted-label =
       %x20-5F
         ; %x60 = "\`"

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -189,10 +189,12 @@ HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 ; * Some
 simple-label = (ALPHA / "_") *(ALPHA / DIGIT / "-" / "/" / "_")
 
-quoted-label =
+quoted-label-char =
       %x20-5F
-        ; %x60 = "\`"
+        ; %x60 = '`'
     / %x61-7E
+
+quoted-label = 1*quoted-label-char
 
 ; NOTE: Dhall does not support Unicode labels, mainly to minimize the potential
 ; for code obfuscation


### PR DESCRIPTION
This expands quoted labels to permit all non-control ASCII characters except
backticks

One motivation for this is that I would like to eventually standardize support
for automatically converting nullary union alternatives to `Text`, but that
in turn requires expanding the set of valid alternative names.

A second motivation for this is to expand the set of field names that Dhall
can generate when targeting JSON/YAML configurations.