### PR TITLE
Allow annotations for empty lists other than "List …"

### DIFF
--- a/standard/type-inference.md
+++ b/standard/type-inference.md
@@ -297,9 +297,9 @@ A `List` literal's type is inferred either from the type of the elements (if
 non-empty) or from the type annotation (if empty):
 
 
-    Γ ⊢ T :⇥ Type
+    Γ ⊢ T₀   T₀ :⇥ List T₁
     ──────────────────────────
-    Γ ⊢ ([] : List T) : List T
+    Γ ⊢ ([] : T₀) : List T₁
 
 
     Γ ⊢ t : T₀   T₀ :⇥ Type   Γ ⊢ [ ts… ] :⇥ List T₁   T₀ ≡ T₁


### PR DESCRIPTION
This would allow e.g. `[] : { x = List Bool }.x`

I have no pressing need for this change but the status quo felt unnecessarily constraining.

**EDIT:** The reason for this constraint must have been to disambiguate from the legacy `Optional` syntax.