### PR TITLE
Set syntax highlighting for Dhall files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+*.dhall linguist-language=Haskell
+Prelude/** linguist-language=Haskell
 standard/dhall.abnf text=auto
 *.dhallb diff=cbor


### PR DESCRIPTION
This uses the `.gitattributes` file to [override the language detection](https://github.com/github/linguist#using-gitattributes) on GitHub so that we can have syntax highlighting for the Dhall files in this repo. This makes the standard library easier to read and will hopefully hold us over until Dhall is popular enough to be supported by GitHub Linguist.

I've chosen to use Haskell for syntax highlighting because it's the language currently being used in the code block examples. After Dhall is supported by Linguist, the changes in this PR should be reverted so that the language detection for this repo returns Dhall instead of Haskell.

If you want to test this change out, beware that GitHub has [caching issues](https://github.com/github/linguist/issues/4251#issuecomment-417735924) associated with syntax highlighting. I've created a couple of examples with different blobs so you can compare the difference:
- [Dhall without syntax highlighting](https://github.com/robbiemcmichael/dhall-lang/blob/27aa7f2eb4567e6428dc8b4e31d63c391a04f30f/Prelude/Text/concatMap)
- [Dhall with syntax highlighting](https://github.com/robbiemcmichael/dhall-lang/blob/9050fc116bf202c3116100c4f03c8befb06cff3e/Prelude/Text/concatMap)