### PR TITLE
Add myself as a user with root privileges on `dhall-lang.org`

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -95,6 +95,8 @@
       in
         [ modifyHydra ];
 
+    security.sudo.wheelNeedsPassword = false;
+
     services = {
       fail2ban.enable = true;
 
@@ -455,6 +457,16 @@
 
         wantedBy = [ "multi-user.target" ];
       };
+    };
+
+    users.users.gabriel = {
+      isNormalUser = true;
+
+      extraGroups = [ "wheel" ];
+
+      openssh.authorizedKeys.keys = [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGquu14+nGeuczn/u9wr2TD8L123DMOGLutPpXMDgMz5 gabriel@chickle"
+      ];
     };
 
     virtualisation.docker = {


### PR DESCRIPTION
This is the first step in making it easier for other people to
manage this machine.  The full set of steps I plan after this are:

* Switch from using NixOps to using NixOS

* Install a service to automatically have `dhall-lang.org` track
  `master`

If you would like to also maintain this machine you can create a pull
request like this one to add yourself as an administrative user.