### PR TITLE
Fix the toMapEmptyNormalizeAnnotation test case

### DIFF
--- a/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationB.dhall
+++ b/tests/type-inference/success/simple/toMapEmptyNormalizeAnnotationB.dhall
@@ -1,1 +1,1 @@
-[] : List { mapKey : Text, mapValue : Double }
+List { mapKey : Text, mapValue : Double }


### PR DESCRIPTION
The result must of course be a type! :/