### PR TITLE
Link to Slack and Zulip Dhall channels on website

### DIFF
--- a/nixops/index.html
+++ b/nixops/index.html
@@ -188,6 +188,12 @@
             <a class="nav-link" href="https://discourse.dhall-lang.org"><img src = "./img/discourse-logo.svg" height="25px" alt="Discourse logo"></a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="https://functionalprogramming.slack.com/app_redirect?channel=dhall"><img src = "./img/slack-logo.png" height="30px" alt="Slack logo"></a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://funprog.zulipchat.com/#narrow/stream/214956-Dhall"><img src = "./img/zulip-logo.png" height="30px" alt="Zulip logo"></a>
+          </li>
+          <li class="nav-item">
           <li class="nav-item">
             <a class="nav-link" href="https://stackoverflow.com/questions/tagged/dhall"><img src = "./img/stack-overflow-logo.svg" height="32px" alt="Stack Overflow logo"></a>
           </li>

--- a/nixops/website.nix
+++ b/nixops/website.nix
@@ -37,9 +37,11 @@ runCommand "try-dhall" {} ''
   ${coreutils}/bin/ln --symbolic ${logo.prometheus} $out/img/prometheus-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.ruby} $out/img/ruby-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.rust} $out/img/rust-logo.png
+  ${coreutils}/bin/ln --symbolic ${logo.slack} $out/img/slack-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.stackOverflow} $out/img/stack-overflow-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.xml} $out/img/xml-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.yaml} $out/img/yaml-logo.png
+  ${coreutils}/bin/ln --symbolic ${logo.zulip} $out/img/zulip-logo.png
   ${coreutils}/bin/ln --symbolic '${logo.twitter}/Twitter Logos/Twitter Logos/Twitter_Logo_Blue/Twitter_Logo_Blue.svg' $out/img/twitter-logo.svg
   ${coreutils}/bin/mkdir $out/nix-support
   ${coreutils}/bin/echo "doc none $out/index.html" > $out/nix-support/hydra-build-products

--- a/release.nix
+++ b/release.nix
@@ -263,6 +263,19 @@ let
           sha256 = "19ff8l1kp3i3gxxbd5na9wbzxkpflcxw0lz2ysb1d6s4ybvr0fnb";
         };
 
+      slack =
+        pkgsNew.fetchurl {
+          name = "slack-logo.png";
+
+          url =
+            "https://brandfolder.com/slack/attachments/pl546j-7le8zk-afym5u?dl=true&resource_key=pl53se-o7edc-2zw45a&resource_type=Collection";
+
+          sha256 = "08zjckbg949rlnxrchjf75d99yn1cwivc9ny3yrklb0514j3i1d9";
+
+          postFetch =
+            "${pkgs.imagemagickBig}/bin/mogrify -format png -crop 300x300+100+100 $downloadedFile";
+        };
+
       stackOverflow =
         pkgsNew.fetchurl {
           url    = "https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg";
@@ -281,6 +294,12 @@ let
         pkgsNew.fetchurl {
           url    = "https://raw.githubusercontent.com/yaml/yaml-spec/a6f764e13de58d5f753877f588a01b35dc9a5168/logo.png";
           sha256 = "12grgaxpqi755p2rnvw3x02zc69brpnzx208id1f0z42w387j4hi";
+        };
+
+      zulip =
+        pkgsNew.fetchurl {
+          url    = "https://raw.githubusercontent.com/zulip/zulip/28d58c848d60b2b93e82b2aa61c560268806ebb6/static/images/logo/zulip-icon-128x128.png";
+          sha256 = "0j7khvym2p4f8dqdl7k7k4rypj1hai2rj0pjzb6h41fvjyjmbrrr";
         };
     };
 

--- a/release.nix
+++ b/release.nix
@@ -270,7 +270,7 @@ let
           url =
             "https://brandfolder.com/slack/attachments/pl546j-7le8zk-afym5u?dl=true&resource_key=pl53se-o7edc-2zw45a&resource_type=Collection";
 
-          sha256 = "08zjckbg949rlnxrchjf75d99yn1cwivc9ny3yrklb0514j3i1d9";
+          sha256 = "0i4yjjgkcky6zfbim17rryy23pbrsc4255jzy14lgy7ja3a5jabk";
 
           postFetch =
             "${pkgs.imagemagickBig}/bin/mogrify -format png -crop 300x300+100+100 $downloadedFile";


### PR DESCRIPTION
This is what the two new logos look like in the top-right corner of the website:

![Screenshot_20200428_215926](https://user-images.githubusercontent.com/1313787/80562112-91f65e80-899b-11ea-9b02-8a12243f886e.png)
