### PR TITLE
Fix nixos warning

### DIFF
--- a/nixops/physical.nix
+++ b/nixops/physical.nix
@@ -25,10 +25,10 @@ in
 
           device = "nodev";
 
-          timeout = 10;
-
           version = 2;
         };
+
+        timeout = 10;
       };
     };
 


### PR DESCRIPTION
I was getting the warning

    trace: warning: The option `boot.loader.grub.timeout' defined in
    `<...>/dhall-lang/nixops/physical.nix' has been renamed to
    `boot.loader.timeout'.

This fixes it, I think.