### PR TITLE
Upgrade `dhall`

### DIFF
--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "9344b89f4c94a6a353382c9cefb80c707e935bf6",
-  "date": "2020-02-17T07:51:35-08:00",
-  "sha256": "0qangrk2aqn4qchpmjp6rixdv8zzizsahim26is94kh5rhisvccb",
+  "rev": "5b29700e1c080ad19278616e0f9dfcab389e539b",
+  "date": "2020-02-22T00:14:11+00:00",
+  "sha256": "0adbiwbd22f38b2gkhl590151w57q6n86m2345h77hk22mrskj59",
   "fetchSubmodules": true
 }


### PR DESCRIPTION
This fixes a GHCJS bug that causes code with numbers to fail to parse

See: https://github.com/dhall-lang/dhall-haskell/pull/1681