### PR TITLE
Link to "Language Tour" on dhall-lang.org

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,6 +8,7 @@ These guides help you get your hands dirty with working examples:
    :maxdepth: 1
 
    Getting-started_Generate-JSON-or-YAML
+   Language-Tour
    string-matrix
 ```
 
@@ -19,10 +20,6 @@ These guides help you get your hands dirty with working examples:
 ## [Learn Dhall in Y minutes](https://learnxinyminutes.com/docs/dhall/)
 
 > Take a whirlwind tour of the language taught using one large Dhall file
-
-## [Language tour](./Language-Tour.md)
-
-> A longer tutorial that briefly touches on all language features
 
 ## [dhall-nethack](https://github.com/dhall-lang/dhall-nethack)
 

--- a/nixops/index.html
+++ b/nixops/index.html
@@ -95,6 +95,8 @@
             <div class="dropdown-menu" aria-labelledby="tutorialDropdown">
               <a class="nav-link" href="https://docs.dhall-lang.org/tutorials/Getting-started_Generate-JSON-or-YAML.html">Getting started: Generate JSON or YAML</a>
               <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://docs.dhall-lang.org/tutorials/Language-Tour.html">Language tour</a>
+              <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://learnxinyminutes.com/docs/dhall/">Learn Dhall in Y minutes</a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://github.com/dhall-lang/dhall-nethack"><code>dhall-nethack</code></a>


### PR DESCRIPTION
... and also fix the docs reference to match the style of other
internal tutorial references