### PR TITLE
Fix link to prelude

### DIFF
--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -301,4 +301,5 @@
 
 *   Prelude
 
-    You can find latest Prelude of importable functions at https://prelude.dhall-lang.org/
+    You can find latest Prelude of importable functions at 
+    [prelude.dhall-lang.org](https://prelude.dhall-lang.org/)


### PR DESCRIPTION
Otherwise the link doesn't work on the docs.dhall-lang.org website