### PR TITLE
Update standard version to "11.0.0"

### DIFF
--- a/standard/versioning.md
+++ b/standard/versioning.md
@@ -9,7 +9,7 @@ The current version string is:
 
 
     ─────────────────────────
-    currentVersion = "10.0.0"
+    currentVersion = "11.0.0"
 
 
 This version string is used by implementations to:


### PR DESCRIPTION
Looks like the "current version" of the standard didn't get updated to "11.0.0" with 8098184d17c3aecc82674a7b874077a7641be05a.