### PR TITLE
Prelude: Move JSON.key{Text,Value} to Map

### DIFF
--- a/Prelude/JSON/keyText
+++ b/Prelude/JSON/keyText
@@ -1,1 +1,2 @@
-../Map/keyText
+  ../Map/keyText sha256:f7b6c802ca5764d03d5e9a6e48d9cb167c01392f775d9c2c87b83cdaa60ea0cc
+? ../Map/keyText

--- a/Prelude/JSON/keyText
+++ b/Prelude/JSON/keyText
@@ -1,14 +1,1 @@
-{-
-Builds a key-value record such that a List of them will be converted to a
-homogeneous record by dhall-to-json and dhall-to-yaml.
-
-Both key and value are fixed to Text.
-Take a look at `Record/keyValue` for a polymorphic version.
--}
-let keyText =
-      λ(key : Text) → λ(value : Text) → { mapKey = key, mapValue = value }
-
-let example0 =
-      assert : keyText "foo" "bar" ≡ { mapKey = "foo", mapValue = "bar" }
-
-in  keyText
+../Map/keyText

--- a/Prelude/JSON/keyValue
+++ b/Prelude/JSON/keyValue
@@ -1,1 +1,2 @@
-../Map/keyValue
+  ../Map/keyValue sha256:a0a97199d280c4cce72ffcbbf93b7ceda0a569cf4d173ac98e0aaaa78034b98c
+? ../Map/keyValue

--- a/Prelude/JSON/keyValue
+++ b/Prelude/JSON/keyValue
@@ -1,17 +1,1 @@
-{-
-Builds a key-value record such that a List of them will be converted to a
-homogeneous record by dhall-to-json and dhall-to-yaml.
--}
-let keyValue =
-        λ(v : Type)
-      → λ(key : Text)
-      → λ(value : v)
-      → { mapKey = key, mapValue = value }
-
-let example0 =
-      assert : keyValue Natural "foo" 2 ≡ { mapKey = "foo", mapValue = 2 }
-
-let example1 =
-      assert : keyValue Text "bar" "baz" ≡ { mapKey = "bar", mapValue = "baz" }
-
-in  keyValue
+../Map/keyValue

--- a/Prelude/Map/keyText
+++ b/Prelude/Map/keyText
@@ -1,0 +1,15 @@
+{-
+Builds a key-value record such that a `List` of them will be converted to a
+homogeneous record by dhall-to-json and dhall-to-yaml.
+
+Both key and value are fixed to `Text`.
+
+Take a look at `./keyValue` for a polymorphic version.
+-}
+let keyText =
+      λ(key : Text) → λ(value : Text) → { mapKey = key, mapValue = value }
+
+let example0 =
+      assert : keyText "foo" "bar" ≡ { mapKey = "foo", mapValue = "bar" }
+
+in  keyText

--- a/Prelude/Map/keyValue
+++ b/Prelude/Map/keyValue
@@ -1,0 +1,17 @@
+{-
+Builds a key-value record such that a List of them will be converted to a
+homogeneous record by dhall-to-json and dhall-to-yaml.
+-}
+let keyValue =
+        λ(v : Type)
+      → λ(key : Text)
+      → λ(value : v)
+      → { mapKey = key, mapValue = value }
+
+let example0 =
+      assert : keyValue Natural "foo" 2 ≡ { mapKey = "foo", mapValue = 2 }
+
+let example1 =
+      assert : keyValue Text "bar" "baz" ≡ { mapKey = "bar", mapValue = "baz" }
+
+in  keyValue

--- a/Prelude/Map/package.dhall
+++ b/Prelude/Map/package.dhall
@@ -7,6 +7,12 @@
 , empty =
       ./empty sha256:4c612558b8bbe8f955550ed3fb295d57b1b864c85cd52615b52d0ee0e9682e52
     ? ./empty
+, keyText =
+      ./keyText sha256:f7b6c802ca5764d03d5e9a6e48d9cb167c01392f775d9c2c87b83cdaa60ea0cc
+    ? ./keyText
+, keyValue =
+      ./keyValue sha256:a0a97199d280c4cce72ffcbbf93b7ceda0a569cf4d173ac98e0aaaa78034b98c
+    ? ./keyValue
 , keys =
       ./keys sha256:d13ec34e6acf7c349d82272ef09a37c7bdf37f0dab489e9df47a1ff215d9f5e7
     ? ./keys

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -17,7 +17,7 @@
       ./Location/package.dhall sha256:0eb4e4a60814018009c720f6820aaa13cf9491eb1b09afb7b832039c6ee4d470
     ? ./Location/package.dhall
 , Map =
-      ./Map/package.dhall sha256:024ea7c599ae0dc94a2c448022b9a34ef136151ac597afaa97d102ec3ec98df5
+      ./Map/package.dhall sha256:598e9c76103b2686fbbda6cc30078f9e60dd846d9eaf155d0149cf0ae06c21c5
     ? ./Map/package.dhall
 , Monoid =
       ./Monoid sha256:26fafa098600ef7a54ef9dba5ada416bbbdd21df1af306c052420c61553ad4af

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -203,6 +203,13 @@
     { Entry : ∀(k : Type) → ∀(v : Type) → Type
     , Type : ∀(k : Type) → ∀(v : Type) → Type
     , empty : ∀(k : Type) → ∀(v : Type) → List { mapKey : k, mapValue : v }
+    , keyText :
+        ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
+    , keyValue :
+          ∀(v : Type)
+        → ∀(key : Text)
+        → ∀(value : v)
+        → { mapKey : Text, mapValue : v }
     , keys :
           ∀(k : Type)
         → ∀(v : Type)


### PR DESCRIPTION
JSON.key{Text,Value} initially remain as re-exports, but will
eventually be removed.

Fixes #770.
