### PR TITLE
Add Integer.{negative,nonNegative,nonPositive,positive}

### DIFF
--- a/Prelude/Integer/greaterThan
+++ b/Prelude/Integer/greaterThan
@@ -6,7 +6,7 @@ let Bool/not =
       ? ../Bool/not
 
 let lessThanEqual =
-        ./lessThanEqual sha256:b58763a060fc19f0b3614183488a99fb1779960d002bc571bb159c105485c2cf
+        ./lessThanEqual sha256:e3cca9f3942f81fa78a2bea23c0c24519c67cfe438116c38e797e12dcd26f6bc
       ? ./lessThanEqual
 
 let greaterThan

--- a/Prelude/Integer/greaterThanEqual
+++ b/Prelude/Integer/greaterThanEqual
@@ -2,7 +2,7 @@
 `greaterThanEqual` checks if one Integer is greater than or equal to another.
 -}
 let lessThanEqual =
-        ./lessThanEqual sha256:b58763a060fc19f0b3614183488a99fb1779960d002bc571bb159c105485c2cf
+        ./lessThanEqual sha256:e3cca9f3942f81fa78a2bea23c0c24519c67cfe438116c38e797e12dcd26f6bc
       ? ./lessThanEqual
 
 let greaterThanEqual

--- a/Prelude/Integer/lessThan
+++ b/Prelude/Integer/lessThan
@@ -2,7 +2,7 @@
 `lessThan` checks if one Integer is less than another.
 -}
 let greaterThan =
-        ./greaterThan sha256:0c9b847676939f9d6c462fd78fc5b010150dd3ce67b6e9ac6b8af7b902093a95
+        ./greaterThan sha256:d23affd73029fc9aaf867c2c7b86510ca2802d3f0d1f3e1d1a93ffd87b7cb64b
       ? ./greaterThan
 
 let lessThan

--- a/Prelude/Integer/lessThanEqual
+++ b/Prelude/Integer/lessThanEqual
@@ -1,10 +1,6 @@
 {-
 `lessThanEqual` checks if one Integer is less than or equal to another.
 -}
-let Bool/not =
-        ../Bool/not sha256:723df402df24377d8a853afed08d9d69a0a6d86e2e5b2bac8960b0d4756c7dc4
-      ? ../Bool/not
-
 let Natural/greaterThanEqual =
         ../Natural/greaterThanEqual sha256:30ebfab0febd7aa0ccccfdf3dc36ee6d50f0117f35dd4a9b034750b7e885a1a4
       ? ../Natural/greaterThanEqual
@@ -13,7 +9,13 @@ let Natural/lessThanEqual =
         ../Natural/lessThanEqual sha256:1a5caa2b80a42b9f58fff58e47ac0d9a9946d0b2d36c54034b8ddfe3cb0f3c99
       ? ../Natural/lessThanEqual
 
-let nonPositive = λ(x : Integer) → Natural/isZero (Integer/clamp x)
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
+
+let nonNegative =
+        ./nonNegative sha256:b463373f070df6b1c8c7082051e0810fee38b360bab35256187c8c2b6af5c663
+      ? ./nonNegative
 
 let lessThanEqual
     : Integer → Integer → Bool
@@ -21,7 +23,7 @@ let lessThanEqual
       → λ(y : Integer)
       →       if nonPositive x
 
-        then      Bool/not (nonPositive y)
+        then      nonNegative y
               ||  Natural/greaterThanEqual
                     (Integer/clamp (Integer/negate x))
                     (Integer/clamp (Integer/negate y))

--- a/Prelude/Integer/multiply
+++ b/Prelude/Integer/multiply
@@ -2,7 +2,9 @@
 `multiply m n` computes `m * n`.
 -}
 
-let nonPositive = λ(x : Integer) → Natural/isZero (Integer/clamp x)
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
 
 let multiplyNonNegative =
         λ(x : Integer)

--- a/Prelude/Integer/negative
+++ b/Prelude/Integer/negative
@@ -1,0 +1,20 @@
+{-
+Returns `True` for any `Integer` less than `+0`.
+
+`negative` is more efficient than `./lessThan +0` or `./lessThanEqual -1`.
+-}
+let positive =
+        ./positive sha256:7bdbf50fcdb83d01f74c7e2a92bf5c9104eff5d8c5b4587e9337f0caefcfdbe3
+      ? ./positive
+
+let negative
+    : Integer → Bool
+    = λ(n : Integer) → positive (Integer/negate n)
+
+let example0 = assert : negative +1 ≡ False
+
+let example1 = assert : negative +0 ≡ False
+
+let example2 = assert : negative -1 ≡ True
+
+in  negative

--- a/Prelude/Integer/nonNegative
+++ b/Prelude/Integer/nonNegative
@@ -1,0 +1,20 @@
+{-
+Returns `True` for `+0` and any positive `Integer`.
+
+`nonNegative` is more efficient than `./greaterThanEqual +0` or `./greaterThan -1`.
+-}
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
+
+let nonNegative
+    : Integer → Bool
+    = λ(n : Integer) → nonPositive (Integer/negate n)
+
+let example0 = assert : nonNegative +1 ≡ True
+
+let example1 = assert : nonNegative +0 ≡ True
+
+let example2 = assert : nonNegative -1 ≡ False
+
+in  nonNegative

--- a/Prelude/Integer/nonPositive
+++ b/Prelude/Integer/nonPositive
@@ -1,0 +1,16 @@
+{-
+Returns `True` for `+0` and any negative `Integer`.
+
+`nonPositive` is more efficient than `./lessThanEqual +0` or `./lessThan +1`.
+-}
+let nonPositive
+    : Integer → Bool
+    = λ(n : Integer) → Natural/isZero (Integer/clamp n)
+
+let example0 = assert : nonPositive +1 ≡ False
+
+let example1 = assert : nonPositive +0 ≡ True
+
+let example2 = assert : nonPositive -1 ≡ True
+
+in  nonPositive

--- a/Prelude/Integer/package.dhall
+++ b/Prelude/Integer/package.dhall
@@ -28,6 +28,18 @@
 , negate =
       ./negate sha256:2373c992e1de93634bc6a8781eb073b2a92a70170133e49762a785f3a136df5d
     ? ./negate
+, negative =
+      ./negative sha256:23e4b3c61eea9e878a7f83bf25fd0ea2c6a6d60174890d65be885828b690a570
+    ? ./negative
+, nonNegative =
+      ./nonNegative sha256:b463373f070df6b1c8c7082051e0810fee38b360bab35256187c8c2b6af5c663
+    ? ./nonNegative
+, nonPositive =
+      ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+    ? ./nonPositive
+, positive =
+      ./positive sha256:7bdbf50fcdb83d01f74c7e2a92bf5c9104eff5d8c5b4587e9337f0caefcfdbe3
+    ? ./positive
 , show =
       ./show sha256:ecf8b0594cd5181bc45d3b7ea0d44d3ba9ad5dac6ec17bb8968beb65f4b1baa9
     ? ./show

--- a/Prelude/Integer/package.dhall
+++ b/Prelude/Integer/package.dhall
@@ -11,16 +11,16 @@
       ./equal sha256:2d99a205086aa77eea17ae1dab22c275f3eb007bccdc8d9895b93497ebfc39f8
     ? ./equal
 , greaterThan =
-      ./greaterThan sha256:0c9b847676939f9d6c462fd78fc5b010150dd3ce67b6e9ac6b8af7b902093a95
+      ./greaterThan sha256:d23affd73029fc9aaf867c2c7b86510ca2802d3f0d1f3e1d1a93ffd87b7cb64b
     ? ./greaterThan
 , greaterThanEqual =
-      ./greaterThanEqual sha256:4bc016975e600f4c45031c5b5d7722ac6c5b1e429cb12e5407e213d3591e5515
+      ./greaterThanEqual sha256:a9fa2dc5cd6067a23b39d7fe8d14a63109583b320429fb0e446658a5aae0a958
     ? ./greaterThanEqual
 , lessThan =
-      ./lessThan sha256:1d6492e394d36c21ad93dbb015b927771b137e7cf7624994838e8e0a4798213a
+      ./lessThan sha256:eeaa0081d10c6c97464ef193c40f1aa5cbb12f0202972ab42f3d310c2fd6a3f0
     ? ./lessThan
 , lessThanEqual =
-      ./lessThanEqual sha256:b58763a060fc19f0b3614183488a99fb1779960d002bc571bb159c105485c2cf
+      ./lessThanEqual sha256:e3cca9f3942f81fa78a2bea23c0c24519c67cfe438116c38e797e12dcd26f6bc
     ? ./lessThanEqual
 , multiply =
       ./multiply sha256:dcb1ed7c8475ece8d67db92cd249fc728541778ff82509e28c3760e341880e4d

--- a/Prelude/Integer/positive
+++ b/Prelude/Integer/positive
@@ -1,0 +1,24 @@
+{-
+Returns `True` for any `Integer` greater than `+0`.
+
+`positive` is more efficient than `./greaterThan +0` or `./greaterThanEqual +1`.
+-}
+let not =
+        ../Bool/not sha256:723df402df24377d8a853afed08d9d69a0a6d86e2e5b2bac8960b0d4756c7dc4
+      ? ../Bool/not
+
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
+
+let positive
+    : Integer → Bool
+    = λ(n : Integer) → not (nonPositive n)
+
+let example0 = assert : positive +1 ≡ True
+
+let example1 = assert : positive +0 ≡ False
+
+let example2 = assert : positive -1 ≡ False
+
+in  positive

--- a/Prelude/Integer/subtract
+++ b/Prelude/Integer/subtract
@@ -1,7 +1,9 @@
 {-
 `subtract m n` computes `n - m`.
 -}
-let nonPositive = λ(x : Integer) → Natural/isZero (Integer/clamp x)
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
 
 let subtractNonNegative =
         λ(xi : Integer)

--- a/Prelude/Integer/toNatural
+++ b/Prelude/Integer/toNatural
@@ -1,14 +1,14 @@
 {-
 Convert an `Integer` to an `Optional Natural`, with negative numbers becoming `None Natural`.
 -}
+let nonNegative =
+        ./nonNegative sha256:b463373f070df6b1c8c7082051e0810fee38b360bab35256187c8c2b6af5c663
+      ? ./nonNegative
+
 let toNatural
     : Integer → Optional Natural
     =   λ(n : Integer)
-      →       if Natural/isZero (Integer/clamp (Integer/negate n))
-
-        then  Some (Integer/clamp n)
-
-        else  None Natural
+      → if nonNegative n then Some (Integer/clamp n) else None Natural
 
 let example0 = assert : toNatural +7 ≡ Some 7
 

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -8,7 +8,7 @@
       ./Function/package.dhall sha256:74c3822b98b9d37f9f820af8e1a7ee790bcfac03050eabd45af4a255fb93e026
     ? ./Function/package.dhall
 , Integer =
-      ./Integer/package.dhall sha256:1a48e81ceee85f98aaafe1cd4963a6e27aba91502d012fd76bbb10bedf108402
+      ./Integer/package.dhall sha256:56248f45f3d0ced91db3b4b687ccf43ee57e53ecc86e8f453c1487695f042387
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -8,7 +8,7 @@
       ./Function/package.dhall sha256:74c3822b98b9d37f9f820af8e1a7ee790bcfac03050eabd45af4a255fb93e026
     ? ./Function/package.dhall
 , Integer =
-      ./Integer/package.dhall sha256:56248f45f3d0ced91db3b4b687ccf43ee57e53ecc86e8f453c1487695f042387
+      ./Integer/package.dhall sha256:d1a572ca3a764781496847e4921d7d9a881c18ffcfac6ae28d0e5299066938a0
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -32,6 +32,10 @@
     , lessThanEqual : ∀(x : Integer) → ∀(y : Integer) → Bool
     , multiply : ∀(m : Integer) → ∀(n : Integer) → Integer
     , negate : Integer → Integer
+    , negative : ∀(n : Integer) → Bool
+    , nonNegative : ∀(n : Integer) → Bool
+    , nonPositive : ∀(n : Integer) → Bool
+    , positive : ∀(n : Integer) → Bool
     , show : Integer → Text
     , subtract : ∀(m : Integer) → ∀(n : Integer) → Integer
     , toDouble : Integer → Double


### PR DESCRIPTION
… as suggested by @Gabriel439 in https://github.com/dhall-lang/dhall-lang/pull/844#discussion_r354457759.

This includes a small optimization in lessThanEqual:
If the first number is non-positive, we can already return True if the second number is non-negative – it need not be positive.