### PR TITLE
Test that the type annotation on a toMap of an empty record is normalized

### DIFF
--- a/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationA.dhall
+++ b/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationA.dhall
@@ -1,0 +1,3 @@
+toMap
+  { x = Bool }.{}
+: List { mapKey : { t = Text }.t, mapValue : { t = Double }.t }

--- a/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationB.dhall
+++ b/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationB.dhall
@@ -1,0 +1,1 @@
+[] : List { mapKey : Text, mapValue : Double }


### PR DESCRIPTION
The rule is:

    Γ ⊢ e :⇥ {}   Γ ⊢ T₀ :⇥ Type   T₀ ⇥ List { mapKey : Text, mapValue : T₁ }
    ─────────────────────────────────────────────────────────────────────────
    Γ ⊢ ( toMap e : T₀ ) : List { mapKey : Text, mapValue : T₁ }
