### PR TITLE
({ a = (t: T) } ⫽ { a = (n: N) }): { a: N }

### DIFF
--- a/standard/semantics.md
+++ b/standard/semantics.md
@@ -3988,7 +3988,7 @@ records of terms or records of types:
     Γ ⊢ { a : A₁, rs… } :⇥ Type
     Γ ⊢ { ls… } ⫽ { rs… } :⇥ { ts… }
     ───────────────────────────────
-    Γ ⊢ l ⫽ r : { a : A₀, ts… }
+    Γ ⊢ l ⫽ r : { a : A₁, ts… }
 
 
     Γ ⊢ l :⇥ { ls… }
@@ -4006,7 +4006,7 @@ records of terms or records of types:
     Γ ⊢ { a : A₁, rs… } :⇥ Kind
     Γ ⊢ { ls… } ⫽ { rs… } :⇥ { ts… }
     ───────────────────────────────
-    Γ ⊢ l ⫽ r : { a : A₀, ts… }
+    Γ ⊢ l ⫽ r : { a : A₁, ts… }
 
 
     Γ ⊢ l :⇥ { ls… }
@@ -4024,7 +4024,7 @@ records of terms or records of types:
     Γ ⊢ { a : A₁, rs… } :⇥ Sort
     Γ ⊢ { ls… } ⫽ { rs… } :⇥ { ts… }
     ───────────────────────────────
-    Γ ⊢ l ⫽ r : { a : A₀, ts… }
+    Γ ⊢ l ⫽ r : { a : A₁, ts… }
 
 
 If the operator arguments are not records then that is a type error.


### PR DESCRIPTION
Fixing what I believe to be a typo in the type checking semantics, the
right-hand type of a right-biased record merge should win.