### PR TITLE
Clarify "Edit me" message on docs site

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,7 +4,7 @@
 <div class="footer" style="position: absolute; margin-top: 30px; margin-right: 10px; top: 0; right: 0;">
   <a style="text-decoration: none"
      href="https://github.com/dhall-lang/dhall-lang/edit/master/docs/{{ sourcename | replace('.txt', '') }}">
-  Edit me
+  Contribute to this page
 </a>
 </div>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,7 +4,7 @@
 <div class="footer" style="position: absolute; margin-top: 30px; margin-right: 10px; top: 0; right: 0;">
   <a style="text-decoration: none"
      href="https://github.com/dhall-lang/dhall-lang/edit/master/docs/{{ sourcename | replace('.txt', '') }}">
-  Contribute to this page
+  Want to contribute? Edit me on Github!
 </a>
 </div>
 {% endblock %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,10 @@ Welcome to the Dhall documentation!
 ```eval_rst
 .. note::
 
-   This website's sources are located in the `dhall-lang project`_
-   docs directory. Please feel free to contribute by clicking the **Edit me** button
-   at the top right corner, or use the `issue system`_. Thanks!
+   This website's sources are located in the `dhall-lang project`_ docs
+   directory. Please feel free to contribute by clicking the
+   **Edit me on Github** button, located in the top right corner of each page,
+   or use the `issue system`_. Thanks!
 
 .. _`dhall-lang project`: https://github.com/dhall-lang/dhall-lang/tree/master/docs
 .. _`issue system`: https://github.com/dhall-lang/dhall-lang/issues/new


### PR DESCRIPTION
There is currently a link with the text "Edit me" in the header of the docs website; clicking on it opens the file for editing on github.  If we're not going to add an extra header, it should be removed.  (Unless someone has something to go in the header?)

![Screenshot_2019-12-10 Cheatsheet — Dhall documentation](https://user-images.githubusercontent.com/2049163/70513051-b7b2c200-1ae5-11ea-987f-3d3fc560e730.png)
