### PR TITLE
Tweak instructions for how to run import tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -111,9 +111,12 @@ Where `A` and `B` are:
 
 ### Running `import` tests
 
-First, set the environment variable `XDG_CACHE_HOME` to the absolute location of
-`dhall-lang/tests/import/cache`.  This is so that we can test that an import
-with an integrity check is fetched from cache (for example, see
+You must run these tests in such a way that they can read cache
+entries from `dhall-lang/tests/import/cache/dhall` as if it were the Dhall
+cache.  For example, on unix systems you could set the environment
+variable `XDG_CACHE_HOME` to the absolute location of
+`dhall-lang/tests/import/cache`.  This is so that we can test that an
+import with an integrity check is fetched from cache (for example, see
 `hashFromCacheA.dhall`).
 
 The tests should:


### PR DESCRIPTION
I realised that the instructions for how to run the import tests are
Unix-specific; setting XDG_CACHE_HOME won't do you any good on Windows
or OS X.  This commit rewrites the instructions to be more
platform-independent.

See also https://github.com/philandstuff/dhall-golang/pull/7 where I
updated dhall-golang's own tests to be more platform-independent.