### PR TITLE
Remove support for fusion

### DIFF
--- a/standard/beta-normalization.md
+++ b/standard/beta-normalization.md
@@ -300,17 +300,6 @@ The `Natural` number type is in normal form:
     n ⇥ n
 
 
-`Natural/build` and `Natural/fold` are inverses of one another, which leads to
-the following fusion rule:
-
-
-    f ⇥ Natural/build   a ⇥ Natural/fold b
-    ──────────────────────────────────────
-    f a ⇥ b
-
-
-Otherwise, fall back on each function's respective implementation.
-
 `Natural/build` is the canonical introduction function for `Natural` numbers:
 
 
@@ -705,17 +694,6 @@ Lists are defined here via induction as if they were linked lists, but a real
 implementation might represent them using another data structure under the hood.
 Dhall does not impose time complexity requirements on list operations.
 
-`List/build` and `List/fold` are inverses of one another, which leads to the
-following fusion rule:
-
-
-    f ⇥ List/build A₀   a ⇥ List/fold A₁ b
-    ──────────────────────────────────────
-    f a ⇥ b
-
-
-Otherwise, fall back on each function's respective implementation.
-
 `List/build` is the canonical introduction function for `List`s:
 
 
@@ -891,15 +869,6 @@ Normalize a `Some` expression by normalizing its argument:
     t₀ ⇥ t₁
     ─────────────────
     Some t₀ ⇥ Some t₁
-
-
-`Optional/build` and `Optional/fold` are inverses of one another, which leads to
-the following fusion rule:
-
-
-    f ⇥ Optional/build A₀   a ⇥ Optional/fold A₁ b
-    ──────────────────────────────────────────────
-    f a ⇥ b
 
 
 `Optional/build` is the canonical introduction function for `Optional` values:

--- a/tests/normalization/success/unit/ListBuildFoldFusionB.dhall
+++ b/tests/normalization/success/unit/ListBuildFoldFusionB.dhall
@@ -1,1 +1,8 @@
-λ(T : Type) → λ(x : List T) → x
+  λ(T : Type)
+→ λ(x : List T)
+→ List/fold
+    T
+    x
+    (List T)
+    (λ(a : T) → λ(`as` : List T) → [ a ] # `as`)
+    ([] : List T)

--- a/tests/normalization/success/unit/NaturalBuildFoldFusionB.dhall
+++ b/tests/normalization/success/unit/NaturalBuildFoldFusionB.dhall
@@ -1,1 +1,1 @@
-λ(x : Natural) → x
+λ(x : Natural) → Natural/fold x Natural (λ(n : Natural) → n + 1) 0

--- a/tests/normalization/success/unit/OptionalBuildFoldFusionB.dhall
+++ b/tests/normalization/success/unit/OptionalBuildFoldFusionB.dhall
@@ -1,1 +1,3 @@
-λ(T : Type) → λ(x : Optional T) → x
+  λ(T : Type)
+→ λ(x : Optional T)
+→ Optional/fold T x (Optional T) (λ(a : T) → Some a) (None T)


### PR DESCRIPTION
The fusion rules do not trigger reliably (i.e. they are not confluent),
and they complicate the standard, so I propose to remove them to
simplify things for new implementations.