### PR TITLE
Treat `missing` as referentially transparent

### DIFF
--- a/Prelude/Location/Type
+++ b/Prelude/Location/Type
@@ -4,4 +4,15 @@ let Location
     : Type
     = < Environment : Text | Local : Text | Missing | Remote : Text >
 
+let example0 =
+        assert
+      :   (   missing sha256:f428188ff9d77ea15bc2bcd0da3f8ed81b304e175b07ade42a3b0fb02941b2aa as Location
+            ? missing as Location
+          )
+        ≡ < Environment : Text
+          | Local : Text
+          | Missing
+          | Remote : Text
+          >.Missing
+
 in  Location

--- a/standard/imports.md
+++ b/standard/imports.md
@@ -417,7 +417,10 @@ A remote import such as `https://example.com/foo` is "referentially transparent"
 because the contents of the import does not change depending on which machine
 you import it from (with caveats, such as not tampering with DNS, etc.).
 
-All non-remote imports are "referentially opaque" because their contents depend
+A `missing` import is also referentially transparent because it always fails
+regardless of where you import `missing` from.
+
+All other imports are "referentially opaque" because their contents depend
 on which machine that you import them from.
 
 Referential transparency is checked using a judgment of the form:
@@ -434,11 +437,15 @@ There is no output: either the judgment matches or it does not.
 The rules for the referential transparency check ensure that a referentially
 transparent parent can never import a referentially opaque child.  In practice
 this means that remote imports can only import other remote imports (after
-both imports have been canonicalized):
+both imports have been canonicalized) or `missing` imports:
 
 
     ───────────────────────────────────────────────────────────────────────────────────────────
     referentiallySane(https://authority₀ directory₀ file₀, https://authority₁ directory₁ file₁)
+
+
+    ───────────────────────────────────────────────────────────────
+    referentiallySane(https://authority₀ directory₀ file₀, missing)
 
 
 ... whereas non-remote imports can import anything:

--- a/tests/import/success/referentiallyTransparentMissing.dhall
+++ b/tests/import/success/referentiallyTransparentMissing.dhall
@@ -1,0 +1,9 @@
+{- This test verifies that `missing` is treated as a referentially transparent
+   import.  The following import contains a `missing as Location` in its
+   test assertion that should succeed since:
+
+   * The `missing` is never actually resolved (due to the `as Location`)
+   * The `missing` should be treated as referentially transparent (and therefore
+     be a valid transitive dependency of a remote import)
+-}
+https://prelude.dhall-lang.org/v11.0.0/Location/Type


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/783