### PR TITLE
Test merging sort-level record types.

### DIFF
--- a/tests/normalization/success/unit/RecursiveRecordTypeMergeSortsA.dhall
+++ b/tests/normalization/success/unit/RecursiveRecordTypeMergeSortsA.dhall
@@ -1,0 +1,1 @@
+{ a : Kind } ⩓ { b : Kind }

--- a/tests/normalization/success/unit/RecursiveRecordTypeMergeSortsB.dhall
+++ b/tests/normalization/success/unit/RecursiveRecordTypeMergeSortsB.dhall
@@ -1,0 +1,1 @@
+{ a : Kind, b : Kind }


### PR DESCRIPTION
This tests for the issue in dhall-lang/dhall-haskell#890. The behavior is
already correct in the spec.