### PR TITLE
Ensure List/null is O(1) on all implementations

### DIFF
--- a/Prelude/JSON/package.dhall
+++ b/Prelude/JSON/package.dhall
@@ -2,7 +2,7 @@
         ./render sha256:81f5a84efbb35211b1556838e86d17ed497912cf765bfa4ab76708b21e5371f1
       ? ./render
   , renderYAML =
-        ./renderYAML sha256:862b535f6b905f1ce4b83207c58dd53ce5af0026da4c0960a3aec90fdbbb3eb0
+        ./renderYAML sha256:dd5f65bda5f0b2752685103cac4e8102c88644dca20898febe4714ea74b4627a
       ? ./renderYAML
   , omitNullFields =
         ./omitNullFields sha256:c28270c553f48c406bd161c61776963315e278af5dae9331c4a320c3f4ecb4ec

--- a/Prelude/JSON/renderYAML
+++ b/Prelude/JSON/renderYAML
@@ -21,7 +21,7 @@ let List/drop =
       ? ../List/drop
 
 let List/null =
-        ../List/null sha256:2338e39637e9a50d66ae1482c0ed559bbcc11e9442bfca8f8c176bbcd9c4fc80
+        ../List/null sha256:1610870eb2585cb437e7796c54fb136a17f13bb0ff6a971297109166d458f7d4
       ? ../List/null
 
 let List/map =

--- a/Prelude/List/null
+++ b/Prelude/List/null
@@ -3,7 +3,9 @@ Returns `True` if the `List` is empty and `False` otherwise
 -}
 let null
     : ∀(a : Type) → List a → Bool
-    = λ(a : Type) → λ(xs : List a) → Natural/isZero (List/length a xs)
+    =   λ(a : Type)
+      → λ(xs : List a)
+      → Optional/fold a (List/head a xs) Bool (λ(x : a) → False) True
 
 let example0 = assert : null Natural [ 0, 1, 2 ] ≡ False
 

--- a/Prelude/List/package.dhall
+++ b/Prelude/List/package.dhall
@@ -50,7 +50,7 @@
       ./map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
     ? ./map
 , null =
-      ./null sha256:2338e39637e9a50d66ae1482c0ed559bbcc11e9442bfca8f8c176bbcd9c4fc80
+      ./null sha256:1610870eb2585cb437e7796c54fb136a17f13bb0ff6a971297109166d458f7d4
     ? ./null
 , partition =
       ./partition sha256:38147ac6d750a6492736dd90cc967bf09aa405c499de943c64fab7b86ae02f03

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -11,7 +11,7 @@
       ./Integer/package.dhall sha256:dbc82e5542a642b9372ce6126967028c0cade2b8ad6923312b086b686ad67e06
     ? ./Integer/package.dhall
 , List =
-      ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7
+      ./List/package.dhall sha256:bff60f12dfcdb6ccd555667089f213b586a22ea990cec84d7184eff4f45edec5
     ? ./List/package.dhall
 , Location =
       ./Location/package.dhall sha256:0eb4e4a60814018009c720f6820aaa13cf9491eb1b09afb7b832039c6ee4d470

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -29,7 +29,7 @@
       ./Optional/package.dhall sha256:7608f2d38dabee8bfe6865b4adc11289059984220f422d2b023b15b3908f7a4c
     ? ./Optional/package.dhall
 , JSON =
-      ./JSON/package.dhall sha256:843783d29e60b558c2de431ce1206ce34bdfde375fcf06de8ec5bf77092fdef7
+      ./JSON/package.dhall sha256:5a3cc53e4a3a1b8340b49a220af1695fa830a3bbe7addf9bf6a42b2981bc1624
     ? ./JSON/package.dhall
 , Text =
       ./Text/package.dhall sha256:0a0ad9f649aed94c2680491efb384925b5b2bb5b353f1b8a7eb134955c1ffe45


### PR DESCRIPTION
This PR is more for discussion than a definite change, but...

The current implementation of `List/null` uses `Natural/isZero (List/length a xs)`.  While `dhall-haskell` uses `Data.Sequence` to represent lists (and thus `List/length` is O(1)), there is not (that I am aware of?) any requirement that Dhall lists be represented in a target language by a data structure that provides a O(1) implementation of `List/length`.  As some common (naive) list implementations have O(n) implementations of `List/length`, it may be preferable to avoid its use for `List/null`.

This PR instead uses `List/head` (which should be O(1) for basically any data structure one would conceivably use to represent a Dhall list) and `Optional/fold` instead.

This seems (to me?) in line with @Gabriel439 's comment [here](https://github.com/dhall-lang/dhall-lang/pull/846#discussion_r355140504) RE: not targeting performance on a specific implementation but rather more broadly (along with the expressed focus on time complexity).