### PR TITLE
Tidy up desugar-with()

### DIFF
--- a/standard/record.md
+++ b/standard/record.md
@@ -254,18 +254,17 @@ A `with` expression with multiple dotted labels is equivalent to chained uses of
 the `//` operator:
 
 
-    desugar-with(e₀ // { k₀ = e₀.k₀ with k₁.ks… = v₁ }) = e₁
-    ─────────────────────────────────────────  ; Inductive case for more than one
-    desugar-with(e₀ with k₀.k₁.ks… = v₀) = e₁  ; label
+    desugar-with(e₀.k with ks… = v ) = e₁
+    ───────────────────────────────────────────────────  ; Inductive case for more than one
+    desugar-with(e₀ with k.ks… = v ) = e₀ // { k = e₁ }  ; label
 
 
 ... and if there is only one update with one label then the `with` keyword is a
 synonym for the `//` operator:
 
 
-    desugar-with(e₀ // { k = v }) = e₁
-    ──────────────────────────────────  ; Base case for exactly one
-    desugar-with(e₀ with k = v) = e₁    ; label
+    ───────────────────────────────────────────  ; Base case for exactly one
+    desugar-with(e with k = v) = e // { k = v }  ; label
 
 
 For all other cases, `desugar-with` descends into sub-expressions and ignores


### PR DESCRIPTION
The desugar-with() judgment was not well-defined, in two ways:

 - There was no actual base case (ie, an inference rule with no
   premises)
 - You could only derive sentences of the form
   `desugar-with(e₀ with ks = v) = e₁`, but the judgment rules required
   inputs of the form `desugar-with(e₀ // e₁) = e₂`

This fixes both of these problems.  The only `desugar-with` sentences
are now in the form `desugar-with(e₀ with ks = v) = e₁`, and there is a
genuine base case.