### PR TITLE
Restyle `docs.dhall-lang.org`

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,14 +1,5 @@
 {% extends '!layout.html' %}
 
-{% block extrahead %}
-<div class="footer" style="position: absolute; margin-top: 30px; margin-right: 10px; top: 0; right: 0;">
-  <a style="text-decoration: none"
-     href="https://github.com/dhall-lang/dhall-lang/edit/master/docs/{{ sourcename | replace('.txt', '') }}">
-  Want to contribute? Edit me on Github!
-</a>
-</div>
-{% endblock %}
-
 {% block footer %}
 <div class="footer">
   <p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,17 +4,22 @@ copyright = '2019, Dhall Contributors'
 author = 'Dhall Contributors'
 master_doc = 'index'
 
-pygments_style = 'sphinx'
-html_theme_options = {
-    'show_related': True,
-    'page_width': 'auto',
+html_theme = 'sphinx_rtd_theme'
+html_context = {
     'github_user': 'dhall-lang',
     'github_repo': 'dhall-lang',
-    'logo': 'dhall-logo.svg',
-    # sticky sidebar
-    #'fixed_sidebar': True,
-    'sidebar_collapse': False,
+    'github_version': 'master',
+    'conf_py_path': '/docs/',
+    'display_github': True,
+    'theme_vcs_pageview_mode': 'edit',
 }
+html_theme_options = {
+    'canonical_url': 'https://docs.dhall-lang.org/',
+    # https://github.com/readthedocs/sphinx_rtd_theme/issues/872
+    # 'logo_only': True,
+}
+# html_logo = '_static/dhall-logo.svg'
+
 html_static_path = ['_static']
 templates_path = ['_templates']
 extensions = [

--- a/release.nix
+++ b/release.nix
@@ -123,6 +123,7 @@ let
       pkgsNew.runCommand "docs"
         { nativeBuildInputs = [
             pkgsNew.pythonPackages.sphinx
+            pkgsNew.pythonPackages.sphinx_rtd_theme
             pkgsNew.pythonPackages.recommonmark
             pkgsNew.pythonPackages.pygments
           ];


### PR DESCRIPTION
This switches to using `sphinx_rtd_theme` to style the page instead
of the default theme

Before this change:

![Screen Shot 2020-02-01 at 10 46 01 AM](https://user-images.githubusercontent.com/1313787/73597360-15f59300-44e0-11ea-8d19-615f62123aac.png)

After this change:

![Screen Shot 2020-02-01 at 10 45 54 AM](https://user-images.githubusercontent.com/1313787/73597362-1c840a80-44e0-11ea-8983-7c034a1bdfb4.png)
