### PR TITLE
Update nixops/dhall-haskell.json

### DIFF
--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell",
-  "rev": "1a831d181341e7fb52fd109baaef620ef7e42e0f",
-  "date": "2019-11-17T18:45:51+01:00",
-  "sha256": "0fwdlg00ksw2ksccvs3ql3blddr6k3c3if1grmzyfb60qmpkz4rv",
+  "rev": "1c592f402fcc85d28c9394b56669c438dee4a23d",
+  "date": "2019-12-16T02:00:33+00:00",
+  "sha256": "19vixhgaq6cgx6ifqpg0m8d8g5xpqv77nq4j82is3b9bwm336nr7",
   "fetchSubmodules": true
 }


### PR DESCRIPTION
#862 currently fails in CI with

    dhall:
    ↳ /"/"/nix/store/ypbpklfy66bzqf8q1bgsq7cdrw5np4bi-expected-prelude/Integer/subtract

    Error: Invalid input

    /nix/store/ypbpklfy66bzqf8q1bgsq7cdrw5np4bi-expected-prelude/Integer/subtract:21:9:
       |
    21 |     = ifPositive
       |         ^^
    unexpected "Po"
    expecting whitespace

This update includes https://github.com/dhall-lang/dhall-haskell/commit/7d01d4685add2571f3dfa509f3150f232682c95d which enables dhall to parse variable names with keyword prefixes.