### PR TITLE
Make whitespace handling in grammar suitable for PEGs

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -168,11 +168,12 @@ quoted-label = 1*quoted-label-char
 ; A label cannot not be any of the reserved identifiers for builtins. Their
 ; list can be found in semantics.md. This is not enforced by the grammar but
 ; should be checked by implementations.
-label = ("`" quoted-label "`" / simple-label) whitespace
+label-raw = ("`" quoted-label "`" / simple-label)
+label = label-raw whitespace
 
 ; An any-label is allowed to be one of the reserved identifiers, but the
 ; implementation should recognize them and treat them as special values.
-any-label = label
+any-label-raw = label-raw
 
 
 ; Dhall's double-quoted strings are equivalent to JSON strings except with
@@ -257,7 +258,7 @@ single-quote-continue =
 
 single-quote-literal = "''" end-of-line single-quote-continue
 
-text-literal = (double-quote-literal / single-quote-literal) whitespace
+text-literal-raw = (double-quote-literal / single-quote-literal)
 
 ; RFC 5234 interprets string literals as case-insensitive and recommends using
 ; hex instead for case-sensitive strings
@@ -295,29 +296,33 @@ Optional = Optional-raw     whitespace
 Text     = Text-raw         whitespace
 List     = List-raw         whitespace
 
-equal         = "="  whitespace
-or            = "||" whitespace
-plus          = "+"  nonempty-whitespace  ; To disambiguate `f +2`
-text-append   = "++" whitespace
-list-append   = "#"  nonempty-whitespace  ; To disambiguate `http://a/a#a`
-and           = "&&" whitespace
-times         = "*"  whitespace
-double-equal  = "==" whitespace
-not-equal     = "!=" whitespace
-dot           = "."  whitespace
-open-brace    = "{"  whitespace
-close-brace   = "}"  whitespace
-open-bracket  = "["  whitespace
-close-bracket = "]"  whitespace
-open-angle    = "<"  whitespace
-close-angle   = ">"  whitespace
-bar           = "|"  whitespace
-comma         = ","  whitespace
-open-parens   = "("  whitespace
-close-parens  = ")"  whitespace
-at            = "@"  whitespace
-colon         = ":"  nonempty-whitespace  ; To disambiguate `env:VARIABLE` from type annotations
-import-alt    = "?"  nonempty-whitespace  ; To disambiguate `http://a/a?a`
+equal             = "="  whitespace
+or                = "||" whitespace
+plus              = "+"  nonempty-whitespace  ; To disambiguate `f +2`
+text-append       = "++" whitespace
+list-append       = "#"  nonempty-whitespace  ; To disambiguate `http://a/a#a`
+and               = "&&" whitespace
+times             = "*"  whitespace
+double-equal      = "==" whitespace
+not-equal         = "!=" whitespace
+dot               = "."  whitespace
+bar               = "|"  whitespace
+comma             = ","  whitespace
+at                = "@"  whitespace
+colon             = ":"  nonempty-whitespace  ; To disambiguate `env:VARIABLE` from type annotations
+import-alt        = "?"  nonempty-whitespace  ; To disambiguate `http://a/a?a`
+open-parens       = "("  whitespace
+close-parens-raw  = ")"
+close-parens      = ")"  whitespace
+open-brace        = "{"  whitespace
+close-brace-raw   = "}"
+close-brace       = "}"  whitespace
+open-bracket      = "["  whitespace
+close-bracket-raw = "]"
+close-bracket     = "]"  whitespace
+open-angle        = "<"  whitespace
+close-angle-raw   = ">"
+close-angle       = ">"  whitespace
 
 combine       = ( %x2227 / "/\"                ) whitespace
 combine-types = ( %x2A53 / "//\\"              ) whitespace
@@ -328,17 +333,14 @@ arrow         = ( %x2192 / "->"                ) whitespace
 
 exponent = "e" [ "+" / "-" ] 1*DIGIT
 
-double-literal = [ "+" / "-" ] 1*DIGIT ( "." 1*DIGIT [ exponent ] / exponent) whitespace
+double-literal-raw = [ "+" / "-" ] 1*DIGIT ( "." 1*DIGIT [ exponent ] / exponent)
 
 natural-literal-raw = 1*DIGIT
 
-integer-literal = ( "+" / "-" ) natural-literal-raw whitespace
+integer-literal-raw = ( "+" / "-" ) natural-literal-raw
 
-natural-literal = natural-literal-raw whitespace
-
-identifier = any-label [ at natural-literal-raw whitespace ]
-
-missing = missing-raw whitespace
+identifier-raw = any-label-raw [ whitespace at natural-literal-raw ]
+identifier = identifier-raw whitespace
 
 ; Printable characters other than " ()[]{}<>/\,"
 ;
@@ -395,8 +397,6 @@ local-raw =
     ; if the second character is "/" or "\" then this should have been parsed
     ; as an operator instead of a path
     / directory file  ; Absolute path
-
-local = local-raw whitespace
 
 ; `http[s]` URI grammar based on RFC7230 and RFC 3986 with some differences
 ; noted below
@@ -459,16 +459,15 @@ unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
 
 http =
-    http-raw whitespace
-    [ using (import-hashed / open-parens import-hashed close-parens) ]
+    http-raw
+    [ whitespace using (import-hashed-raw / open-parens import-hashed-raw whitespace close-parens-raw) ] 
 
 ; Dhall supports unquoted environment variables that are Bash-compliant or
 ; quoted environment variables that are POSIX-compliant
-env = "env:"
+env-raw = "env:"
     ( bash-environment-variable
     / %x22 posix-environment-variable %x22
     )
-    whitespace
 
 ; Bash supports a restricted subset of POSIX environment variables.  From the
 ; Bash `man` page, an environment variable name is:
@@ -527,20 +526,23 @@ posix-environment-variable-character =
         ; %x5C = "\"
     / %x5D-7E
 
-import-type = missing / local / http / env
+import-type-raw = missing-raw / local-raw / http / env-raw
 
-hash = %x73.68.61.32.35.36.3a 64HEXDIG whitespace  ; "sha256:XXX...XXX"
+hash-raw = %x73.68.61.32.35.36.3a 64HEXDIG  ; "sha256:XXX...XXX"
 
-import-hashed = import-type [ hash ]
+import-hashed-raw = import-type-raw [ whitespace hash-raw ]
 
 ; "http://example.com"
 ; "./foo/bar"
 ; "env:FOO"
-import = import-hashed [ as Text ]
+import-raw = import-hashed-raw [ whitespace as Text-raw ]
 
 ; NOTE: Every rule past this point should only reference rules that end with
 ; whitespace.  This ensures consistent handling of whitespace in the absence of
-; a separate lexing step
+; a separate lexing step.
+; The exception is the rules ending in -raw, which should _not_ end in whitespace.
+; This is important for PEGs, that parse greedily and would otherwise fail to
+; parse application-expression. See #395.
 
 expression =
     ; "\(x : a) -> b"
@@ -603,10 +605,12 @@ not-equal-expression     = application-expression   *(not-equal     application-
 ; Import expressions need to be separated by some whitespace, otherwise there
 ; would be ambiguity: `./ab` could be interpreted as "import the file `./ab`",
 ; or "apply the import `./a` to label `b`"
+; The whitespace handling is important for PEGs, see #395.
 application-expression =
-    [ Some ] import-expression *(whitespace-chunk import-expression)
+    [ Some ] import-expression-raw *(nonempty-whitespace import-expression-raw) whitespace
 
-import-expression = import / selector-expression
+import-expression-raw = import-raw / selector-expression-raw
+import-expression = import-expression-raw whitespace
 
 ; `record.field` extracts one field of a record
 ;
@@ -616,45 +620,45 @@ import-expression = import / selector-expression
 ; can't tell from parsing just the period whether "foo." will become "foo.bar"
 ; (i.e. accessing field `bar` of the record `foo`) or `foo./bar` (i.e. applying
 ; the function `foo` to the relative path `./bar`)
-selector-expression = primitive-expression *(dot ( label / labels ))
+selector-expression-raw = primitive-expression-raw *(whitespace dot ( label-raw / labels-raw ))
 
 ; NOTE: Backtrack when parsing the first three alternatives (i.e. the numeric
 ; literals).  This is because they share leading characters in common
-primitive-expression =
+primitive-expression-raw =
     ; "2.0"
-      double-literal
+      double-literal-raw
     
     ; "2"
-    / natural-literal
+    / natural-literal-raw
     
     ; "+2"
-    / integer-literal
+    / integer-literal-raw
     
     ; "-Infinity"
-    / "-" Infinity-raw whitespace
+    / "-" Infinity-raw
     
     ; '"ABC"'
-    / text-literal
+    / text-literal-raw
     
     ; "{ foo = 1      , bar = True }"
     ; "{ foo : Integer, bar : Bool }"
-    / open-brace record-type-or-literal close-brace
+    / open-brace record-type-or-literal close-brace-raw
     
     ; "< Foo : Integer | Bar : Bool >"
     ; "< Foo : Integer | Bar = True >"
-    / open-angle union-type-or-literal  close-angle
+    / open-angle union-type-or-literal  close-angle-raw
     
     ; "[1, 2, 3]"
     / non-empty-list-literal  ; `annotated-expression` handles empty lists
     
     ; "x"
     ; "x@2"
-    / identifier
+    / identifier-raw
     
     ; "( e )"
-    / open-parens expression close-parens
+    / open-parens expression close-parens-raw
 
-labels = open-brace (  label *(comma label) / "" ) close-brace
+labels-raw = open-brace ( label *(comma label) / "" ) close-brace-raw
 
 record-type-or-literal =
       equal                             ; Empty record literal


### PR DESCRIPTION
An alternative to https://github.com/dhall-lang/dhall-lang/pull/422, if we'd rather keep existing parsing behaviour, and support CFGs too. 