### PR TITLE
Add dhall-golang to official implementations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ actively maintained implementations of the Dhall language.  Votes are made
 using the GitHub pull request review feature.  Each implementation gets one
 vote.
 
-At the time of this writing the four actively supported implementations of Dhall
+At the time of this writing the five actively supported implementations of Dhall
 are:
 
 *   [`dhall-haskell` - Haskell bindings to Dhall](https://github.com/dhall-lang/dhall-haskell)
@@ -108,6 +108,10 @@ are:
 *   [`dhall-rust` - Rust bindings to Dhall](https://github.com/Nadrieril/dhall-rust)
 
     Led by @Nadrieril
+
+*   [`dhall-golang` - Go bindings to Dhall](https://github.com/philandstuff/dhall-golang)
+
+    Led by @philandstuff
 
 Each of those implementations get one vote cast by the lead contributor for each
 implementation.

--- a/nixops/index.html
+++ b/nixops/index.html
@@ -141,6 +141,8 @@
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/f-f/dhall-clj/blob/master/README.md"><img src = "./img/clojure-logo.svg" height="32px" alt="Clojure logo"><span>Clojure</span></a>
               <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/philandstuff/dhall-golang"><img src = "./img/go-logo.svg" height="32px" alt="Go logo"><span>Go</span></a>
+              <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/blob/master/dhall/README.md"><img src = "./img/haskell-logo.png" height="32px" alt="Haskell logo"><span>Haskell</span></a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-nix"><img src = "./img/nix-logo.png" height="32px" alt="Nix logo"><span>Nix</span></a>
@@ -148,8 +150,6 @@
               <a class="nav-link" href="https://git.sr.ht/~singpolyma/dhall-ruby"><img src = "./img/ruby-logo.svg" height="32px" alt="Ruby logo"><span>Ruby</span></a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/Nadrieril/dhall-rust"><img src = "./img/rust-logo.png" height="32px" alt="Rust logo"><span>Rust</span></a>
-              <div class="dropdown-divider"></div>
-              <a class="nav-link" href="https://github.com/philandstuff/dhall-golang"><img src = "./img/go-logo.svg" height="32px" alt="Go logo"><span>Go</span></a>
             </div>
           </li>
           <li class="nav-item dropdown">

--- a/nixops/index.html
+++ b/nixops/index.html
@@ -148,6 +148,8 @@
               <a class="nav-link" href="https://git.sr.ht/~singpolyma/dhall-ruby"><img src = "./img/ruby-logo.svg" height="32px" alt="Ruby logo"><span>Ruby</span></a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/Nadrieril/dhall-rust"><img src = "./img/rust-logo.png" height="32px" alt="Rust logo"><span>Rust</span></a>
+              <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://github.com/philandstuff/dhall-golang"><img src = "./img/go-logo.svg" height="32px" alt="Go logo"><span>Go</span></a>
             </div>
           </li>
           <li class="nav-item dropdown">

--- a/nixops/website.nix
+++ b/nixops/website.nix
@@ -27,6 +27,7 @@ runCommand "try-dhall" {} ''
   ${coreutils}/bin/ln --symbolic ${logo.dhallSmall} $out/img/dhall-small-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.discourse} $out/img/discourse-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.github}/PNG/GitHub-Mark-32px.png $out/img/github-logo.png
+  ${coreutils}/bin/ln --symbolic ${logo.golang}/Go-Logo/SVG/Go-Logo_Blue.svg $out/img/go-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.haskell} $out/img/haskell-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.json} $out/img/json-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.kops} $out/img/kops-logo.svg

--- a/release.nix
+++ b/release.nix
@@ -180,6 +180,14 @@ let
           sha256 = "0mrjzv690g9mxljzxsvay8asyr8vlxhhs9smmax7mp3psd49b43g";
         };
 
+      golang =
+        pkgsNew.fetchzip {
+          # See also https://blog.golang.org/go-brand
+          url    = "https://storage.googleapis.com/golang-assets/go-logos-v1.0.zip";
+          sha256 = "06vlpk22nxl1a3mz9rpk9fyq483rc4ml8f7lkkfqmabbia9ah7np";
+          stripRoot = false;
+        };
+
       ruby =
         pkgsNew.fetchurl {
           url    = "https://upload.wikimedia.org/wikipedia/commons/7/73/Ruby_logo.svg";


### PR DESCRIPTION
Note: the `fetchzip` thing I do for the Go logos could maybe also be used for the github logos?