### PR TITLE
Add failure test for mismatching merge annotation

### DIFF
--- a/tests/type-inference/failure/unit/MergeAnnotationMismatch.dhall
+++ b/tests/type-inference/failure/unit/MergeAnnotationMismatch.dhall
@@ -1,0 +1,1 @@
+merge { x = 0 } < x >.x : Bool

--- a/tests/type-inference/failure/unit/MergeWithWrongAnnotation.dhall
+++ b/tests/type-inference/failure/unit/MergeWithWrongAnnotation.dhall
@@ -1,1 +1,0 @@
-merge { x = λ(_ : Bool) → _ } (< x : Bool >.x True) : Natural


### PR DESCRIPTION
This also removes a similar but more complex test that I had initially overlooked.