### PR TITLE
Allow version-pinned links to the Prelude.

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -188,9 +188,10 @@
                   }
 
                   rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/master/Prelude redirect;
+                  rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 break;
+                  rewrite ^/(.*)$ /dhall-lang/dhall-lang/v8.0.0/Prelude/$1 break;
                 '';
-
-                proxyPass = "https://raw.githubusercontent.com/dhall-lang/dhall-lang/136a3491753fef251b2087031617d1ee1053f285/Prelude/";
+                proxyPass = "https://raw.githubusercontent.com";
               };
             };
 


### PR DESCRIPTION
Now, e.g., `https://prelude.dhall-lang.org/v8.0.0/Optional/map` will
resolve to the version 8.0.0 version of that function forever.

Fixes #670.