### PR TITLE
Make Prelude.Integer.multiply slightly more efficient

### DIFF
--- a/Prelude/Integer/multiply
+++ b/Prelude/Integer/multiply
@@ -2,27 +2,30 @@
 `multiply m n` computes `m * n`.
 -}
 
-let Integer/abs =
-        ./abs sha256:35212fcbe1e60cb95b033a4a9c6e45befca4a298aa9919915999d09e69ddced1
-      ? ./abs
+let nonPositive = λ(x : Integer) → Natural/isZero (Integer/clamp x)
+
+let multiplyNonNegative =
+        λ(x : Integer)
+      → λ(y : Integer)
+      → Natural/toInteger (Integer/clamp x * Integer/clamp y)
 
 let multiply
     : Integer → Integer → Integer
     =   λ(m : Integer)
       → λ(n : Integer)
-      → let mAbs = Integer/abs m
+      →       if nonPositive m
 
-        let nAbs = Integer/abs n
+        then        if nonPositive n
 
-        let mNonPos = Natural/isZero (Integer/clamp m)
+              then  multiplyNonNegative (Integer/negate m) (Integer/negate n)
 
-        let nNonPos = Natural/isZero (Integer/clamp n)
+              else  Integer/negate (multiplyNonNegative (Integer/negate m) n)
 
-        in        if mNonPos == nNonPos
+        else  if nonPositive n
 
-            then  Natural/toInteger (mAbs * nAbs)
+        then  Integer/negate (multiplyNonNegative m (Integer/negate n))
 
-            else  Integer/negate (Natural/toInteger (mAbs * nAbs))
+        else  multiplyNonNegative m n
 
 let example0 = assert : multiply +3 +5 ≡ +15
 

--- a/Prelude/Integer/package.dhall
+++ b/Prelude/Integer/package.dhall
@@ -23,7 +23,7 @@
       ./lessThanEqual sha256:a849203a9cd270210588f9db23e02b819117a997df1c8131b6f9a634cb2e5c8d
     ? ./lessThanEqual
 , multiply =
-      ./multiply sha256:71b2a720976c70f0cd06baba9c213867b9744e655927dc3857fa92c864c3cf86
+      ./multiply sha256:dcb1ed7c8475ece8d67db92cd249fc728541778ff82509e28c3760e341880e4d
     ? ./multiply
 , negate =
       ./negate sha256:2373c992e1de93634bc6a8781eb073b2a92a70170133e49762a785f3a136df5d

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -8,7 +8,7 @@
       ./Function/package.dhall sha256:74c3822b98b9d37f9f820af8e1a7ee790bcfac03050eabd45af4a255fb93e026
     ? ./Function/package.dhall
 , Integer =
-      ./Integer/package.dhall sha256:dbc82e5542a642b9372ce6126967028c0cade2b8ad6923312b086b686ad67e06
+      ./Integer/package.dhall sha256:b363163793d3c67cd9354dc856ac861cb126cd31e01eec0ca48eb0f8c9282e80
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7


### PR DESCRIPTION
The case analysis allows us to avoid using Integer/abs on factors
of known sign. This is very similar to what we can do with
subtract (see #845).