### PR TITLE
tests/semantic-hash/success/prelude/Text/show/1: Fix hex digit capitalization

### DIFF
--- a/tests/semantic-hash/success/prelude/Text/show/1A.dhall
+++ b/tests/semantic-hash/success/prelude/Text/show/1A.dhall
@@ -1,1 +1,1 @@
-../../../../../../Prelude/Text/show "\u0000 \$ \\ \n \u263a"
+../../../../../../Prelude/Text/show "\u0000 \$ \\ \n \u263A"


### PR DESCRIPTION
The grammar doesn't allow lower case hex digits:

https://github.com/dhall-lang/dhall-lang/blob/464b7358545a0d5c10d0aa987fed94bedc7f5162/standard/dhall.abnf#L283-L284

https://github.com/dhall-lang/dhall-lang/blob/464b7358545a0d5c10d0aa987fed94bedc7f5162/standard/dhall.abnf#L191

