### PR TITLE
Fix "generate-diagnostic-files" reference

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -60,7 +60,7 @@ Where `A` and `B` are:
 
 *Note*: Each `B.dhallb` file has a matching `B.diag` file containing the
 CBOR diagnostic notation for the encoded expression.  You can generate
-the `.diag` file using the `./scripts/generate-diagnostic-files.sh` script
+the `.diag` file using the `./scripts/generate-test-files.sh` script
 and our continuous integration will remind you to do so (by failing if you
 don't keep the diagnostic file up-to-date).
 


### PR DESCRIPTION
da02ab2faf81b3e627f01cc5f4bb37403a15ab0e missed a reference to a renamed file in the `tests/README.md`.  Should be fixed to avoid confusion.  Maybe just want to amend last commit though?