### PR TITLE
Mention comments in cheatsheet

### DIFF
--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -302,3 +302,20 @@
 *   Prelude
 
     You can find latest Prelude of importable functions at https://prelude.dhall-lang.org/
+
+*   Comments
+
+    Dhall has single-line and block comments (with a syntax borrowed from Haskell):
+
+    ```dhall
+    -- single-line comment
+
+    True -- Line comments may follow code on the same line
+
+    {- block
+       comment -}
+
+    {- block comments can be {- nested -} -}
+
+    let x {- block comments can appear inside of expressions like whitespace -} = 1 in x
+    ```


### PR DESCRIPTION
I think it would be nice to be able to quickly look up the comments syntax in the cheatsheet. (That's where I went to look for them.)