### PR TITLE
Documentation: Cheatsheet improvements

### DIFF
--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -192,9 +192,13 @@
 *   Unions
 
     ```dhall
-    < Foo | Bar : Natural >.Foo, < Foo | Bar : Natural >.Bar 1 : < Foo | Bar : Natural >
+    let FooBar = < Foo | Bar : Natural >
 
-    merge { Foo = False, Bar = Natural/even } < Foo | Bar : Natural >.Bar 2 = True
+    let isEven =
+        \(foobar : FooBar) -> merge { Foo = False, Bar = Natural/even } foobar
+
+    in  [ isEven FooBar.Foo, isEven (FooBar.Bar 3), isEven (FooBar.Bar 4) ]
+    = [ False, False, True ]
     ```
 
 ## Programming
@@ -307,6 +311,14 @@
 
     You can find latest Prelude of importable functions at 
     [prelude.dhall-lang.org](https://prelude.dhall-lang.org/)
+
+    You can import Prelude as a whole with:
+
+    ```dhall
+    let Prelude = https://prelude.dhall-lang.org/package.dhall
+
+    in Prelude.List.last Natural [2, 3, 4]
+    ```
 
 *   Comments
 


### PR DESCRIPTION
Rephrased union example - previous phrasing of an example was unreadable to me as a beginner and I had to fallback to different sources. Also, I believe named union type is something you usually see "in wild" as opposed to anonymous union type

Mentioned ability to import Prelude as a whole - I happened to get to know about it by reading threads on discourse. Previously I was importing each function one by one as I was not aware of importing packages