### PR TITLE
import as any-label

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -620,7 +620,7 @@ import-hashed = import-type [ whsp1 hash ]
 ; "http://example.com"
 ; "./foo/bar"
 ; "env:FOO"
-import = import-hashed [ whsp as whsp1 Text ]
+import = import-hashed [ whsp as whsp1 any-label ]
 
 expression =
     ; "\(x : a) -> b"


### PR DESCRIPTION
This does not change what programs are valid Dhall, but only moves
something like `./t.dhall as JSON` from a syntax error to a semantics
error.  This would allow users to add custom import types in implementations
that wish to support it in the same way that we currently allow adding
custom builtins.