### PR TITLE
Fix normalization test for prelude/JSON/Type

### DIFF
--- a/tests/normalization/success/prelude/JSON/Type/0B.dhall
+++ b/tests/normalization/success/prelude/JSON/Type/0B.dhall
@@ -1,11 +1,24 @@
   λ(JSON : Type)
-→ λ(string : Text → JSON)
-→ λ(number : Double → JSON)
-→ λ(object : List { mapKey : Text, mapValue : JSON } → JSON)
-→ λ(array : List JSON → JSON)
-→ λ(bool : Bool → JSON)
-→ λ(null : JSON)
-→ object
-  [ { mapKey = "foo", mapValue = null }
-  , { mapKey = "bar", mapValue = array [ number 1.0, bool True ] }
+→ λ ( json
+	: { array :
+		  List JSON → JSON
+	  , bool :
+		  Bool → JSON
+	  , null :
+		  JSON
+	  , number :
+		  Double → JSON
+	  , object :
+		  List { mapKey : Text, mapValue : JSON } → JSON
+	  , string :
+		  Text → JSON
+	  }
+	)
+→ json.object
+  [ { mapKey = "foo", mapValue = json.null }
+  , { mapKey =
+		"bar"
+	, mapValue =
+		json.array [ json.number 1.0, json.bool True ]
+	}
   ]


### PR DESCRIPTION
In #586, after some debate we went with a record encoding rather than a
curried encoding, but we forgot to update a test to reflect this.