### PR TITLE
Fix Prelude inferred type

### DIFF
--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -67,31 +67,6 @@
               }
             )
         → JSON
-    , filterNullFields :
-          ∀ ( old
-            :   ∀(JSON : Type)
-              → ∀ ( json
-                  : { array : List JSON → JSON
-                    , bool : Bool → JSON
-                    , null : JSON
-                    , number : Double → JSON
-                    , object : List { mapKey : Text, mapValue : JSON } → JSON
-                    , string : Text → JSON
-                    }
-                  )
-              → JSON
-            )
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , null : JSON
-              , number : Double → JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
     , keyText :
         ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
     , keyValue :
@@ -142,6 +117,31 @@
                         )
                     → JSON
                 }
+            )
+        → ∀(JSON : Type)
+        → ∀ ( json
+            : { array : List JSON → JSON
+              , bool : Bool → JSON
+              , null : JSON
+              , number : Double → JSON
+              , object : List { mapKey : Text, mapValue : JSON } → JSON
+              , string : Text → JSON
+              }
+            )
+        → JSON
+    , omitNullFields :
+          ∀ ( old
+            :   ∀(JSON : Type)
+              → ∀ ( json
+                  : { array : List JSON → JSON
+                    , bool : Bool → JSON
+                    , null : JSON
+                    , number : Double → JSON
+                    , object : List { mapKey : Text, mapValue : JSON } → JSON
+                    , string : Text → JSON
+                    }
+                  )
+              → JSON
             )
         → ∀(JSON : Type)
         → ∀ ( json


### PR DESCRIPTION
In https://github.com/dhall-lang/dhall-lang/pull/784 I renamed the
`filterNullFields` function to `omitNullFields` without a corresponding change
to the Prelude expected output, which this change fixes