### PR TITLE
Fix docs.dhall-lang.org to display correct Copyright date

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -127,6 +127,8 @@ let
           ];
         }
         ''
+        SOURCE_DATE_EPOCH="$(${pkgsNew.coreutils}/bin/date '+%s')"
+
         sphinx-build ${./docs} $out
 
         cp ${./img/dhall-logo.svg} $out/_static/dhall-logo.svg


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/852

This fix is based on https://github.com/sphinx-doc/sphinx/issues/3451