### PR TITLE
improve documentation of tests/parser/failure/boundBuiltins.dhall

### DIFF
--- a/tests/parser/failure/boundBuiltins.dhall
+++ b/tests/parser/failure/boundBuiltins.dhall
@@ -1,6 +1,6 @@
 {-
     Builtin names are disallowed in bound variables.
     The grammar doesn't explicitely disallow this, but the implementation should
-    refuse it. See the comments above the `label` rule.
+    refuse it. See the comments above the `nonreserved-label` rule.
 -}
 let Bool : Natural = 1 in Bool


### PR DESCRIPTION
My implementation was failing this test, but the comments above the
`label` rule weren't helpful.  In #442, the restriction migrated to
the `nonreserved-label` rule, but this comment wasn't updated.