### PR TITLE
Configure dhall-lang.org to automatically track `master`

### DIFF
--- a/nixops/dhallLangNixpkgs.nix
+++ b/nixops/dhallLangNixpkgs.nix
@@ -1,0 +1,5 @@
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/2437bb394392322d28d4244a63ab9b7ae8cc18dd.tar.gz";
+
+  sha256 = "1c26n0z2zsapc1hxww1rpj056f8ah76f11h4f6wqjzjlj40i8jrq";
+}

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -314,10 +314,10 @@
 
         discourseSmtpPassword =
           let
-            eval = builtins.tryEval (builtins.readFile ./discourseSmtpPassword);
+            path = ./discourseSmtpPassword;
 
           in
-            if eval.success then eval.value else "";
+            if builtins.pathExists path then builtins.readFile path else "";
 
         discourseConfiguration =
           pkgs.writeText "discourse-app.yaml" ''

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -36,7 +36,7 @@
           "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
           "hydra/machines".text = ''
-            hydra-queue-runner@hydra x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local
+            hydra-queue-runner@dhall-lang.org x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local
           '';
         };
 

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -312,6 +312,13 @@
 
         varDirectory = dirOf discourseDirectory;
 
+        discourseSmtpPassword =
+          let
+            eval = builtins.tryEval (builtins.readFile ./discourseSmtpPassword);
+
+          in
+            if eval.success then eval.value else "";
+
         discourseConfiguration =
           pkgs.writeText "discourse-app.yaml" ''
             templates:
@@ -345,7 +352,7 @@
 
               DISCOURSE_SMTP_USER_NAME: discourse@dhall-lang.org
 
-              DISCOURSE_SMTP_PASSWORD: '${builtins.readFile ./discourseSmtpPassword}'
+              DISCOURSE_SMTP_PASSWORD: '${discourseSmtpPassword}'
 
               # TODO: Use CDN?
               #

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -36,7 +36,7 @@
           "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
           "hydra/machines".text = ''
-            hydra-queue-runner@dhall-lang.org x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local
+            hydra-queue-runner@dhall-lang.org x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local,big-parallel
           '';
         };
 

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -1,481 +1,538 @@
-{ hydra = { config, pkgs, ... }: {
-    imports =
-      let
-        nixos-mailserver =
-          builtins.fetchTarball {
-            url = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/archive/v2.2.1/nixos-mailserver-v2.2.0.tar.gz";
+{ config, pkgs, ... }: {
+  imports =
+    let
+      nixos-mailserver =
+        builtins.fetchTarball {
+          url = "https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/archive/v2.2.1/nixos-mailserver-v2.2.0.tar.gz";
 
-            sha256 = "03d49v8qnid9g9rha0wg2z6vic06mhp0b049s3whccn1axvs2zzx";
-          };
+          sha256 = "03d49v8qnid9g9rha0wg2z6vic06mhp0b049s3whccn1axvs2zzx";
+        };
+
+    in
+      [ nixos-mailserver ];
+
+  environment = {
+    etc =
+      let
+        toProject = suffix: {
+          name = "hydra/dhall-${suffix}.json";
+
+          value = { text = builtins.toJSON (import ./project.nix suffix); };
+        };
+
+        suffixes = [
+          "bash"
+          "haskell"
+          "json"
+          "kubernetes"
+          "lang"
+          "nix"
+          "text"
+          "to-cabal"
+        ];
 
       in
-        [ nixos-mailserver ];
+        builtins.listToAttrs (builtins.map toProject suffixes) // {
+          "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
-    environment = {
-      etc =
-        let
-          toProject = suffix: {
-            name = "hydra/dhall-${suffix}.json";
+          "hydra/machines".text = ''
+            hydra-queue-runner@hydra x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local
+          '';
+        };
 
-            value = { text = builtins.toJSON (import ./project.nix suffix); };
-          };
+    systemPackages = [ pkgs.hydra ];
+  };
 
-          suffixes = [
-            "bash"
-            "haskell"
-            "json"
-            "kubernetes"
-            "lang"
-            "nix"
-            "text"
-            "to-cabal"
-          ];
+  mailserver = {
+    enable = true;
 
-        in
-          builtins.listToAttrs (builtins.map toProject suffixes) // {
-            "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
+    certificateScheme = 3;
 
-            "hydra/machines".text = ''
-              hydra-queue-runner@hydra x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local
-            '';
-          };
+    domains = [ "discourse.dhall-lang.org" "dhall-lang.org" ];
 
-      systemPackages = [ pkgs.hydra ];
+    enableImap = true;
+    enableImapSsl = true;
+    enablePop3 = true;
+    enablePop3Ssl = true;
+
+    fqdn = "mail.dhall-lang.org";
+
+    loginAccounts = {
+      "discourse@dhall-lang.org" = {
+        hashedPassword = "$6$.vCIyiyMp4/HzO$FyW1OMFpL7tmPQvfDs2wDfhn5qTZW4NePBfDsrFQxPepIISrFYyjISeZS2kAHO6F/AolD7sus2mJUXsQUgCfv0";
+
+        aliases = [ "postmaster@dhall-lang.org" ];
+      };
     };
 
-    mailserver = {
-      enable = true;
+    policydSPFExtraConfig = ''
+      skip_addresses = 172.17.0.2/32
+    '';
+  };
 
-      certificateScheme = 3;
+  networking.firewall.allowedTCPPorts = [ 22 80 443 ];
 
-      domains = [ "discourse.dhall-lang.org" "dhall-lang.org" ];
+  nix = {
+    autoOptimiseStore = true;
 
-      enableImap = true;
-      enableImapSsl = true;
-      enablePop3 = true;
-      enablePop3Ssl = true;
+    gc.automatic = true;
 
-      fqdn = "mail.dhall-lang.org";
+    useSandbox = false;
 
-      loginAccounts = {
-        "discourse@dhall-lang.org" = {
-          hashedPassword = "$6$.vCIyiyMp4/HzO$FyW1OMFpL7tmPQvfDs2wDfhn5qTZW4NePBfDsrFQxPepIISrFYyjISeZS2kAHO6F/AolD7sus2mJUXsQUgCfv0";
+    trustedUsers = [ "gabriel" ];
+  };
 
-          aliases = [ "postmaster@dhall-lang.org" ];
-        };
+  nixpkgs.overlays =
+    let
+      modifyHydra = packagesNew: packagesOld: {
+        hydra = packagesOld.hydra.overrideAttrs (old: {
+            patches = (old.patches or []) ++ [
+              ./hydra.patch
+              ./no-restrict-eval.patch
+            ];
+          }
+        );
       };
 
-      policydSPFExtraConfig = ''
-        skip_addresses = 172.17.0.2/32
+    in
+      [ modifyHydra ];
+
+  programs.ssh.knownHosts = [
+    { hostNames = [ "github.com" ];
+
+      publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
+    }
+  ];
+
+  security.sudo.wheelNeedsPassword = false;
+
+  services = {
+    fail2ban.enable = true;
+
+    hydra = {
+      buildMachinesFiles = [ "/etc/hydra/machines" ];
+
+      enable = true;
+
+      extraConfig = ''
+        <githubstatus>
+          jobs = .*:.*:dhall.*
+          inputs = src
+          authorization = dhall-lang
+          context = hydra
+        </githubstatus>
       '';
+
+      hydraURL = "https://hydra.dhall-lang.org";
+
+      listenHost = "127.0.0.1";
+
+      logo = ../img/dhall-logo.png;
+
+      notificationSender = "noreply@dhall-lang.org";
     };
 
-    networking.firewall.allowedTCPPorts = [ 22 80 443 ];
-
-    nix = {
-      autoOptimiseStore = true;
-
-      gc.automatic = true;
-
-      useSandbox = false;
-    };
-
-    nixpkgs.overlays =
-      let
-        modifyHydra = packagesNew: packagesOld: {
-          hydra = packagesOld.hydra.overrideAttrs (old: {
-              patches = (old.patches or []) ++ [
-                ./hydra.patch
-                ./no-restrict-eval.patch
-              ];
-            }
-          );
-        };
-
-      in
-        [ modifyHydra ];
-
-    security.sudo.wheelNeedsPassword = false;
-
-    services = {
-      fail2ban.enable = true;
-
-      hydra = {
-        buildMachinesFiles = [ "/etc/hydra/machines" ];
-
-        enable = true;
-
-        extraConfig = ''
-          <githubstatus>
-            jobs = .*:.*:dhall.*
-            inputs = src
-            authorization = dhall-lang
-            context = hydra
-          </githubstatus>
-        '';
-
-        hydraURL = "https://hydra.dhall-lang.org";
-
-        listenHost = "127.0.0.1";
-
-        logo = ../img/dhall-logo.png;
-
-        notificationSender = "noreply@dhall-lang.org";
-      };
-
-      nginx = {
-        enable = true;
-
-        recommendedGzipSettings = true;
-
-        recommendedOptimisation = true;
-
-        recommendedTlsSettings = true;
-
-        virtualHosts =
-          let
-            latestRelease = "v13.0.0";
-
-            prelude = {
-              forceSSL = true;
-
-              enableACME = true;
-
-              locations."/" = {
-                extraConfig = ''
-                  if ($request_method = 'OPTIONS') {
-                    add_header 'Access-Control-Allow-Origin' "*";
-                    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                    add_header 'Access-Control-Max-Age' 600;
-                    add_header 'Content-Type' 'text/plain; charset=utf-8';
-                    add_header 'Content-Length' 0;
-                    return 204;
-                  }
-                  if ($request_method = 'GET') {
-                    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-                    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-                    add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-                  }
-
-                  rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/${latestRelease}/Prelude redirect;
-                  rewrite ^/(v[^/]+)$ https://github.com/dhall-lang/dhall-lang/tree/$1/Prelude redirect;
-                  rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 break;
-                  rewrite ^/(.*)$ /dhall-lang/dhall-lang/${latestRelease}/Prelude/$1 break;
-                '';
-                proxyPass = "https://raw.githubusercontent.com";
-              };
-            };
-
-          in
-            { "dhall-lang.org" =
-                let
-                  json = builtins.fromJSON (builtins.readFile ./dhall-haskell.json);
-
-                  dhall-haskell =
-                    pkgs.fetchFromGitHub {
-                      owner = "dhall-lang";
-
-                      repo = "dhall-haskell";
-
-                      inherit (json) rev sha256 fetchSubmodules;
-                    };
-
-                dhall-haskell-derivations =
-                  import "${dhall-haskell}/default.nix";
-
-                inherit (dhall-haskell-derivations) website;
-
-              in
-                { forceSSL = true;
-
-                  default = true;
-
-                  enableACME = true;
-
-                  locations."/" = {
-                    index = "index.html";
-
-                    root = "${website}";
-                  };
-                };
-
-            "cache.dhall-lang.org" = {
-              forceSSL = true;
-
-              enableACME = true;
-
-              locations."/".proxyPass = "http://127.0.0.1:5000";
-            };
-
-            "discourse.dhall-lang.org" = {
-              forceSSL = true;
-
-              extraConfig = ''
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-Server $host;
-                proxy_set_header Accept-Encoding "";
-              '';
-
-              enableACME = true;
-
-              locations."/".proxyPass = "http://unix:/var/discourse/shared/standalone/nginx.http.sock";
-            };
-
-            "docs.dhall-lang.org" =
-              let
-                dhall-lang-derivations = import ../release.nix { };
-
-                inherit (dhall-lang-derivations) docs;
-
-              in
-                { forceSSL = true;
-
-                  enableACME = true;
-
-                  locations."/" = {
-                    index = "index.html";
-
-                    root = "${docs}";
-                  };
-                };
-
-            "hydra.dhall-lang.org" = {
-              forceSSL = true;
-
-              extraConfig = ''
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header X-Forwarded-Host $host;
-                proxy_set_header X-Forwarded-Server $host;
-                proxy_set_header Accept-Encoding "";
-              '';
-
-              enableACME = true;
-
-              locations."/".proxyPass = "http://127.0.0.1:3000";
-            };
-
-            "prelude.dhall-lang.org" = prelude;
-
-            # Same as `prelude.dhall-lang.org` except requires a header named
-            # `Test` to be present to authorize requests.  This is used to test
-            # support for header forwarding for the test suite.
-            "test.dhall-lang.org" =
-              pkgs.lib.mkMerge
-                [ prelude
-                  { locations."/".extraConfig = ''
-                      if ($http_test = "") {
-                        return 403;
-                      }
-                    '';
-                  }
-                ];
-          };
-      };
-
-      nix-serve = {
-        bindAddress = "127.0.0.1";
-
-        enable = true;
-
-        secretKeyFile = "/etc/nix-serve/nix-serve.sec";
-      };
-
-      openssh.enable = true;
-    };
-
-    systemd.services = {
-      discourse =
-        let
-          discourseDirectory = "/var/discourse_docker";
-
-          varDirectory = dirOf discourseDirectory;
-
-          discourseConfiguration =
-            pkgs.writeText "discourse-app.yaml" ''
-              templates:
-                - "templates/postgres.template.yml"
-                - "templates/redis.template.yml"
-                - "templates/web.template.yml"
-                - "templates/web.ratelimited.template.yml"
-                - "templates/web.socketed.template.yml"
-
-              expose: []
-
-              params:
-                db_default_text_search_config: "pg_catalog.english"
-
-                db_shared_buffers: "256MB"
-
-                db_work_mem: "40MB"
-
-                version: 41f09ee29c44424901054a7dbe0bf8c0a9b86742
-
-              env:
-                LANG: en_US.UTF-8
-
-                UNICORN_WORKERS: 1
-
-                DISCOURSE_HOSTNAME: 'discourse.dhall-lang.org'
-
-                DISCOURSE_DEVELOPER_EMAILS: 'Gabriel439@gmail.com'
-
-                DISCOURSE_SMTP_ADDRESS: mail.dhall-lang.org
-
-                DISCOURSE_SMTP_USER_NAME: discourse@dhall-lang.org
-
-                DISCOURSE_SMTP_PASSWORD: '${builtins.readFile ./discourseSmtpPassword}'
-
-                # TODO: Use CDN?
-                #
-                #DISCOURSE_CDN_URL: https://discourse-cdn.example.com
-
-              volumes:
-                - volume:
-                    host: /var/discourse/shared/standalone
-                    guest: /shared
-                - volume:
-                    host: /var/discourse/shared/standalone/log/var-log
-                    guest: /var/log
-
-              hooks:
-                after_code:
-                  - exec:
-                      cd: $home/plugins
-                      cmd:
-                        - git clone https://github.com/discourse/docker_manager.git
-
-              run: []
-            '';
-
-        in
-          { after = [ "network.target" "docker.service" ];
-
-            path = [ pkgs.git pkgs.nettools pkgs.which pkgs.gawk pkgs.docker ];
-
-            script = ''
-              if [[ ! -e ${discourseDirectory} ]]; then
-                ${pkgs.coreutils}/bin/mkdir --parents ${varDirectory}
-
-                cd ${varDirectory}
-
-                ${pkgs.git}/bin/git clone https://github.com/discourse/discourse_docker.git
-              fi
-
-              cd ${discourseDirectory}
-
-              ${pkgs.git}/bin/git checkout 77edaf675a47729bb693d09b94713a2a98b5d686
-
-              ${pkgs.coreutils}/bin/cp ${discourseConfiguration} ${discourseDirectory}/containers/app.yml
-
-              ${pkgs.bash}/bin/bash ${discourseDirectory}/launcher rebuild app
-            '';
-
-            wantedBy = [ "multi-user.target" ];
-
-            wants = [ "docker.service" ];
-          };
-
-      generate-hydra-queue-runner-key-pair = {
-        script =
-          let
-            keyDirectory = "/etc/keys/hydra-queue-runner";
-
-            user = "hydra-queue-runner";
-
-            group = "hydra";
-
-            privateKey = "${keyDirectory}/${user}_rsa";
-
-            publicKey = "${privateKey}.pub";
-
-            authorizedKeysDirectory = "/etc/ssh/authorized_keys.d";
-
-            authorizedKeysFile = "${authorizedKeysDirectory}/${user}";
-          in
-            ''
-              if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
-                mkdir -p ${keyDirectory}
-
-                ${pkgs.openssh}/bin/ssh-keygen -t rsa -N "" -f ${privateKey} -C "${user}@hydra" >/dev/null
-
-                chown -R ${user}:${group} ${keyDirectory}
-              fi
-
-              if ! [ -e ${authorizedKeysFile} ]; then
-                mkdir -p "${authorizedKeysDirectory}"
-
-                cp ${publicKey} ${authorizedKeysFile}
-              fi
-            '';
-
-        serviceConfig.Type = "oneshot";
-
-        wantedBy = [ "multi-user.target" ];
-      };
-
-      kick-hydra-evaluator = {
-        script = ''
-          ${pkgs.systemd}/bin/systemctl restart hydra-evaluator
-        '';
-
-        startAt = "*:0/5";
-
-        wantedBy = [ "multi-user.target" ];
-      };
-
-      nix-serve-keys = {
-        script =
-          let
-            keyDirectory = "/etc/nix-serve";
-
-            privateKey = "${keyDirectory}/nix-serve.sec";
-
-            publicKey = "${keyDirectory}/nix-serve.pub";
-
-          in
-            ''
-              if [ ! -e ${keyDirectory} ]; then
-                mkdir -p ${keyDirectory}
-              fi
-
-              if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
-                ${pkgs.nix}/bin/nix-store --generate-binary-cache-key cache.dhall-lang.org ${privateKey} ${publicKey}
-              fi
-
-              chown -R nix-serve:hydra /etc/nix-serve
-            '';
-
-        serviceConfig.Type = "oneshot";
-
-        wantedBy = [ "multi-user.target" ];
-      };
-    };
-
-    users.users.gabriel = {
-      isNormalUser = true;
-
-      extraGroups = [ "wheel" ];
-
-      openssh.authorizedKeys.keys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGquu14+nGeuczn/u9wr2TD8L123DMOGLutPpXMDgMz5 gabriel@chickle"
-      ];
-    };
-
-    virtualisation.docker = {
+    nginx = {
       enable = true;
 
-      # Discourse complains if you use anything other than AUFS.  That warning
-      # can be overriden, but it's easier to just use AUFS since nothing else on
-      # this system uses `docker`
-      storageDriver = "aufs";
+      recommendedGzipSettings = true;
+
+      recommendedOptimisation = true;
+
+      recommendedTlsSettings = true;
+
+      virtualHosts =
+        let
+          latestRelease = "v13.0.0";
+
+          prelude = {
+            forceSSL = true;
+
+            enableACME = true;
+
+            locations."/" = {
+              extraConfig = ''
+                if ($request_method = 'OPTIONS') {
+                  add_header 'Access-Control-Allow-Origin' "*";
+                  add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+                  add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                  add_header 'Access-Control-Max-Age' 600;
+                  add_header 'Content-Type' 'text/plain; charset=utf-8';
+                  add_header 'Content-Length' 0;
+                  return 204;
+                }
+                if ($request_method = 'GET') {
+                  add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+                  add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+                  add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+                }
+
+                rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/${latestRelease}/Prelude redirect;
+                rewrite ^/(v[^/]+)$ https://github.com/dhall-lang/dhall-lang/tree/$1/Prelude redirect;
+                rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 break;
+                rewrite ^/(.*)$ /dhall-lang/dhall-lang/${latestRelease}/Prelude/$1 break;
+              '';
+              proxyPass = "https://raw.githubusercontent.com";
+            };
+          };
+
+        in
+          { "dhall-lang.org" =
+              let
+                json = builtins.fromJSON (builtins.readFile ./dhall-haskell.json);
+
+                dhall-haskell =
+                  pkgs.fetchFromGitHub {
+                    owner = "dhall-lang";
+
+                    repo = "dhall-haskell";
+
+                    inherit (json) rev sha256 fetchSubmodules;
+                  };
+
+              dhall-haskell-derivations =
+                import "${dhall-haskell}/default.nix";
+
+              inherit (dhall-haskell-derivations) website;
+
+            in
+              { forceSSL = true;
+
+                default = true;
+
+                enableACME = true;
+
+                locations."/" = {
+                  index = "index.html";
+
+                  root = "${website}";
+                };
+              };
+
+          "cache.dhall-lang.org" = {
+            forceSSL = true;
+
+            enableACME = true;
+
+            locations."/".proxyPass = "http://127.0.0.1:5000";
+          };
+
+          "discourse.dhall-lang.org" = {
+            forceSSL = true;
+
+            extraConfig = ''
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_set_header X-Forwarded-Server $host;
+              proxy_set_header Accept-Encoding "";
+            '';
+
+            enableACME = true;
+
+            locations."/".proxyPass = "http://unix:/var/discourse/shared/standalone/nginx.http.sock";
+          };
+
+          "docs.dhall-lang.org" =
+            let
+              dhall-lang-derivations = import ../release.nix { };
+
+              inherit (dhall-lang-derivations) docs;
+
+            in
+              { forceSSL = true;
+
+                enableACME = true;
+
+                locations."/" = {
+                  index = "index.html";
+
+                  root = "${docs}";
+                };
+              };
+
+          "hydra.dhall-lang.org" = {
+            forceSSL = true;
+
+            extraConfig = ''
+              proxy_set_header Host $host;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header X-Forwarded-Host $host;
+              proxy_set_header X-Forwarded-Server $host;
+              proxy_set_header Accept-Encoding "";
+            '';
+
+            enableACME = true;
+
+            locations."/".proxyPass = "http://127.0.0.1:3000";
+          };
+
+          "prelude.dhall-lang.org" = prelude;
+
+          # Same as `prelude.dhall-lang.org` except requires a header named
+          # `Test` to be present to authorize requests.  This is used to test
+          # support for header forwarding for the test suite.
+          "test.dhall-lang.org" =
+            pkgs.lib.mkMerge
+              [ prelude
+                { locations."/".extraConfig = ''
+                    if ($http_test = "") {
+                      return 403;
+                    }
+                  '';
+                }
+              ];
+        };
     };
+
+    nix-serve = {
+      bindAddress = "127.0.0.1";
+
+      enable = true;
+
+      secretKeyFile = "/etc/nix-serve/nix-serve.sec";
+    };
+
+    openssh.enable = true;
+  };
+
+  systemd.services = {
+    discourse =
+      let
+        discourseDirectory = "/var/discourse_docker";
+
+        varDirectory = dirOf discourseDirectory;
+
+        discourseConfiguration =
+          pkgs.writeText "discourse-app.yaml" ''
+            templates:
+              - "templates/postgres.template.yml"
+              - "templates/redis.template.yml"
+              - "templates/web.template.yml"
+              - "templates/web.ratelimited.template.yml"
+              - "templates/web.socketed.template.yml"
+
+            expose: []
+
+            params:
+              db_default_text_search_config: "pg_catalog.english"
+
+              db_shared_buffers: "256MB"
+
+              db_work_mem: "40MB"
+
+              version: 41f09ee29c44424901054a7dbe0bf8c0a9b86742
+
+            env:
+              LANG: en_US.UTF-8
+
+              UNICORN_WORKERS: 1
+
+              DISCOURSE_HOSTNAME: 'discourse.dhall-lang.org'
+
+              DISCOURSE_DEVELOPER_EMAILS: 'Gabriel439@gmail.com'
+
+              DISCOURSE_SMTP_ADDRESS: mail.dhall-lang.org
+
+              DISCOURSE_SMTP_USER_NAME: discourse@dhall-lang.org
+
+              DISCOURSE_SMTP_PASSWORD: '${builtins.readFile ./discourseSmtpPassword}'
+
+              # TODO: Use CDN?
+              #
+              #DISCOURSE_CDN_URL: https://discourse-cdn.example.com
+
+            volumes:
+              - volume:
+                  host: /var/discourse/shared/standalone
+                  guest: /shared
+              - volume:
+                  host: /var/discourse/shared/standalone/log/var-log
+                  guest: /var/log
+
+            hooks:
+              after_code:
+                - exec:
+                    cd: $home/plugins
+                    cmd:
+                      - git clone https://github.com/discourse/docker_manager.git
+
+            run: []
+          '';
+
+      in
+        { after = [ "network.target" "docker.service" ];
+
+          path = [ pkgs.git pkgs.nettools pkgs.which pkgs.gawk pkgs.docker ];
+
+          script = ''
+            if [[ ! -e ${discourseDirectory} ]]; then
+              ${pkgs.coreutils}/bin/mkdir --parents ${varDirectory}
+
+              cd ${varDirectory}
+
+              ${pkgs.git}/bin/git clone https://github.com/discourse/discourse_docker.git
+            fi
+
+            cd ${discourseDirectory}
+
+            ${pkgs.git}/bin/git checkout 77edaf675a47729bb693d09b94713a2a98b5d686
+
+            ${pkgs.coreutils}/bin/cp ${discourseConfiguration} ${discourseDirectory}/containers/app.yml
+
+            ${pkgs.bash}/bin/bash ${discourseDirectory}/launcher rebuild app
+          '';
+
+          wantedBy = [ "multi-user.target" ];
+
+          wants = [ "docker.service" ];
+        };
+
+    generate-hydra-queue-runner-key-pair = {
+      script =
+        let
+          keyDirectory = "/etc/keys/hydra-queue-runner";
+
+          user = "hydra-queue-runner";
+
+          group = "hydra";
+
+          privateKey = "${keyDirectory}/${user}_rsa";
+
+          publicKey = "${privateKey}.pub";
+
+          authorizedKeysDirectory = "/etc/ssh/authorized_keys.d";
+
+          authorizedKeysFile = "${authorizedKeysDirectory}/${user}";
+        in
+          ''
+            if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
+              mkdir -p ${keyDirectory}
+
+              ${pkgs.openssh}/bin/ssh-keygen -t rsa -N "" -f ${privateKey} -C "${user}@hydra" >/dev/null
+
+              chown -R ${user}:${group} ${keyDirectory}
+            fi
+
+            if ! [ -e ${authorizedKeysFile} ]; then
+              mkdir -p "${authorizedKeysDirectory}"
+
+              cp ${publicKey} ${authorizedKeysFile}
+            fi
+          '';
+
+      serviceConfig.Type = "oneshot";
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    kick-hydra-evaluator = {
+      script = ''
+        ${pkgs.systemd}/bin/systemctl restart hydra-evaluator
+      '';
+
+      startAt = "*:0/5";
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    nix-serve-keys = {
+      script =
+        let
+          keyDirectory = "/etc/nix-serve";
+
+          privateKey = "${keyDirectory}/nix-serve.sec";
+
+          publicKey = "${keyDirectory}/nix-serve.pub";
+
+        in
+          ''
+            if [ ! -e ${keyDirectory} ]; then
+              mkdir -p ${keyDirectory}
+            fi
+
+            if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
+              ${pkgs.nix}/bin/nix-store --generate-binary-cache-key cache.dhall-lang.org ${privateKey} ${publicKey}
+            fi
+
+            chown -R nix-serve:hydra /etc/nix-serve
+          '';
+
+      serviceConfig.Type = "oneshot";
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    self-deploy =
+      let
+        workingDirectory = "/var/lib/self-deploy";
+
+        owner = "dhall-lang";
+
+        repository = "dhall-lang";
+
+        repositoryDirectory = "${workingDirectory}/${repository}";
+
+        build = "${repositoryDirectory}/result";
+
+      in
+        { wantedBy = [ "multi-user.target" ];
+
+          after = [ "network-online.target" ];
+
+          path = [ pkgs.gnutar pkgs.gzip ];
+
+          serviceConfig.X-RestartIfChanged = false;
+
+          script = ''
+            if [ ! -e ${workingDirectory} ]; then
+              ${pkgs.coreutils}/bin/mkdir --parents ${workingDirectory}
+            fi
+
+            if [ ! -e ${repositoryDirectory} ]; then
+              cd ${workingDirectory}
+              ${pkgs.git}/bin/git clone git@github.com:${owner}/${repository}.git
+            fi
+
+            cd ${repositoryDirectory}
+
+            ${pkgs.git}/bin/git fetch https://github.com/dhall-lang/dhall-lang.git master
+
+            ${pkgs.git}/bin/git checkout FETCH_HEAD
+
+            ${pkgs.nix}/bin/nix-build --attr machine ${repositoryDirectory}/release.nix
+
+            ${pkgs.nix}/bin/nix-env --profile /nix/var/nix/profiles/system --set ${build}
+
+            ${pkgs.git}/bin/git gc --prune=all
+
+            ${build}/bin/switch-to-configuration switch
+          '';
+
+          startAt = "hourly";
+        };
+  };
+
+  users.users.gabriel = {
+    isNormalUser = true;
+
+    extraGroups = [ "wheel" ];
+
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGquu14+nGeuczn/u9wr2TD8L123DMOGLutPpXMDgMz5 gabriel@chickle"
+    ];
+  };
+
+  virtualisation.docker = {
+    enable = true;
+
+    # Discourse complains if you use anything other than AUFS.  That warning
+    # can be overriden, but it's easier to just use AUFS since nothing else on
+    # this system uses `docker`
+    storageDriver = "aufs";
   };
 }

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -102,6 +102,11 @@
 
       publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
     }
+
+    { hostNames = [ "dhall-lang.org" ];
+
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBp/WR0q2LUjpzHDwm03CijnpUyvHS9CDnJYvR0YNBpT";
+    }
   ];
 
   security.sudo.wheelNeedsPassword = false;

--- a/nixops/physical.nix
+++ b/nixops/physical.nix
@@ -1,61 +1,38 @@
 let
-  region = "us-west-1";
+  dhallLangNixpkgs = import ./dhallLangNixpkgs.nix;
 
 in
-  { ipfs = { resources, ... }: {
-      deployment = {
-        targetEnv = "ec2";
+  { ... }: {
+    imports = [ "${dhallLangNixpkgs}/nixos/modules/profiles/qemu-guest.nix" ];
 
-        ec2 = {
-          inherit region;
+    nixpkgs.system = "x86_64-linux";
 
-          inherit (resources.ec2KeyPairs) keyPair;
+    boot = {
+      initrd.availableKernelModules =
+        [ "ata_piix" "virtio_pci" "floppy" "sd_mod" ];
 
-          instanceType = "t2.micro";
+      kernelParams = [ "console=ttyS0,19200n8" ];
+
+      loader = {
+        grub = {
+          enable = true;
+
+          extraConfig = ''
+            serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
+            terminal_input serial;
+            terminal_output serial;
+          '';
+
+          device = "nodev";
+
+          timeout = 10;
+
+          version = 2;
         };
       };
     };
 
-    hydra = { ... }: {
-      deployment = {
-        targetEnv = "none";
+    fileSystems."/" = { device = "/dev/sda"; fsType = "ext4"; };
 
-        targetHost = "hydra.dhall-lang.org";
-      };
-
-      imports = [ <nixpkgs/nixos/modules/profiles/qemu-guest.nix> ];
-
-      nixpkgs.system = "x86_64-linux";
-
-      boot = {
-        initrd.availableKernelModules =
-          [ "ata_piix" "virtio_pci" "floppy" "sd_mod" ];
-
-        kernelParams = [ "console=ttyS0,19200n8" ];
-
-        loader = {
-          grub = {
-            enable = true;
-
-            extraConfig = ''
-              serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
-              terminal_input serial;
-              terminal_output serial;
-            '';
-
-            device = "nodev";
-
-            timeout = 10;
-
-            version = 2;
-          };
-        };
-      };
-
-      fileSystems."/" = { device = "/dev/sda"; fsType = "ext4"; };
-
-      swapDevices = [ { device = "/dev/sdb"; } ];
-    };
-
-    resources.ec2KeyPairs.keyPair = { inherit region; };
+    swapDevices = [ { device = "/dev/sdb"; } ];
   }

--- a/release.nix
+++ b/release.nix
@@ -8,6 +8,8 @@ let
       sha256 = "0ri58704vwv6gnyw33vjirgnvh2f1201vbflk0ydj5ff7vpyy7hf";
     };
 
+  dhallLangNixpkgs = import ./nixops/dhallLangNixpkgs.nix;
+
   overlay = pkgsNew: pkgsOld: {
     dhall =
       let
@@ -144,6 +146,17 @@ let
   # master in).
   rev = pkgs.runCommand "rev" {} ''echo "${src.rev}" > $out'';
 
+  machine =
+    (import "${dhallLangNixpkgs}/nixos" {
+      configuration = {
+        imports = [ ./nixops/logical.nix ./nixops/physical.nix ];
+
+        networking.hostName = "dhall-lang";
+      };
+
+      system = "x86_64-linux";
+    }).system;
+
 in
   { dhall-lang = pkgs.releaseTools.aggregate {
       name = "dhall-lang";
@@ -153,9 +166,12 @@ in
         pkgs.ensure-trailing-newlines
         pkgs.prelude-lint
         pkgs.test-files-lint
+        machine
         rev
       ];
     };
 
     inherit (pkgs) expected-prelude expected-test-files docs;
+
+    inherit machine;
   }


### PR DESCRIPTION
This changes dhall-lang.org to no longer be managed via NixOps.
Instead, it will automatically install the system built by the
`machine` attribute built from the `master` branch every hour.