### PR TITLE
Remove reference to `--pretty` and add `--plain`

### DIFF
--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -17,8 +17,6 @@
 
 *   Add the `--explain` flag for detailed explanations of type errors.
 
-*   Add the `--plain` flag to disable syntax highlighting.
-
 ## Primitive types
 
 *   `Bool`:

--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -17,7 +17,7 @@
 
 *   Add the `--explain` flag for detailed explanations of type errors.
 
-*   Add the `--pretty` flag to format output.
+*   Add the `--plain` flag to disable syntax highlighting.
 
 ## Primitive types
 


### PR DESCRIPTION
`--pretty` flag was removed in https://github.com/dhall-lang/dhall-haskell/pull/303 in favor of formatting by default, with the `--plain` flag added in https://github.com/dhall-lang/dhall-haskell/pull/310 to disable this behavior.  The cheatsheet still referenced the `--pretty` flag, however.

I replaced the `--pretty` reference with `--plain` behavior, but would it be better to simply remove it entirely?