### PR TITLE
Fix a typechecker test

### DIFF
--- a/tests/typecheck/success/simple/kindParameterB.dhall
+++ b/tests/typecheck/success/simple/kindParameterB.dhall
@@ -1,1 +1,1 @@
-∀(k : Kind) → (k → k → Type) → k → k → Type
+∀(k : Kind) → ∀(a : k → k → Type) → ∀(x : k) → k → Type


### PR DESCRIPTION
Expected result was missing some function type variable names, as
produced by dhall-haskell and indicated by semantics.md should be
present.