### PR TITLE
Fix prelude version

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -132,7 +132,7 @@
 
         virtualHosts =
           let
-            latestRelease = "v11.1.0";
+            latestRelease = "v12.0.0";
 
             prelude = {
               forceSSL = true;


### PR DESCRIPTION
https://prelude.dhall-lang.org should always link to the latest release.