### PR TITLE
Fix referentially opaque Prelude test

### DIFF
--- a/Prelude/Location/Type
+++ b/Prelude/Location/Type
@@ -4,15 +4,4 @@ let Location
     : Type
     = < Environment : Text | Local : Text | Missing | Remote : Text >
 
-let example0 =
-        assert
-      :   (   missing sha256:f428188ff9d77ea15bc2bcd0da3f8ed81b304e175b07ade42a3b0fb02941b2aa as Location
-            ? missing as Location
-          )
-        ≡ < Environment : Text
-          | Local : Text
-          | Missing
-          | Remote : Text
-          >.Missing
-
 in  Location


### PR DESCRIPTION
The deleted test causes the Prelude to fail when imported remotely
due to failing the referential sanity check.

The right solution here is to make `missing` a valid transitive import
for remote imports, but this is a quick fix to restore Prelude
functionality until then.
