### PR TITLE
fix tests/typecheck/success/prelude

### DIFF
--- a/tests/typecheck/success/preludeB.dhall
+++ b/tests/typecheck/success/preludeB.dhall
@@ -319,6 +319,16 @@
         ∀(n : Natural) → Double
     , toInteger :
         Natural → Integer
+    , lessThan :
+        Natural → Natural → Bool
+    , lessThanEqual :
+        Natural → Natural → Bool
+    , equal :
+        Natural → Natural → Bool
+    , greaterThan :
+        Natural → Natural → Bool
+    , greaterThanEqual :
+        Natural → Natural → Bool
     }
 , Optional :
     { all :


### PR DESCRIPTION
PR #674 added new functions to the prelude without updating this test,
which now fails.  This fixes it.