### PR TITLE
Fix 502 errors for discourse

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -414,6 +414,8 @@
             ${pkgs.bash}/bin/bash ${discourseDirectory}/launcher rebuild app
           '';
 
+          serviceConfig.RemainAfterExit = true;
+
           wantedBy = [ "multi-user.target" ];
 
           wants = [ "docker.service" ];


### PR DESCRIPTION
The `discourse` service was being restarted every hour for the following
two reasons:

* The `discourse` service was missing `RemainAfterExit=true`

  The `discourse` service launches a `docker` container in the
  background and then immediately terminates with a non-zero exit code.
  However, without `RemainAfterExit` then `systemd` marks the service as
  inactive / dead, so re-deploying the system reactivates the service.

* The system was being deployed hourly off of `master` using the
  `self-deploy` service

The combination of the above two problems meant that the `discourse`
service was being restarted on an hourly basis and people were seeing
502 errors after hourly boundaries.  Since the service takes quite a
while to start up (~10 minutes) these restarts were quite noticeable.

Enabling `RemainAfterExit=true` means that even after the `docker`
container is launched the service status is now marked as
active / success, so subsequent re-deploys of the system don't
restart the service.