### PR TITLE
[RFC] Prelude: Add Integer.ifPositive

### DIFF
--- a/Prelude/Integer/abs
+++ b/Prelude/Integer/abs
@@ -1,14 +1,15 @@
 {-
 Returns the absolute value of an `Integer`, i.e. its non-negative value.
 -}
+let ifPositive =
+        ./ifPositive sha256:5d489fbcc2da522928dd9ca6dff957eeba67841928d2fe928b7c2b518166b233
+      ? ./ifPositive
+
+let identity = λ(n : Natural) → n
+
 let abs
     : Integer → Natural
-    =   λ(n : Integer)
-      →       if Natural/isZero (Integer/clamp n)
-
-        then  Integer/clamp (Integer/negate n)
-
-        else  Integer/clamp n
+    = ifPositive Natural identity identity
 
 let example0 = assert : abs +7 ≡ 7
 

--- a/Prelude/Integer/add
+++ b/Prelude/Integer/add
@@ -2,7 +2,7 @@
 `add m n` computes `m + n`.
 -}
 let Integer/subtract =
-        ./subtract sha256:a34d36272fa8ae4f1ec8b56222fe8dc8a2ec55ec6538b840de0cbe207b006fda
+        ./subtract sha256:024225efd0c667586b73f66a68e8f26822f83e0fba6633697f1fbcbf4008b2ed
       ? ./subtract
 
 let add

--- a/Prelude/Integer/ifPositive
+++ b/Prelude/Integer/ifPositive
@@ -1,0 +1,30 @@
+{-
+A helper for destructuring `Integer`s via `Natural` operations.
+
+In `ifPositive T true false n` , the `true` Function is used when `n` is in the
+range `+1..∞` and applied to the corresponding `Natural`.
+`false` is used when `n` is in the range `-∞..+0` and applied to the
+corresponding negated `Natural in the range `0..∞`.
+-}
+let nonPositive =
+        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
+      ? ./nonPositive
+
+let ifPositive
+    : ∀(a : Type) → (Natural → a) → (Natural → a) → Integer → a
+    =   λ(a : Type)
+      → λ(true : Natural → a)
+      → λ(false : Natural → a)
+      → λ(i : Integer)
+      →       if nonPositive i
+
+        then  false (Integer/clamp (Integer/negate i))
+
+        else  true (Integer/clamp i)
+
+let example =
+      let abs = ifPositive Natural (λ(n : Natural) → n) (λ(n : Natural) → n)
+
+      in  assert : abs -3 ≡ 3
+
+in  ifPositive

--- a/Prelude/Integer/multiply
+++ b/Prelude/Integer/multiply
@@ -1,33 +1,26 @@
 {-
 `multiply m n` computes `m * n`.
 -}
-
-let nonPositive =
-        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
-      ? ./nonPositive
-
-let multiplyNonNegative =
-        λ(x : Integer)
-      → λ(y : Integer)
-      → Natural/toInteger (Integer/clamp x * Integer/clamp y)
+let ifPositive =
+        ./ifPositive sha256:5d489fbcc2da522928dd9ca6dff957eeba67841928d2fe928b7c2b518166b233
+      ? ./ifPositive
 
 let multiply
     : Integer → Integer → Integer
-    =   λ(m : Integer)
-      → λ(n : Integer)
-      →       if nonPositive m
-
-        then        if nonPositive n
-
-              then  multiplyNonNegative (Integer/negate m) (Integer/negate n)
-
-              else  Integer/negate (multiplyNonNegative (Integer/negate m) n)
-
-        else  if nonPositive n
-
-        then  Integer/negate (multiplyNonNegative m (Integer/negate n))
-
-        else  multiplyNonNegative m n
+    = ifPositive
+        (Integer → Integer)
+        (   λ(x : Natural)
+          → ifPositive
+              Integer
+              (λ(y : Natural) → Natural/toInteger (x * y))
+              (λ(y : Natural) → Integer/negate (Natural/toInteger (x * y)))
+        )
+        (   λ(x : Natural)
+          → ifPositive
+              Integer
+              (λ(y : Natural) → Integer/negate (Natural/toInteger (x * y)))
+              (λ(y : Natural) → Natural/toInteger (x * y))
+        )
 
 let example0 = assert : multiply +3 +5 ≡ +15
 

--- a/Prelude/Integer/package.dhall
+++ b/Prelude/Integer/package.dhall
@@ -2,7 +2,7 @@
       ./abs sha256:35212fcbe1e60cb95b033a4a9c6e45befca4a298aa9919915999d09e69ddced1
     ? ./abs
 , add =
-      ./add sha256:7da1306a0bf87c5668beead2a1db1b18861e53d7ce1f38057b2964b649f59c3b
+      ./add sha256:a9ab3e060bd5b859fa3494997fc928a63c28abd016839780f13a5d3aeca0c2dd
     ? ./add
 , clamp =
       ./clamp sha256:ea42096cf3e024fadfaf910e0b839005b0ea7514fff11e5a3950a77694d9c5d2
@@ -44,7 +44,7 @@
       ./show sha256:ecf8b0594cd5181bc45d3b7ea0d44d3ba9ad5dac6ec17bb8968beb65f4b1baa9
     ? ./show
 , subtract =
-      ./subtract sha256:a34d36272fa8ae4f1ec8b56222fe8dc8a2ec55ec6538b840de0cbe207b006fda
+      ./subtract sha256:024225efd0c667586b73f66a68e8f26822f83e0fba6633697f1fbcbf4008b2ed
     ? ./subtract
 , toDouble =
       ./toDouble sha256:77bc5d635dc4d952f37cc96f2a681d5ac503b4e8b21fc00055b1946adb5beda7

--- a/Prelude/Integer/package.dhall
+++ b/Prelude/Integer/package.dhall
@@ -23,7 +23,7 @@
       ./lessThanEqual sha256:e3cca9f3942f81fa78a2bea23c0c24519c67cfe438116c38e797e12dcd26f6bc
     ? ./lessThanEqual
 , multiply =
-      ./multiply sha256:dcb1ed7c8475ece8d67db92cd249fc728541778ff82509e28c3760e341880e4d
+      ./multiply sha256:93a94f27d44c2890716184dc3888a67b6c303ea28772185fc46a5d5c853994fd
     ? ./multiply
 , negate =
       ./negate sha256:2373c992e1de93634bc6a8781eb073b2a92a70170133e49762a785f3a136df5d

--- a/Prelude/Integer/subtract
+++ b/Prelude/Integer/subtract
@@ -1,46 +1,37 @@
 {-
 `subtract m n` computes `n - m`.
 -}
-let nonPositive =
-        ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
-      ? ./nonPositive
+let ifPositive =
+        ./ifPositive sha256:5d489fbcc2da522928dd9ca6dff957eeba67841928d2fe928b7c2b518166b233
+      ? ./ifPositive
 
-let subtractNonNegative =
-        λ(xi : Integer)
-      → λ(yi : Integer)
-      → let xn = Integer/clamp xi
+let subtract =
+        λ(x : Natural)
+      → λ(y : Natural)
+      → let d = Natural/subtract x y
 
-        let yn = Integer/clamp yi
+        in        if Natural/isZero d
 
-        let dn = Natural/subtract xn yn
+            then  Integer/negate (Natural/toInteger (Natural/subtract y x))
 
-        in        if Natural/isZero dn
-
-            then  Integer/negate (Natural/toInteger (Natural/subtract yn xn))
-
-            else  Natural/toInteger dn
+            else  Natural/toInteger d
 
 let subtract
     : Integer → Integer → Integer
-    =   λ(m : Integer)
-      → λ(n : Integer)
-      →       if nonPositive m
-
-        then        if nonPositive n
-
-              then  subtractNonNegative (Integer/negate n) (Integer/negate m)
-
-              else  Natural/toInteger
-                      (Integer/clamp (Integer/negate m) + Integer/clamp n)
-
-        else  if nonPositive n
-
-        then  Integer/negate
-                ( Natural/toInteger
-                    (Integer/clamp m + Integer/clamp (Integer/negate n))
-                )
-
-        else  subtractNonNegative m n
+    = ifPositive
+        (Integer → Integer)
+        (   λ(m : Natural)
+          → ifPositive
+              Integer
+              (λ(n : Natural) → subtract m n)
+              (λ(n : Natural) → Integer/negate (Natural/toInteger (m + n)))
+        )
+        (   λ(m : Natural)
+          → ifPositive
+              Integer
+              (λ(n : Natural) → Natural/toInteger (m + n))
+              (λ(n : Natural) → subtract n m)
+        )
 
 let example0 = assert : subtract +3 +5 ≡ +2
 

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -8,7 +8,7 @@
       ./Function/package.dhall sha256:74c3822b98b9d37f9f820af8e1a7ee790bcfac03050eabd45af4a255fb93e026
     ? ./Function/package.dhall
 , Integer =
-      ./Integer/package.dhall sha256:9bfafac111eedd98be1a25d7ed199ac326a60c4d44ca7f86c975dc3d93ec8fe1
+      ./Integer/package.dhall sha256:19b2aad086c171f24c66fbff27f1db8534c7f690fedeb923957424d1c0c4b545
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -8,7 +8,7 @@
       ./Function/package.dhall sha256:74c3822b98b9d37f9f820af8e1a7ee790bcfac03050eabd45af4a255fb93e026
     ? ./Function/package.dhall
 , Integer =
-      ./Integer/package.dhall sha256:d1a572ca3a764781496847e4921d7d9a881c18ffcfac6ae28d0e5299066938a0
+      ./Integer/package.dhall sha256:9bfafac111eedd98be1a25d7ed199ac326a60c4d44ca7f86c975dc3d93ec8fe1
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall sha256:f0fdab7ab30415c128d89424589c42a15c835338be116fa14484086e4ba118d7


### PR DESCRIPTION
`ifPositive` encodes the standard pattern for destructuring an `Integer` by testing it with `nonPositive` and converting it to `Natural`.

The changes in `abs`, `multiply` and `subtract` are mostly for demonstration purposes – I wouldn't mind reverting them.

If anyone has an idea for a better name, I'd be happy to change it!