### PR TITLE
Fix "assert" missing from keyword rule

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -336,6 +336,7 @@ keyword =
     / using / missing / as
     / Infinity / NaN
     / merge / Some / toMap
+    / assert
 
 builtin =
       Natural-fold


### PR DESCRIPTION
Single-line change to the ABNF standard to correct `assert` missing from the `keyword` rule.