### PR TITLE
Documentation: Updated the dhall-yaml integration hyperlink

### DIFF
--- a/docs/howtos/How-to-integrate-Dhall.md
+++ b/docs/howtos/How-to-integrate-Dhall.md
@@ -36,7 +36,7 @@ The following integrations built on top of another implementation are still in p
 
 You can convert Dhall to one of the following configuration formats if your language does not natively support Dhall.
 
-* [YAML](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md) - Via the `dhall-to-yaml` executable
+* [YAML](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-yaml/README.md) - Via the `dhall-to-yaml` executable
 
 * [JSON](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md) - Via the `dhall-to-json` executable
 

--- a/docs/howtos/How-to-integrate-Dhall.md
+++ b/docs/howtos/How-to-integrate-Dhall.md
@@ -36,7 +36,7 @@ The following integrations built on top of another implementation are still in p
 
 You can convert Dhall to one of the following configuration formats if your language does not natively support Dhall.
 
-* [YAML](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-yaml/README.md) - Via the `dhall-to-yaml` executable
+* [YAML](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-yaml/README.md) - Via the `dhall-to-yaml-ng` executable
 
 * [JSON](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-json/README.md) - Via the `dhall-to-json` executable
 


### PR DESCRIPTION
Updates the hyperlink URL for dhall-yaml to actually point at dhall-yaml instead of dhall-json.