### PR TITLE
Integrity protect any expression

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -216,11 +216,14 @@ label = ("`" quoted-label "`" / simple-label)
 ; (unless quoted).
 ; Their list can be found in the `builtin` rule.
 ; The only place where this restriction applies is bound variables.
+; A nonreserved-label also cannot start with sha256-prefix.  This would be true
+; anyway since that contains a `:` but a PEG parser may want to explicitly
+; look for this case to avoid greedily matching the start of the prefix.
 ; A PEG parser could use negative lookahead to avoid parsing those identifiers,
 ; e.g. as follows:
 ; nonreserved-label =
 ;      builtin 1*simple-label-next-char
-;    / !builtin label
+;    / !(builtin / sha256-prefix) label
 nonreserved-label = label
 
 ; An any-label is allowed to be one of the reserved identifiers.
@@ -664,16 +667,18 @@ posix-environment-variable-character =
 
 import-type = missing / local / http / env
 
-hash = %x73.68.61.32.35.36.3a 64HEXDIG ; "sha256:XXX...XXX"
+sha256-prefix = %x73.68.61.32.35.36.3a
 
-import-hashed = import-type [ whsp1 hash ]
+hash = sha256-prefix 64HEXDIG ; "sha256:XXX...XXX"
 
 ; "http://example.com"
 ; "./foo/bar"
 ; "env:FOO"
-import = import-hashed [ whsp as whsp1 (Text / Location) ]
+import = import-type [ whsp as whsp1 (Text / Location) ]
 
-expression =
+expression = unprotected-expression [ whsp1 hash ]
+
+unprotected-expression =
     ; "\(x : a) -> b"
       lambda whsp "(" whsp nonreserved-label whsp ":" whsp1 expression whsp ")" whsp arrow whsp expression
     

--- a/standard/imports.md
+++ b/standard/imports.md
@@ -14,10 +14,10 @@ in  { name = env:USER as Text  -- Expression imported from the environment
     } : ./schema.dhall  -- Expression imported from a file
 ```
 
-You can protect imports with integrity checks if you append SHA-256 hash (such
-as the `concatSep` import above) and you can also import a value as raw `Text`
-by appending `as Text` (such as the `env:USER` import above) or as a resolved
-path by appending `as Location`.
+You can protect imports (or any expression) with integrity checks if you
+append SHA-256 hash (such as the `concatSep` import above) and you can also
+import a value as raw `Text` by appending `as Text` (such as the `env:USER`
+import above) or as a resolved path by appending `as Location`.
 
 Imported expressions can transitively import other expressions.  For example,
 the `./schema.dhall` file imported above might also import other files:

--- a/tests/parser/success/unit/import/asLocationA.dhall
+++ b/tests/parser/success/unit/import/asLocationA.dhall
@@ -1,5 +1,5 @@
 { _1 = ./some/import.dhall as Location
-, _2 = /absolute/import sha256:f9340badf94a684e652e0a384f64363293d8b632d971f3453f7ee22f10ab6e75 as Location
+, _2 = /absolute/import as Location sha256:f9340badf94a684e652e0a384f64363293d8b632d971f3453f7ee22f10ab6e75
 , _3 = https://prelude.dhall-lang.org/package.dhall as Location
 , _4 = env:HOME as Location
 , _5 = missing as Location


### PR DESCRIPTION
This starts work on #570 and moves the integrity check out of the import
AST and into its own node.  Tests have not yet all been updated and the
check step itself has not yet been pulled out of imports.md into its own
step.