### PR TITLE
Add Integer/toSigned

### DIFF
--- a/standard/README.md
+++ b/standard/README.md
@@ -150,6 +150,7 @@ a, b, f, l, r, e, t, u, A, B, E, T, U, c, i, o
   / Natural/show                      ; Convert Natural to Text representation
   / Natural/subtract                  ; Perform truncated subtraction on two Naturals
   / Integer/toDouble                  ; Convert Integer to Double
+  / Integer/toSigned                  ; Convert integers to pairs of sign and Naturals
   / Integer/show                      ; Convert Integer to Text representation
   / Double/show                       ; Convert Double to Text representation
   / List/build                        ; List introduction

--- a/standard/alpha-normalization.md
+++ b/standard/alpha-normalization.md
@@ -354,6 +354,10 @@ sub-expressions for the remaining rules:
     Integer/toDouble ↦ Integer/toDouble
 
 
+    ───────────────────────────────────
+    Integer/toSigned ↦ Integer/toSigned
+
+
     ───────────────────────────
     Integer/show ↦ Integer/show
 

--- a/standard/beta-normalization.md
+++ b/standard/beta-normalization.md
@@ -1269,6 +1269,26 @@ the nearest `Double`. Ties go to the `Double` with an even least significant
 bit. When the magnitude of `a` is greater than or equal to `c`, the magnitude
 will round to `Infinity`, where `c = 2^1024 - 2^970 ≈ 1.8e308`.
 
+
+`Integer/toSigned` transforms an `Integer` into a pair of a `Natural` number,
+and the sign of the number.
+
+
+    f ⇥ Integer/toSigned   a ⇥ -n
+    ───────────────────────────────────────────────────────────────────
+    f a ⇥ < Negative : Natural | Zero | Positive : Natural >.Negative n
+
+
+    f ⇥ Integer/toSigned   a ⇥ 0
+    ─────────────────────────────────────────────────────────────
+    f a ⇥ < Negative : Natural | Zero | Positive : Natural >.Zero
+
+
+    f ⇥ Integer/toSigned   a ⇥ +n
+    ───────────────────────────────────────────────────────────────────
+    f a ⇥ < Negative : Natural | Zero | Positive : Natural >.Positive n
+
+
 `Integer/show` transforms an `Integer` into a `Text` literal representing valid
 Dhall code for representing that `Integer` number:
 

--- a/standard/binary.md
+++ b/standard/binary.md
@@ -217,6 +217,10 @@ matching their identifier.
     encode(Integer/toDouble) = "Integer/toDouble"
 
 
+    ─────────────────────────────────────────────────
+    encode(Integer/toSigned) = "Integer/toSigned"
+
+
     ─────────────────────────────────────────
     encode(Integer/show) = "Integer/show"
 
@@ -904,6 +908,10 @@ a built-in identifier if it matches any of the following strings:
 
     ─────────────────────────────────────────────────
     decode("Integer/toDouble") = Integer/toDouble
+
+
+    ─────────────────────────────────────────────────
+    decode("Integer/toSigned") = Integer/toSigned
 
 
     ─────────────────────────────────────────

--- a/standard/shift.md
+++ b/standard/shift.md
@@ -421,6 +421,10 @@ The remaining rules are:
     ↑(d, x, m, Integer/toDouble) = Integer/toDouble
 
 
+    ───────────────────────────────────────────────
+    ↑(d, x, m, Integer/toSigned) = Integer/toSigned
+
+
     ───────────────────────────────────────
     ↑(d, x, m, Integer/show) = Integer/show
 

--- a/standard/substitution.md
+++ b/standard/substitution.md
@@ -402,6 +402,10 @@ The remaining rules are:
     Integer/toDouble[x@n ≔ e] = Integer/toDouble
 
 
+    ────────────────────────────────────────────
+    Integer/toSigned[x@n ≔ e] = Integer/toSigned
+
+
     ────────────────────────────────────
     Integer/show[x@n ≔ e] = Integer/show
 

--- a/standard/type-inference.md
+++ b/standard/type-inference.md
@@ -934,6 +934,10 @@ The built-in functions on `Integer` have the following types:
     Γ ⊢ Integer/toDouble : Integer → Double
 
 
+    ───────────────────────────────────────────────────────────────────────────────────
+    Γ ⊢ Integer/toSigned : Integer → < Negative : Natural | Zero | Positive : Natural >
+
+
 ## `Double`
 
 `Double` is a type:


### PR DESCRIPTION
This new builtin splits an Integer apart into a Natural, and an encoding
of its sign.

There are a few points of motivation:

1. We have Integer/show, but this could be decomposed into
   Integer/toSigned and Natural/show.

2. We can represent exact rational numbers via the type
   { numerator : Natural, denominator : Natural }. However, constructing
   values of this type is difficult. One familiar way to construct such
   a value would be to use scientific notation. For example, 0.15625
   could be written as `e 15625 -5`.

3. https://github.com/dhall-lang/dhall-lang/issues/508 wants a way to
   show Integers signed, but only showing the sign when it's
   negative (that is, no leading +). This cannot be done with Integers
   currently, forcing this work to invent its own signed integer type.

This does open the door to exposing the total ordering of Integers (as
we now expose enough to determine the total ordering of Naturals). It
also gives you *some* form of Integer arithmetic, but you can't
reconstruct an Integer from it's signed type.