### PR TITLE
Add a `Prelude.JSON.omitNullFields`

### DIFF
--- a/Prelude/JSON/filterNullFields
+++ b/Prelude/JSON/filterNullFields
@@ -1,0 +1,152 @@
+{-
+This utility filters out all `null` record fields, which is often the idiomatic
+way for a configuration to encode absent fields
+-}
+let JSON/Type =
+        ./Type sha256:5adb234f5868a5b0eddeb034d690aaba8cb94ea20d0d557003e90334fff6be3e
+      ? ./Type
+
+let string =
+        ./string sha256:7a8ac435d30a96092d72889f3d48eabf7cba47ecf553fd6bc07a79fdf473e8d2
+      ? ./string
+
+let number =
+        ./number sha256:534745568065ae19d2b0fe1d09eeb071e9717d0f392187eb0bc95f386b018bec
+      ? ./number
+
+let object =
+        ./object sha256:a4e047cf157c3971b026b3942a87d474c85950d9b9654f8ebc8631740abf75a9
+      ? ./object
+
+let array =
+        ./array sha256:3a4c06cf135f4c80619e48c0808f6600d19782705bc59ee7c27cfc2e0f097eb7
+      ? ./array
+
+let bool =
+        ./bool sha256:018d29f030b45d642aba6bb81bf2c19a7bf183684612ce7a2c8afd2099783c48
+      ? ./bool
+
+let null =
+        ./null sha256:52c1d45ab2ca54875b444bfb1afdea497c8c9b0652e5044fafd8b16d97f4b78d
+      ? ./null
+
+let List/concatMap =
+        ../List/concatMap sha256:3b2167061d11fda1e4f6de0522cbe83e0d5ac4ef5ddf6bb0b2064470c5d3fb64
+      ? ../List/concatMap
+
+let List/map =
+        ../List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+      ? ../List/map
+
+let filterNullFields
+    : JSON/Type → JSON/Type
+    =   λ(old : JSON/Type)
+      → λ(JSON : Type)
+      → λ ( json
+          : { string : Text → JSON
+            , number : Double → JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , array : List JSON → JSON
+            , bool : Bool → JSON
+            , null : JSON
+            }
+          )
+      → let result =
+              old
+                { value : JSON, isNull : Bool }
+                { string =
+                    λ(x : Text) → { value = json.string x, isNull = False }
+                , number =
+                    λ(x : Double) → { value = json.number x, isNull = False }
+                , object =
+                      λ ( keyValues
+                        : List
+                            { mapKey : Text
+                            , mapValue : { value : JSON, isNull : Bool }
+                            }
+                        )
+                    → let value =
+                            json.object
+                              ( List/concatMap
+                                  { mapKey : Text
+                                  , mapValue : { value : JSON, isNull : Bool }
+                                  }
+                                  { mapKey : Text, mapValue : JSON }
+                                  (   λ ( keyValue
+                                        : { mapKey : Text
+                                          , mapValue :
+                                              { value : JSON, isNull : Bool }
+                                          }
+                                        )
+                                    →       if keyValue.mapValue.isNull
+                                      
+                                      then  [] : List
+                                                   { mapKey : Text
+                                                   , mapValue : JSON
+                                                   }
+                                      
+                                      else  [   keyValue.{ mapKey }
+                                              ∧ { mapValue =
+                                                    keyValue.mapValue.value
+                                                }
+                                            ]
+                                  )
+                                  keyValues
+                              )
+                      
+                      in  { value = value, isNull = False }
+                , array =
+                      λ(xs : List { value : JSON, isNull : Bool })
+                    → let value =
+                            json.array
+                              ( List/map
+                                  { value : JSON, isNull : Bool }
+                                  JSON
+                                  (   λ(x : { value : JSON, isNull : Bool })
+                                    → x.value
+                                  )
+                                  xs
+                              )
+                      
+                      in  { value = value, isNull = False }
+                , bool = λ(x : Bool) → { value = json.bool x, isNull = False }
+                , null = { value = json.null, isNull = True }
+                }
+        
+        in  result.value
+
+let property =
+        λ(a : Text)
+      → λ(b : Double)
+      → λ(c : Bool)
+      →   assert
+        :   filterNullFields
+              ( object
+                  ( toMap
+                      { string = string a
+                      , number = number b
+                      , bool = bool c
+                      , null = null
+                      }
+                  )
+              )
+          ≡ object
+              (toMap { string = string a, number = number b, bool = bool c })
+
+let example =
+        assert
+      :   filterNullFields
+            ( object
+                (toMap { array = array [ object (toMap { null = null }) ] })
+            )
+        ≡ object
+            ( toMap
+                { array =
+                    array
+                      [ object
+                          ([] : List { mapKey : Text, mapValue : JSON/Type })
+                      ]
+                }
+            )
+
+in  filterNullFields

--- a/Prelude/JSON/filterNullFields
+++ b/Prelude/JSON/filterNullFields
@@ -149,4 +149,6 @@ let example =
                 }
             )
 
+let example = assert : filterNullFields (array [ null ]) ≡ array [ null ]
+
 in  filterNullFields

--- a/Prelude/JSON/omitNullFields
+++ b/Prelude/JSON/omitNullFields
@@ -1,6 +1,6 @@
 {-
-This utility filters out all `null` record fields, which is often the idiomatic
-way for a configuration to encode absent fields
+This utility omits all `null` record fields, which is often the idiomatic way
+for a configuration to encode absent fields
 -}
 let JSON/Type =
         ./Type sha256:5adb234f5868a5b0eddeb034d690aaba8cb94ea20d0d557003e90334fff6be3e
@@ -38,7 +38,7 @@ let List/map =
         ../List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
       ? ../List/map
 
-let filterNullFields
+let omitNullFields
     : JSON/Type → JSON/Type
     =   λ(old : JSON/Type)
       → λ(JSON : Type)
@@ -120,7 +120,7 @@ let property =
       → λ(b : Double)
       → λ(c : Bool)
       →   assert
-        :   filterNullFields
+        :   omitNullFields
               ( object
                   ( toMap
                       { string = string a
@@ -135,7 +135,7 @@ let property =
 
 let example =
         assert
-      :   filterNullFields
+      :   omitNullFields
             ( object
                 (toMap { array = array [ object (toMap { null = null }) ] })
             )
@@ -149,6 +149,6 @@ let example =
                 }
             )
 
-let example = assert : filterNullFields (array [ null ]) ≡ array [ null ]
+let example = assert : omitNullFields (array [ null ]) ≡ array [ null ]
 
-in  filterNullFields
+in  omitNullFields

--- a/Prelude/JSON/package.dhall
+++ b/Prelude/JSON/package.dhall
@@ -34,7 +34,7 @@
 , render =
       ./render sha256:81f5a84efbb35211b1556838e86d17ed497912cf765bfa4ab76708b21e5371f1
     ? ./render
-, filterNullFields =
-      ./filterNullFields sha256:c28270c553f48c406bd161c61776963315e278af5dae9331c4a320c3f4ecb4ec
-    ? ./filterNullFields
+, omitNullFields =
+      ./omitNullFields sha256:c28270c553f48c406bd161c61776963315e278af5dae9331c4a320c3f4ecb4ec
+    ? ./omitNullFields
 }

--- a/Prelude/JSON/package.dhall
+++ b/Prelude/JSON/package.dhall
@@ -34,4 +34,7 @@
 , render =
       ./render sha256:81f5a84efbb35211b1556838e86d17ed497912cf765bfa4ab76708b21e5371f1
     ? ./render
+, filterNullFields =
+      ./filterNullFields sha256:c28270c553f48c406bd161c61776963315e278af5dae9331c4a320c3f4ecb4ec
+    ? ./filterNullFields
 }

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -29,7 +29,7 @@
       ./Optional/package.dhall sha256:7608f2d38dabee8bfe6865b4adc11289059984220f422d2b023b15b3908f7a4c
     ? ./Optional/package.dhall
 , JSON =
-      ./JSON/package.dhall sha256:96c47b48ae8c361a1b6d52b63a1929fc383cf5e316f01df9111234306db34e6f
+      ./JSON/package.dhall sha256:3b504fef8d9110bfb4960abb4d2b467e70ffe3f318e9c180e1c0b25c9425e4f9
     ? ./JSON/package.dhall
 , Text =
       ./Text/package.dhall sha256:0a0ad9f649aed94c2680491efb384925b5b2bb5b353f1b8a7eb134955c1ffe45

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -29,7 +29,7 @@
       ./Optional/package.dhall sha256:7608f2d38dabee8bfe6865b4adc11289059984220f422d2b023b15b3908f7a4c
     ? ./Optional/package.dhall
 , JSON =
-      ./JSON/package.dhall sha256:0c3c40a63108f2e6ad59f23b789c18eb484d0e9aebc9416c5a4f338c6753084b
+      ./JSON/package.dhall sha256:96c47b48ae8c361a1b6d52b63a1929fc383cf5e316f01df9111234306db34e6f
     ? ./JSON/package.dhall
 , Text =
       ./Text/package.dhall sha256:0a0ad9f649aed94c2680491efb384925b5b2bb5b353f1b8a7eb134955c1ffe45

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -67,6 +67,31 @@
               }
             )
         → JSON
+    , filterNullFields :
+          ∀ ( old
+            :   ∀(JSON : Type)
+              → ∀ ( json
+                  : { array : List JSON → JSON
+                    , bool : Bool → JSON
+                    , null : JSON
+                    , number : Double → JSON
+                    , object : List { mapKey : Text, mapValue : JSON } → JSON
+                    , string : Text → JSON
+                    }
+                  )
+              → JSON
+            )
+        → ∀(JSON : Type)
+        → ∀ ( json
+            : { array : List JSON → JSON
+              , bool : Bool → JSON
+              , null : JSON
+              , number : Double → JSON
+              , object : List { mapKey : Text, mapValue : JSON } → JSON
+              , string : Text → JSON
+              }
+            )
+        → JSON
     , keyText :
         ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
     , keyValue :


### PR DESCRIPTION
This is one step towards moving more `dhall-to-json` functionality into pure
Dhall.  This implements the `--omitNull` functionality of the
command-line tool.