### PR TITLE
Update `dhall-haskell` reference to 1.32.0

### DIFF
--- a/Prelude/Bool/and
+++ b/Prelude/Bool/and
@@ -4,8 +4,8 @@ The `and` function returns `False` if there are any `False` elements in the
 -}
 let and
     : List Bool → Bool
-    =   λ(xs : List Bool)
-      → List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l && r) True
+    = λ(xs : List Bool) →
+        List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l && r) True
 
 let example0 = assert : and [ True, False, True ] ≡ False
 

--- a/Prelude/Bool/build
+++ b/Prelude/Bool/build
@@ -3,8 +3,8 @@
 -}
 let build
     : (∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) → Bool
-    =   λ(f : ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool)
-      → f Bool True False
+    = λ(f : ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) →
+        f Bool True False
 
 let example0 =
         assert

--- a/Prelude/Bool/even
+++ b/Prelude/Bool/even
@@ -6,8 +6,8 @@ This function is the `Monoid` for the `==` operation.
 -}
 let even
     : List Bool → Bool
-    =   λ(xs : List Bool)
-      → List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x == y) True
+    = λ(xs : List Bool) →
+        List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x == y) True
 
 let example0 = assert : even [ False, True, False ] ≡ True
 

--- a/Prelude/Bool/fold
+++ b/Prelude/Bool/fold
@@ -3,11 +3,11 @@
 -}
 let fold
     : ∀(b : Bool) → ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool
-    =   λ(b : Bool)
-      → λ(bool : Type)
-      → λ(true : bool)
-      → λ(false : bool)
-      → if b then true else false
+    = λ(b : Bool) →
+      λ(bool : Type) →
+      λ(true : bool) →
+      λ(false : bool) →
+        if b then true else false
 
 let example0 = assert : fold True Natural 0 1 ≡ 0
 

--- a/Prelude/Bool/odd
+++ b/Prelude/Bool/odd
@@ -6,8 +6,8 @@ This function is the `Monoid` for the `!=` operation.
 -}
 let odd
     : List Bool → Bool
-    =   λ(xs : List Bool)
-      → List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x != y) False
+    = λ(xs : List Bool) →
+        List/fold Bool xs Bool (λ(x : Bool) → λ(y : Bool) → x != y) False
 
 let example0 = assert : odd [ True, False, True ] ≡ False
 

--- a/Prelude/Bool/or
+++ b/Prelude/Bool/or
@@ -4,8 +4,8 @@ and returns `False` otherwise
 -}
 let or
     : List Bool → Bool
-    =   λ(xs : List Bool)
-      → List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l || r) False
+    = λ(xs : List Bool) →
+        List/fold Bool xs Bool (λ(l : Bool) → λ(r : Bool) → l || r) False
 
 let example0 = assert : or [ True, False, True ] ≡ True
 

--- a/Prelude/Function/compose
+++ b/Prelude/Function/compose
@@ -3,13 +3,13 @@ Compose two functions into one.
 -}
 let compose
     : ∀(a : Type) → ∀(b : Type) → ∀(c : Type) → (a → b) → (b → c) → a → c
-    =   λ(A : Type)
-      → λ(B : Type)
-      → λ(C : Type)
-      → λ(f : A → B)
-      → λ(g : B → C)
-      → λ(x : A)
-      → g (f x)
+    = λ(A : Type) →
+      λ(B : Type) →
+      λ(C : Type) →
+      λ(f : A → B) →
+      λ(g : B → C) →
+      λ(x : A) →
+        g (f x)
 
 let example0 =
         assert

--- a/Prelude/Integer/abs
+++ b/Prelude/Integer/abs
@@ -3,11 +3,9 @@ Returns the absolute value of an `Integer`, i.e. its non-negative value.
 -}
 let abs
     : Integer → Natural
-    =   λ(n : Integer)
-      →       if Natural/isZero (Integer/clamp n)
-
+    = λ(n : Integer) →
+        if    Natural/isZero (Integer/clamp n)
         then  Integer/clamp (Integer/negate n)
-
         else  Integer/clamp n
 
 let example0 = assert : abs +7 ≡ 7

--- a/Prelude/Integer/equal
+++ b/Prelude/Integer/equal
@@ -7,9 +7,9 @@ let Natural/equal =
 
 let equal
     : Integer → Integer → Bool
-    =   λ(a : Integer)
-      → λ(b : Integer)
-      →     Natural/equal (Integer/clamp a) (Integer/clamp b)
+    = λ(a : Integer) →
+      λ(b : Integer) →
+            Natural/equal (Integer/clamp a) (Integer/clamp b)
         &&  Natural/equal
               (Integer/clamp (Integer/negate a))
               (Integer/clamp (Integer/negate b))

--- a/Prelude/Integer/lessThanEqual
+++ b/Prelude/Integer/lessThanEqual
@@ -19,15 +19,13 @@ let nonNegative =
 
 let lessThanEqual
     : Integer → Integer → Bool
-    =   λ(x : Integer)
-      → λ(y : Integer)
-      →       if nonPositive x
-
+    = λ(x : Integer) →
+      λ(y : Integer) →
+        if    nonPositive x
         then      nonNegative y
               ||  Natural/greaterThanEqual
                     (Integer/clamp (Integer/negate x))
                     (Integer/clamp (Integer/negate y))
-
         else  Natural/lessThanEqual (Integer/clamp x) (Integer/clamp y)
 
 let example0 = assert : lessThanEqual +5 +6 ≡ True

--- a/Prelude/Integer/multiply
+++ b/Prelude/Integer/multiply
@@ -7,26 +7,20 @@ let nonPositive =
       ? ./nonPositive
 
 let multiplyNonNegative =
-        λ(x : Integer)
-      → λ(y : Integer)
-      → Natural/toInteger (Integer/clamp x * Integer/clamp y)
+      λ(x : Integer) →
+      λ(y : Integer) →
+        Natural/toInteger (Integer/clamp x * Integer/clamp y)
 
 let multiply
     : Integer → Integer → Integer
-    =   λ(m : Integer)
-      → λ(n : Integer)
-      →       if nonPositive m
-
-        then        if nonPositive n
-
+    = λ(m : Integer) →
+      λ(n : Integer) →
+        if    nonPositive m
+        then  if    nonPositive n
               then  multiplyNonNegative (Integer/negate m) (Integer/negate n)
-
               else  Integer/negate (multiplyNonNegative (Integer/negate m) n)
-
         else  if nonPositive n
-
         then  Integer/negate (multiplyNonNegative m (Integer/negate n))
-
         else  multiplyNonNegative m n
 
 let example0 = assert : multiply +3 +5 ≡ +15

--- a/Prelude/Integer/subtract
+++ b/Prelude/Integer/subtract
@@ -6,40 +6,32 @@ let nonPositive =
       ? ./nonPositive
 
 let subtractNonNegative =
-        λ(xi : Integer)
-      → λ(yi : Integer)
-      → let xn = Integer/clamp xi
+      λ(xi : Integer) →
+      λ(yi : Integer) →
+        let xn = Integer/clamp xi
 
         let yn = Integer/clamp yi
 
         let dn = Natural/subtract xn yn
 
-        in        if Natural/isZero dn
-
+        in  if    Natural/isZero dn
             then  Integer/negate (Natural/toInteger (Natural/subtract yn xn))
-
             else  Natural/toInteger dn
 
 let subtract
     : Integer → Integer → Integer
-    =   λ(m : Integer)
-      → λ(n : Integer)
-      →       if nonPositive m
-
-        then        if nonPositive n
-
+    = λ(m : Integer) →
+      λ(n : Integer) →
+        if    nonPositive m
+        then  if    nonPositive n
               then  subtractNonNegative (Integer/negate n) (Integer/negate m)
-
               else  Natural/toInteger
                       (Integer/clamp (Integer/negate m) + Integer/clamp n)
-
         else  if nonPositive n
-
         then  Integer/negate
                 ( Natural/toInteger
                     (Integer/clamp m + Integer/clamp (Integer/negate n))
                 )
-
         else  subtractNonNegative m n
 
 let example0 = assert : subtract +3 +5 ≡ +2

--- a/Prelude/Integer/toNatural
+++ b/Prelude/Integer/toNatural
@@ -7,8 +7,8 @@ let nonNegative =
 
 let toNatural
     : Integer → Optional Natural
-    =   λ(n : Integer)
-      → if nonNegative n then Some (Integer/clamp n) else None Natural
+    = λ(n : Integer) →
+        if nonNegative n then Some (Integer/clamp n) else None Natural
 
 let example0 = assert : toNatural +7 ≡ Some 7
 

--- a/Prelude/JSON/Tagged
+++ b/Prelude/JSON/Tagged
@@ -20,8 +20,8 @@ let Nesting = ./Nesting
 
 let wrap
     : Provisioner → Tagged Provisioner
-    =   λ(x : Provisioner)
-      → { field = "type", nesting = Nesting.Nested "params", contents = x }
+    = λ(x : Provisioner) →
+        { field = "type", nesting = Nesting.Nested "params", contents = x }
 
 in  { provisioners =
         map
@@ -62,8 +62,8 @@ in  { provisioners =
 -}
 let Tagged
     : Type → Type
-    =   λ(a : Type)
-      → { field : Text
+    = λ(a : Type) →
+        { field : Text
         , nesting :
               ./Nesting sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
             ? ./Nesting

--- a/Prelude/JSON/Type
+++ b/Prelude/JSON/Type
@@ -9,32 +9,23 @@
    ... corresponds to the following Dhall expression:
 
 ```
-  λ(JSON : Type)
-→ λ ( json
-    : { array :
-          List JSON → JSON
-      , bool :
-          Bool → JSON
-      , null :
-          JSON
-      , double :
-          Double → JSON
-      , integer :
-          Integer → JSON
-      , object :
-          List { mapKey : Text, mapValue : JSON } → JSON
-      , string :
-          Text → JSON
-      }
-    )
-→ json.object
-  [ { mapKey = "foo", mapValue = json.null }
-  , { mapKey =
-        "bar"
-    , mapValue =
-        json.array [ json.double 1.0, json.bool True ]
+λ(JSON : Type) →
+λ ( json
+  : { array : List JSON → JSON
+    , bool : Bool → JSON
+    , null : JSON
+    , double : Double → JSON
+    , integer : Integer → JSON
+    , object : List { mapKey : Text, mapValue : JSON } → JSON
+    , string : Text → JSON
     }
-  ]
+  ) →
+  json.object
+    [ { mapKey = "foo", mapValue = json.null }
+    , { mapKey = "bar"
+      , mapValue = json.array [ json.double 1.0, json.bool True ]
+      }
+    ]
 ```
 
   You do not need to create these values directly, though.  You can use
@@ -45,29 +36,27 @@
 let JSON = ./package.dhall
 
 in  JSON.object
-    [ { mapKey = "foo", mapValue = JSON.null }
-    , { mapKey =
-          "bar"
-      , mapValue =
-          JSON.array [ JSON.double 1.0, JSON.bool True ]
-      }
-    ]
+      [ { mapKey = "foo", mapValue = JSON.null }
+      , { mapKey = "bar"
+        , mapValue = JSON.array [ JSON.double 1.0, JSON.bool True ]
+        }
+      ]
 ```
 
 -}
 let JSON/Type
     : Type
-    =   ∀(JSON : Type)
-      → ∀ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → JSON
+    = ∀(JSON : Type) →
+      ∀ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        JSON
 
 in  JSON/Type

--- a/Prelude/JSON/array
+++ b/Prelude/JSON/array
@@ -21,18 +21,18 @@ let List/map =
 
 let array
     : List JSON → JSON
-    =   λ(x : List JSON)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.array (List/map JSON@1 JSON (λ(j : JSON@1) → j JSON json) x)
+    = λ(x : List JSON) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.array (List/map JSON@1 JSON (λ(j : JSON@1) → j JSON json) x)
 
 in  array

--- a/Prelude/JSON/bool
+++ b/Prelude/JSON/bool
@@ -16,18 +16,18 @@ let JSON =
 
 let bool
     : Bool → JSON
-    =   λ(x : Bool)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.bool x
+    = λ(x : Bool) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.bool x
 
 in  bool

--- a/Prelude/JSON/double
+++ b/Prelude/JSON/double
@@ -16,18 +16,18 @@ let JSON =
 
 let double
     : Double → JSON
-    =   λ(x : Double)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.double x
+    = λ(x : Double) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.double x
 
 in  double

--- a/Prelude/JSON/integer
+++ b/Prelude/JSON/integer
@@ -16,18 +16,18 @@ let JSON =
 
 let integer
     : Integer → JSON
-    =   λ(x : Integer)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.integer x
+    = λ(x : Integer) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.integer x
 
 in  integer

--- a/Prelude/JSON/natural
+++ b/Prelude/JSON/natural
@@ -12,18 +12,18 @@ let JSON =
 
 let natural
     : Natural → JSON
-    =   λ(x : Natural)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.integer (Natural/toInteger x)
+    = λ(x : Natural) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.integer (Natural/toInteger x)
 
 in  natural

--- a/Prelude/JSON/null
+++ b/Prelude/JSON/null
@@ -12,17 +12,17 @@ let JSON =
 
 let null
     : JSON
-    =   λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.null
+    = λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.null
 
 in  null

--- a/Prelude/JSON/object
+++ b/Prelude/JSON/object
@@ -27,24 +27,24 @@ let List/map =
 
 let object
     : List { mapKey : Text, mapValue : JSON } → JSON
-    =   λ(x : List { mapKey : Text, mapValue : JSON })
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.object
+    = λ(x : List { mapKey : Text, mapValue : JSON }) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.object
           ( List/map
               { mapKey : Text, mapValue : JSON@1 }
               { mapKey : Text, mapValue : JSON }
-              (   λ(kv : { mapKey : Text, mapValue : JSON@1 })
-                → { mapKey = kv.mapKey, mapValue = kv.mapValue JSON json }
+              ( λ(kv : { mapKey : Text, mapValue : JSON@1 }) →
+                  { mapKey = kv.mapKey, mapValue = kv.mapValue JSON json }
               )
               x
           )

--- a/Prelude/JSON/omitNullFields
+++ b/Prelude/JSON/omitNullFields
@@ -16,19 +16,19 @@ let List/map =
 
 let omitNullFields
     : JSON.Type → JSON.Type
-    =   λ(old : JSON.Type)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → let result =
+    = λ(old : JSON.Type) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        let result =
               old
                 { value : JSON, isNull : Bool }
                 { string =
@@ -38,32 +38,30 @@ let omitNullFields
                 , integer =
                     λ(x : Integer) → { value = json.integer x, isNull = False }
                 , object =
-                      λ ( keyValues
-                        : List
-                            { mapKey : Text
-                            , mapValue : { value : JSON, isNull : Bool }
-                            }
-                        )
-                    → let value =
+                    λ ( keyValues
+                      : List
+                          { mapKey : Text
+                          , mapValue : { value : JSON, isNull : Bool }
+                          }
+                      ) →
+                      let value =
                             json.object
                               ( List/concatMap
                                   { mapKey : Text
                                   , mapValue : { value : JSON, isNull : Bool }
                                   }
                                   { mapKey : Text, mapValue : JSON }
-                                  (   λ ( keyValue
-                                        : { mapKey : Text
-                                          , mapValue :
-                                              { value : JSON, isNull : Bool }
-                                          }
-                                        )
-                                    →       if keyValue.mapValue.isNull
-
+                                  ( λ ( keyValue
+                                      : { mapKey : Text
+                                        , mapValue :
+                                            { value : JSON, isNull : Bool }
+                                        }
+                                      ) →
+                                      if    keyValue.mapValue.isNull
                                       then  [] : List
                                                    { mapKey : Text
                                                    , mapValue : JSON
                                                    }
-
                                       else  [   keyValue.{ mapKey }
                                               ∧ { mapValue =
                                                     keyValue.mapValue.value
@@ -73,21 +71,21 @@ let omitNullFields
                                   keyValues
                               )
 
-                      in  { value = value, isNull = False }
+                      in  { value, isNull = False }
                 , array =
-                      λ(xs : List { value : JSON, isNull : Bool })
-                    → let value =
+                    λ(xs : List { value : JSON, isNull : Bool }) →
+                      let value =
                             json.array
                               ( List/map
                                   { value : JSON, isNull : Bool }
                                   JSON
-                                  (   λ(x : { value : JSON, isNull : Bool })
-                                    → x.value
+                                  ( λ(x : { value : JSON, isNull : Bool }) →
+                                      x.value
                                   )
                                   xs
                               )
 
-                      in  { value = value, isNull = False }
+                      in  { value, isNull = False }
                 , bool = λ(x : Bool) → { value = json.bool x, isNull = False }
                 , null = { value = json.null, isNull = True }
                 }
@@ -95,10 +93,10 @@ let omitNullFields
         in  result.value
 
 let property =
-        λ(a : Text)
-      → λ(b : Double)
-      → λ(c : Bool)
-      →   assert
+      λ(a : Text) →
+      λ(b : Double) →
+      λ(c : Bool) →
+          assert
         :   omitNullFields
               ( JSON.object
                   ( toMap

--- a/Prelude/JSON/renderAs
+++ b/Prelude/JSON/renderAs
@@ -42,12 +42,12 @@ let NonEmpty
 
 let List/uncons
     : ∀(a : Type) → List a → Optional (NonEmpty a)
-    =   λ(a : Type)
-      → λ(ls : List a)
-      → Optional/map
+    = λ(a : Type) →
+      λ(ls : List a) →
+        Optional/map
           a
           (NonEmpty a)
-          (λ(head : a) → { head = head, tail = List/drop 1 a ls })
+          (λ(head : a) → { head, tail = List/drop 1 a ls })
           (List/head a ls)
 
 let NonEmpty/singleton
@@ -60,9 +60,9 @@ let NonEmpty/toList
 
 let NonEmpty/concat
     : ∀(a : Type) → NonEmpty (NonEmpty a) → NonEmpty a
-    =   λ(a : Type)
-      → λ(lss : NonEmpty (NonEmpty a))
-      → { head = lss.head.head
+    = λ(a : Type) →
+      λ(lss : NonEmpty (NonEmpty a)) →
+        { head = lss.head.head
         , tail =
               lss.head.tail
             # List/concatMap (NonEmpty a) a (NonEmpty/toList a) lss.tail
@@ -70,32 +70,32 @@ let NonEmpty/concat
 
 let NonEmpty/map
     : ∀(a : Type) → ∀(b : Type) → (a → b) → NonEmpty a → NonEmpty b
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(fn : a → b)
-      → λ(ls : NonEmpty a)
-      → { head = fn ls.head, tail = List/map a b fn ls.tail }
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(fn : a → b) →
+      λ(ls : NonEmpty a) →
+        { head = fn ls.head, tail = List/map a b fn ls.tail }
 
 let NonEmpty/mapHead
     : ∀(a : Type) → (a → a) → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(fn : a → a)
-      → λ(ls : NonEmpty a)
-      → ls ⫽ { head = fn ls.head }
+    = λ(a : Type) →
+      λ(fn : a → a) →
+      λ(ls : NonEmpty a) →
+        ls ⫽ { head = fn ls.head }
 
 let NonEmpty/mapTail
     : ∀(a : Type) → (a → a) → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(fn : a → a)
-      → λ(ls : NonEmpty a)
-      → ls ⫽ { tail = List/map a a fn ls.tail }
+    = λ(a : Type) →
+      λ(fn : a → a) →
+      λ(ls : NonEmpty a) →
+        ls ⫽ { tail = List/map a a fn ls.tail }
 
 let List/splitAt
     : Natural → ∀(a : Type) → List a → { head : List a, tail : List a }
-    =   λ(index : Natural)
-      → λ(a : Type)
-      → λ(ls : List a)
-      → { head = List/take index a ls, tail = List/drop index a ls }
+    = λ(index : Natural) →
+      λ(a : Type) →
+      λ(ls : List a) →
+        { head = List/take index a ls, tail = List/drop index a ls }
 
 let _testSplitAt0 =
         assert
@@ -117,33 +117,31 @@ let _testSplitAt =
         ≡ { head = [] : List Natural, tail = [] : List Natural }
 
 let List/splitLast =
-        λ(a : Type)
-      → λ(ls : List a)
-      → List/splitAt (Natural/subtract 1 (List/length a ls)) a ls
+      λ(a : Type) →
+      λ(ls : List a) →
+        List/splitAt (Natural/subtract 1 (List/length a ls)) a ls
 
 let NonEmpty/prepend
     : ∀(a : Type) → a → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(prefix : a)
-      → λ(ls : NonEmpty a)
-      → { head = prefix, tail = NonEmpty/toList a ls }
+    = λ(a : Type) →
+      λ(prefix : a) →
+      λ(ls : NonEmpty a) →
+        { head = prefix, tail = NonEmpty/toList a ls }
 
 let NonEmpty/append
     : ∀(a : Type) → a → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(suffix : a)
-      → λ(ls : NonEmpty a)
-      → { head = ls.head, tail = ls.tail # [ suffix ] }
+    = λ(a : Type) →
+      λ(suffix : a) →
+      λ(ls : NonEmpty a) →
+        { head = ls.head, tail = ls.tail # [ suffix ] }
 
 let NonEmpty/mapLast
     : ∀(a : Type) → (a → a) → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(fn : a → a)
-      → λ(ls : NonEmpty a)
-      →       if List/null a ls.tail
-
+    = λ(a : Type) →
+      λ(fn : a → a) →
+      λ(ls : NonEmpty a) →
+        if    List/null a ls.tail
         then  { head = fn ls.head, tail = [] : List a }
-
         else  let split = List/splitLast a ls.tail
 
               in  { head = ls.head
@@ -152,13 +150,11 @@ let NonEmpty/mapLast
 
 let NonEmpty/mapLeading
     : ∀(a : Type) → (a → a) → NonEmpty a → NonEmpty a
-    =   λ(a : Type)
-      → λ(fn : a → a)
-      → λ(ls : NonEmpty a)
-      →       if List/null a ls.tail
-
+    = λ(a : Type) →
+      λ(fn : a → a) →
+      λ(ls : NonEmpty a) →
+        if    List/null a ls.tail
         then  ls
-
         else  let split = List/splitLast a ls.tail
 
               in  { head = fn ls.head
@@ -175,8 +171,8 @@ let Block
 
 let Block/toLines
     : Block → Lines
-    =   λ(block : Block)
-      → merge
+    = λ(block : Block) →
+        merge
           { Simple = NonEmpty/singleton Text
           , Complex = Function/identity Lines
           }
@@ -184,11 +180,11 @@ let Block/toLines
 
 let manyBlocks
     : ∀(a : Type) → Text → (NonEmpty a → Lines) → List a → Block
-    =   λ(a : Type)
-      → λ(ifEmpty : Text)
-      → λ(render : NonEmpty a → Lines)
-      → λ(inputs : List a)
-      → merge
+    = λ(a : Type) →
+      λ(ifEmpty : Text) →
+      λ(render : NonEmpty a → Lines) →
+      λ(inputs : List a) →
+        merge
           { Some = λ(inputs : NonEmpty a) → Block.Complex (render inputs)
           , None = Block.Simple ifEmpty
           }
@@ -196,8 +192,8 @@ let manyBlocks
 
 let blockToText
     : Block → Text
-    =   λ(block : Block)
-      → Text/concatMap
+    = λ(block : Block) →
+        Text/concatMap
           Text
           (λ(line : Text) → line ++ "\n")
           (NonEmpty/toList Text (Block/toLines block))
@@ -215,10 +211,10 @@ let Format =
 let ObjectField = { mapKey : Text, mapValue : Block }
 
 let renderJSONStruct =
-        λ(prefix : Text)
-      → λ(suffix : Text)
-      → λ(blocks : NonEmpty Lines)
-      → let indent = NonEmpty/map Text Text addIndent
+      λ(prefix : Text) →
+      λ(suffix : Text) →
+      λ(blocks : NonEmpty Lines) →
+        let indent = NonEmpty/map Text Text addIndent
 
         let appendComma
             : Lines → Lines
@@ -228,40 +224,38 @@ let renderJSONStruct =
 
         let block = NonEmpty/concat Text blocks
 
-        in        if List/null Text block.tail
-
+        in  if    List/null Text block.tail
             then  NonEmpty/singleton Text "${prefix} ${block.head} ${suffix}"
-
             else  NonEmpty/prepend
                     Text
                     prefix
                     (NonEmpty/append Text suffix (indent block))
 
 let renderObject =
-        λ(format : Format)
-      → λ(fields : NonEmpty ObjectField)
-      → let keystr = λ(field : ObjectField) → "${Text/show field.mapKey}:"
+      λ(format : Format) →
+      λ(fields : NonEmpty ObjectField) →
+        let keystr = λ(field : ObjectField) → "${Text/show field.mapKey}:"
 
         let prefixKeyOnFirst =
-                λ(field : ObjectField)
-              → NonEmpty/mapHead
+              λ(field : ObjectField) →
+                NonEmpty/mapHead
                   Text
                   (addPrefix "${keystr field} ")
                   (Block/toLines field.mapValue)
 
         let prependKeyLine =
-                λ(field : ObjectField)
-              → NonEmpty/prepend
+              λ(field : ObjectField) →
+                NonEmpty/prepend
                   Text
                   (keystr field)
                   (Block/toLines field.mapValue)
 
         let renderYAMLField =
-                λ(field : ObjectField)
-              → merge
+              λ(field : ObjectField) →
+                merge
                   { Simple =
-                        λ(line : Text)
-                      → NonEmpty/singleton Text "${keystr field} ${line}"
+                      λ(line : Text) →
+                        NonEmpty/singleton Text "${keystr field} ${line}"
                   , Complex = λ(_ : Lines) → indentTail (prependKeyLine field)
                   }
                   field.mapValue
@@ -280,16 +274,16 @@ let renderObject =
               format
 
 let renderYAMLArrayField =
-        λ(block : Block)
-      → NonEmpty/mapHead
+      λ(block : Block) →
+        NonEmpty/mapHead
           Text
           (addPrefix "- ")
           (indentTail (Block/toLines block))
 
 let renderArray =
-        λ(format : Format)
-      → λ(fields : NonEmpty Block)
-      → merge
+      λ(format : Format) →
+      λ(fields : NonEmpty Block) →
+        merge
           { JSON =
               renderJSONStruct
                 "["
@@ -304,9 +298,9 @@ let renderArray =
 
 let renderAs
     : Format → JSON.Type → Text
-    =   λ(format : Format)
-      → λ(json : JSON.Type)
-      → blockToText
+    = λ(format : Format) →
+      λ(json : JSON.Type) →
+        blockToText
           ( json
               Block
               { string = λ(x : Text) → Block.Simple (Text/show x)

--- a/Prelude/JSON/renderInteger.dhall
+++ b/Prelude/JSON/renderInteger.dhall
@@ -8,11 +8,9 @@ let Integer/nonNegative =
 
 let renderInteger
     : Integer → Text
-    =   λ(integer : Integer)
-      →       if Integer/nonNegative integer
-
+    = λ(integer : Integer) →
+        if    Integer/nonNegative integer
         then  Natural/show (Integer/clamp integer)
-
         else  Integer/show integer
 
 let positive = assert : renderInteger +1 ≡ "1"

--- a/Prelude/JSON/string
+++ b/Prelude/JSON/string
@@ -16,18 +16,18 @@ let JSON =
 
 let string
     : Text → JSON
-    =   λ(x : Text)
-      → λ(JSON : Type)
-      → λ ( json
-          : { array : List JSON → JSON
-            , bool : Bool → JSON
-            , double : Double → JSON
-            , integer : Integer → JSON
-            , null : JSON
-            , object : List { mapKey : Text, mapValue : JSON } → JSON
-            , string : Text → JSON
-            }
-          )
-      → json.string x
+    = λ(x : Text) →
+      λ(JSON : Type) →
+      λ ( json
+        : { array : List JSON → JSON
+          , bool : Bool → JSON
+          , double : Double → JSON
+          , integer : Integer → JSON
+          , null : JSON
+          , object : List { mapKey : Text, mapValue : JSON } → JSON
+          , string : Text → JSON
+          }
+        ) →
+        json.string x
 
 in  string

--- a/Prelude/JSON/tagInline
+++ b/Prelude/JSON/tagInline
@@ -10,10 +10,10 @@ let Tagged =
 
 let tagInline
     : Text → ∀(a : Type) → a → Tagged a
-    =   λ(tagFieldName : Text)
-      → λ(a : Type)
-      → λ(contents : a)
-      → { nesting = Nesting.Inline, field = tagFieldName, contents = contents }
+    = λ(tagFieldName : Text) →
+      λ(a : Type) →
+      λ(contents : a) →
+        { nesting = Nesting.Inline, field = tagFieldName, contents }
 
 let example0 =
       let Example = < Left : { foo : Natural } | Right : { bar : Bool } >

--- a/Prelude/JSON/tagNested
+++ b/Prelude/JSON/tagNested
@@ -10,13 +10,13 @@ let Tagged =
 
 let tagNested
     : Text → Text → ∀(a : Type) → a → Tagged a
-    =   λ(contentsFieldName : Text)
-      → λ(tagFieldName : Text)
-      → λ(a : Type)
-      → λ(contents : a)
-      → { nesting = Nesting.Nested contentsFieldName
+    = λ(contentsFieldName : Text) →
+      λ(tagFieldName : Text) →
+      λ(a : Type) →
+      λ(contents : a) →
+        { nesting = Nesting.Nested contentsFieldName
         , field = tagFieldName
-        , contents = contents
+        , contents
         }
 
 let example0 =

--- a/Prelude/List/all
+++ b/Prelude/List/all
@@ -4,10 +4,10 @@ Returns `True` if the supplied function returns `True` for all elements in the
 -}
 let all
     : ∀(a : Type) → (a → Bool) → List a → Bool
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : List a)
-      → List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x && r) True
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : List a) →
+        List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x && r) True
 
 let example0 = assert : all Natural Natural/even [ 2, 3, 5 ] ≡ False
 

--- a/Prelude/List/any
+++ b/Prelude/List/any
@@ -4,10 +4,10 @@ Returns `True` if the supplied function returns `True` for any element in the
 -}
 let any
     : ∀(a : Type) → (a → Bool) → List a → Bool
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : List a)
-      → List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x || r) False
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : List a) →
+        List/fold a xs Bool (λ(x : a) → λ(r : Bool) → f x || r) False
 
 let example0 = assert : any Natural Natural/even [ 2, 3, 5 ] ≡ True
 

--- a/Prelude/List/build
+++ b/Prelude/List/build
@@ -2,19 +2,19 @@
 `build` is the inverse of `fold`
 -}
 let build
-    :   ∀(a : Type)
-      → (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list)
-      → List a
+    : ∀(a : Type) →
+      (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list) →
+        List a
     = List/build
 
 let example0 =
         assert
       :   build
             Text
-            (   λ(list : Type)
-              → λ(cons : Text → list → list)
-              → λ(nil : list)
-              → cons "ABC" (cons "DEF" nil)
+            ( λ(list : Type) →
+              λ(cons : Text → list → list) →
+              λ(nil : list) →
+                cons "ABC" (cons "DEF" nil)
             )
         ≡ [ "ABC", "DEF" ]
 
@@ -22,10 +22,10 @@ let example1 =
         assert
       :   build
             Text
-            (   λ(list : Type)
-              → λ(cons : Text → list → list)
-              → λ(nil : list)
-              → nil
+            ( λ(list : Type) →
+              λ(cons : Text → list → list) →
+              λ(nil : list) →
+                nil
             )
         ≡ ([] : List Text)
 

--- a/Prelude/List/concat
+++ b/Prelude/List/concat
@@ -3,14 +3,14 @@ Concatenate a `List` of `List`s into a single `List`
 -}
 let concat
     : ∀(a : Type) → List (List a) → List a
-    =   λ(a : Type)
-      → λ(xss : List (List a))
-      → List/build
+    = λ(a : Type) →
+      λ(xss : List (List a)) →
+        List/build
           a
-          (   λ(list : Type)
-            → λ(cons : a → list → list)
-            → λ(nil : list)
-            → List/fold
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+            λ(nil : list) →
+              List/fold
                 (List a)
                 xss
                 list

--- a/Prelude/List/concatMap
+++ b/Prelude/List/concatMap
@@ -4,15 +4,15 @@ results
 -}
 let concatMap
     : ∀(a : Type) → ∀(b : Type) → (a → List b) → List a → List b
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(f : a → List b)
-      → λ(xs : List a)
-      → List/build
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → List b) →
+      λ(xs : List a) →
+        List/build
           b
-          (   λ(list : Type)
-            → λ(cons : b → list → list)
-            → List/fold a xs list (λ(x : a) → List/fold b (f x) list cons)
+          ( λ(list : Type) →
+            λ(cons : b → list → list) →
+              List/fold a xs list (λ(x : a) → List/fold b (f x) list cons)
           )
 
 let example0 =

--- a/Prelude/List/default
+++ b/Prelude/List/default
@@ -4,9 +4,9 @@ Unpack an `Optional` containing a `List`, defaulting to an empty list when the
 -}
 let default
     : ∀(a : Type) → Optional (List a) → List a
-    =   λ(a : Type)
-      → λ(o : Optional (List a))
-      → merge { Some = λ(l : List a) → l, None = [] : List a } o
+    = λ(a : Type) →
+      λ(o : Optional (List a)) →
+        merge { Some = λ(l : List a) → l, None = [] : List a } o
 
 let example0 = assert : default Bool (None (List Bool)) ≡ ([] : List Bool)
 

--- a/Prelude/List/drop
+++ b/Prelude/List/drop
@@ -5,19 +5,17 @@ let Natural/greaterThanEqual =
 
 let drop
     : ∀(n : Natural) → ∀(a : Type) → List a → List a
-    =   λ(n : Natural)
-      → λ(a : Type)
-      → λ(xs : List a)
-      → List/fold
+    = λ(n : Natural) →
+      λ(a : Type) →
+      λ(xs : List a) →
+        List/fold
           { index : Natural, value : a }
           (List/indexed a xs)
           (List a)
-          (   λ(x : { index : Natural, value : a })
-            → λ(xs : List a)
-            →       if Natural/greaterThanEqual x.index n
-
+          ( λ(x : { index : Natural, value : a }) →
+            λ(xs : List a) →
+              if    Natural/greaterThanEqual x.index n
               then  [ x.value ] # xs
-
               else  xs
           )
           ([] : List a)

--- a/Prelude/List/filter
+++ b/Prelude/List/filter
@@ -5,14 +5,14 @@ Examples:
 -}
 let filter
     : ∀(a : Type) → (a → Bool) → List a → List a
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : List a)
-      → List/build
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : List a) →
+        List/build
           a
-          (   λ(list : Type)
-            → λ(cons : a → list → list)
-            → List/fold
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+              List/fold
                 a
                 xs
                 list

--- a/Prelude/List/fold
+++ b/Prelude/List/fold
@@ -5,12 +5,12 @@ If you treat the list `[ x, y, z ]` as `cons x (cons y (cons z nil))`, then a
 `fold` just replaces each `cons` and `nil` with something else
 -}
 let fold
-    :   ∀(a : Type)
-      → List a
-      → ∀(list : Type)
-      → ∀(cons : a → list → list)
-      → ∀(nil : list)
-      → list
+    : ∀(a : Type) →
+      List a →
+      ∀(list : Type) →
+      ∀(cons : a → list → list) →
+      ∀(nil : list) →
+        list
     = List/fold
 
 let example0 =
@@ -25,8 +25,8 @@ let example0 =
 
 let example1 =
         assert
-      :   (   λ(nil : Natural)
-            → fold
+      :   ( λ(nil : Natural) →
+              fold
                 Natural
                 [ 2, 3, 5 ]
                 Natural
@@ -37,15 +37,15 @@ let example1 =
 
 let example2 =
         assert
-      :   (   λ(list : Type)
-            → λ(cons : Natural → list → list)
-            → λ(nil : list)
-            → fold Natural [ 2, 3, 5 ] list cons nil
+      :   ( λ(list : Type) →
+            λ(cons : Natural → list → list) →
+            λ(nil : list) →
+              fold Natural [ 2, 3, 5 ] list cons nil
           )
-        ≡ (   λ(list : Type)
-            → λ(cons : Natural → list → list)
-            → λ(nil : list)
-            → cons 2 (cons 3 (cons 5 nil))
+        ≡ ( λ(list : Type) →
+            λ(cons : Natural → list → list) →
+            λ(nil : list) →
+              cons 2 (cons 3 (cons 5 nil))
           )
 
 in  fold

--- a/Prelude/List/generate
+++ b/Prelude/List/generate
@@ -4,22 +4,22 @@ up to but not including the supplied `Natural` number
 -}
 let generate
     : Natural → ∀(a : Type) → (Natural → a) → List a
-    =   λ(n : Natural)
-      → λ(a : Type)
-      → λ(f : Natural → a)
-      → List/build
+    = λ(n : Natural) →
+      λ(a : Type) →
+      λ(f : Natural → a) →
+        List/build
           a
-          (   λ(list : Type)
-            → λ(cons : a → list → list)
-            → List/fold
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+              List/fold
                 { index : Natural, value : {} }
                 ( List/indexed
                     {}
                     ( List/build
                         {}
-                        (   λ(list : Type)
-                          → λ(cons : {} → list → list)
-                          → Natural/fold n list (cons {=})
+                        ( λ(list : Type) →
+                          λ(cons : {} → list → list) →
+                            Natural/fold n list (cons {=})
                         )
                     )
                 )

--- a/Prelude/List/iterate
+++ b/Prelude/List/iterate
@@ -4,29 +4,29 @@ function
 -}
 let iterate
     : Natural → ∀(a : Type) → (a → a) → a → List a
-    =   λ(n : Natural)
-      → λ(a : Type)
-      → λ(f : a → a)
-      → λ(x : a)
-      → List/build
+    = λ(n : Natural) →
+      λ(a : Type) →
+      λ(f : a → a) →
+      λ(x : a) →
+        List/build
           a
-          (   λ(list : Type)
-            → λ(cons : a → list → list)
-            → List/fold
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+              List/fold
                 { index : Natural, value : {} }
                 ( List/indexed
                     {}
                     ( List/build
                         {}
-                        (   λ(list : Type)
-                          → λ(cons : {} → list → list)
-                          → Natural/fold n list (cons {=})
+                        ( λ(list : Type) →
+                          λ(cons : {} → list → list) →
+                            Natural/fold n list (cons {=})
                         )
                     )
                 )
                 list
-                (   λ(y : { index : Natural, value : {} })
-                  → cons (Natural/fold y.index a f x)
+                ( λ(y : { index : Natural, value : {} }) →
+                    cons (Natural/fold y.index a f x)
                 )
           )
 

--- a/Prelude/List/map
+++ b/Prelude/List/map
@@ -3,15 +3,15 @@ Transform a list by applying a function to each element
 -}
 let map
     : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(f : a → b)
-      → λ(xs : List a)
-      → List/build
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → b) →
+      λ(xs : List a) →
+        List/build
           b
-          (   λ(list : Type)
-            → λ(cons : b → list → list)
-            → List/fold a xs list (λ(x : a) → cons (f x))
+          ( λ(list : Type) →
+            λ(cons : b → list → list) →
+              List/fold a xs list (λ(x : a) → cons (f x))
           )
 
 let example0 =

--- a/Prelude/List/partition
+++ b/Prelude/List/partition
@@ -8,19 +8,17 @@ let Partition
 
 let partition
     : ∀(a : Type) → (a → Bool) → List a → Partition a
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : List a)
-      → List/fold
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : List a) →
+        List/fold
           a
           xs
           (Partition a)
-          (   λ(x : a)
-            → λ(p : Partition a)
-            →       if f x
-
+          ( λ(x : a) →
+            λ(p : Partition a) →
+              if    f x
               then  { true = [ x ] # p.true, false = p.false }
-
               else  { true = p.true, false = [ x ] # p.false }
           )
           { true = [] : List a, false = [] : List a }

--- a/Prelude/List/replicate
+++ b/Prelude/List/replicate
@@ -3,14 +3,14 @@ Build a list by copying the given element the specified number of times
 -}
 let replicate
     : Natural → ∀(a : Type) → a → List a
-    =   λ(n : Natural)
-      → λ(a : Type)
-      → λ(x : a)
-      → List/build
+    = λ(n : Natural) →
+      λ(a : Type) →
+      λ(x : a) →
+        List/build
           a
-          (   λ(list : Type)
-            → λ(cons : a → list → list)
-            → Natural/fold n list (cons x)
+          ( λ(list : Type) →
+            λ(cons : a → list → list) →
+              Natural/fold n list (cons x)
           )
 
 let example0 = assert : replicate 9 Natural 1 ≡ [ 1, 1, 1, 1, 1, 1, 1, 1, 1 ]

--- a/Prelude/List/shifted
+++ b/Prelude/List/shifted
@@ -3,38 +3,38 @@ Combine a `List` of `List`s, offsetting the `index` of each element by the
 number of elements in preceding lists
 -}
 let shifted
-    :   ∀(a : Type)
-      → List (List { index : Natural, value : a })
-      → List { index : Natural, value : a }
-    =   λ(a : Type)
-      → λ(kvss : List (List { index : Natural, value : a }))
-      → List/build
+    : ∀(a : Type) →
+      List (List { index : Natural, value : a }) →
+        List { index : Natural, value : a }
+    = λ(a : Type) →
+      λ(kvss : List (List { index : Natural, value : a })) →
+        List/build
           { index : Natural, value : a }
-          (   λ(list : Type)
-            → λ(cons : { index : Natural, value : a } → list → list)
-            → λ(nil : list)
-            → let result =
+          ( λ(list : Type) →
+            λ(cons : { index : Natural, value : a } → list → list) →
+            λ(nil : list) →
+              let result =
                     List/fold
                       (List { index : Natural, value : a })
                       kvss
                       { count : Natural, diff : Natural → list }
-                      (   λ(kvs : List { index : Natural, value : a })
-                        → λ(y : { count : Natural, diff : Natural → list })
-                        → let length =
+                      ( λ(kvs : List { index : Natural, value : a }) →
+                        λ(y : { count : Natural, diff : Natural → list }) →
+                          let length =
                                 List/length { index : Natural, value : a } kvs
 
                           in  { count = y.count + length
                               , diff =
-                                    λ(n : Natural)
-                                  → List/fold
+                                  λ(n : Natural) →
+                                    List/fold
                                       { index : Natural, value : a }
                                       kvs
                                       list
-                                      (   λ ( kvOld
-                                            : { index : Natural, value : a }
-                                            )
-                                        → λ(z : list)
-                                        → let kvNew =
+                                      ( λ ( kvOld
+                                          : { index : Natural, value : a }
+                                          ) →
+                                        λ(z : list) →
+                                          let kvNew =
                                                 { index = kvOld.index + n
                                                 , value = kvOld.value
                                                 }

--- a/Prelude/List/take
+++ b/Prelude/List/take
@@ -5,16 +5,16 @@ let Natural/lessThan =
 
 let take
     : ∀(n : Natural) → ∀(a : Type) → List a → List a
-    =   λ(n : Natural)
-      → λ(a : Type)
-      → λ(xs : List a)
-      → List/fold
+    = λ(n : Natural) →
+      λ(a : Type) →
+      λ(xs : List a) →
+        List/fold
           { index : Natural, value : a }
           (List/indexed a xs)
           (List a)
-          (   λ(x : { index : Natural, value : a })
-            → λ(xs : List a)
-            → if Natural/lessThan x.index n then [ x.value ] # xs else xs
+          ( λ(x : { index : Natural, value : a }) →
+            λ(xs : List a) →
+              if Natural/lessThan x.index n then [ x.value ] # xs else xs
           )
           ([] : List a)
 

--- a/Prelude/List/unzip
+++ b/Prelude/List/unzip
@@ -2,19 +2,19 @@
 Unzip a `List` into two separate `List`s
 -}
 let unzip
-    :   ∀(a : Type)
-      → ∀(b : Type)
-      → List { _1 : a, _2 : b }
-      → { _1 : List a, _2 : List b }
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(xs : List { _1 : a, _2 : b })
-      → { _1 =
+    : ∀(a : Type) →
+      ∀(b : Type) →
+      List { _1 : a, _2 : b } →
+        { _1 : List a, _2 : List b }
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(xs : List { _1 : a, _2 : b }) →
+        { _1 =
             List/build
               a
-              (   λ(list : Type)
-                → λ(cons : a → list → list)
-                → List/fold
+              ( λ(list : Type) →
+                λ(cons : a → list → list) →
+                  List/fold
                     { _1 : a, _2 : b }
                     xs
                     list
@@ -23,9 +23,9 @@ let unzip
         , _2 =
             List/build
               b
-              (   λ(list : Type)
-                → λ(cons : b → list → list)
-                → List/fold
+              ( λ(list : Type) →
+                λ(cons : b → list → list) →
+                  List/fold
                     { _1 : a, _2 : b }
                     xs
                     list

--- a/Prelude/List/zip
+++ b/Prelude/List/zip
@@ -4,20 +4,21 @@ Zip two `List` into a single `List`
 Resulting `List` will have the length of the shortest of its arguments.
 -}
 let List/drop =
-      ./drop sha256:af983ba3ead494dd72beed05c0f3a17c36a4244adedf7ced502c6512196ed0cf
+        ./drop sha256:af983ba3ead494dd72beed05c0f3a17c36a4244adedf7ced502c6512196ed0cf
+      ? ./drop
 
 let zip
     : ∀(a : Type) → List a → ∀(b : Type) → List b → List { _1 : a, _2 : b }
-    =   λ(a : Type)
-      → λ(xa : List a)
-      → λ(b : Type)
-      → λ(xb : List b)
-      → let Carry = { acc : List { _1 : a, _2 : b }, context : List b }
+    = λ(a : Type) →
+      λ(xa : List a) →
+      λ(b : Type) →
+      λ(xb : List b) →
+        let Carry = { acc : List { _1 : a, _2 : b }, context : List b }
 
         let cons =
-                λ(elem : a)
-              → λ(prev : Carry)
-              → let nextAcc =
+              λ(elem : a) →
+              λ(prev : Carry) →
+                let nextAcc =
                       merge
                         { Some =
                             λ(bb : b) → [ { _1 = elem, _2 = bb } ] # prev.acc

--- a/Prelude/Location/Type
+++ b/Prelude/Location/Type
@@ -6,9 +6,8 @@ let Location
 
 let example0 =
         assert
-      :   (   missing sha256:f428188ff9d77ea15bc2bcd0da3f8ed81b304e175b07ade42a3b0fb02941b2aa as Location
-            ? missing as Location
-          )
+      :     missing sha256:f428188ff9d77ea15bc2bcd0da3f8ed81b304e175b07ade42a3b0fb02941b2aa as Location
+          ? missing as Location
         ≡ < Environment : Text
           | Local : Text
           | Missing

--- a/Prelude/Map/keyValue
+++ b/Prelude/Map/keyValue
@@ -3,10 +3,10 @@ Builds a key-value record such that a List of them will be converted to a
 homogeneous record by dhall-to-json and dhall-to-yaml.
 -}
 let keyValue =
-        λ(v : Type)
-      → λ(key : Text)
-      → λ(value : v)
-      → { mapKey = key, mapValue = value }
+      λ(v : Type) →
+      λ(key : Text) →
+      λ(value : v) →
+        { mapKey = key, mapValue = value }
 
 let example0 =
       assert : keyValue Natural "foo" 2 ≡ { mapKey = "foo", mapValue = 2 }

--- a/Prelude/Map/keys
+++ b/Prelude/Map/keys
@@ -15,9 +15,9 @@ let List/map =
 
 let keys
     : ∀(k : Type) → ∀(v : Type) → Map k v → List k
-    =   λ(k : Type)
-      → λ(v : Type)
-      → List/map (Entry k v) k (λ(x : Entry k v) → x.mapKey)
+    = λ(k : Type) →
+      λ(v : Type) →
+        List/map (Entry k v) k (λ(x : Entry k v) → x.mapKey)
 
 let example0 =
         assert

--- a/Prelude/Map/map
+++ b/Prelude/Map/map
@@ -15,16 +15,16 @@ let List/map =
 
 let map
     : ∀(k : Type) → ∀(a : Type) → ∀(b : Type) → (a → b) → Map k a → Map k b
-    =   λ(k : Type)
-      → λ(a : Type)
-      → λ(b : Type)
-      → λ(f : a → b)
-      → λ(m : Map k a)
-      → List/map
+    = λ(k : Type) →
+      λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → b) →
+      λ(m : Map k a) →
+        List/map
           (Entry k a)
           (Entry k b)
-          (   λ(before : Entry k a)
-            → { mapKey = before.mapKey, mapValue = f before.mapValue }
+          ( λ(before : Entry k a) →
+              { mapKey = before.mapKey, mapValue = f before.mapValue }
           )
           m
 

--- a/Prelude/Map/values
+++ b/Prelude/Map/values
@@ -15,9 +15,9 @@ let List/map =
 
 let values
     : ∀(k : Type) → ∀(v : Type) → Map k v → List v
-    =   λ(k : Type)
-      → λ(v : Type)
-      → List/map (Entry k v) v (λ(x : Entry k v) → x.mapValue)
+    = λ(k : Type) →
+      λ(v : Type) →
+        List/map (Entry k v) v (λ(x : Entry k v) → x.mapValue)
 
 let example0 =
         assert

--- a/Prelude/Natural/build
+++ b/Prelude/Natural/build
@@ -2,31 +2,31 @@
 `build` is the inverse of `fold`
 -}
 let build
-    :   (   ∀(natural : Type)
-          → ∀(succ : natural → natural)
-          → ∀(zero : natural)
-          → natural
-        )
-      → Natural
+    : ( ∀(natural : Type) →
+        ∀(succ : natural → natural) →
+        ∀(zero : natural) →
+          natural
+      ) →
+        Natural
     = Natural/build
 
 let example0 =
         assert
       :   build
-            (   λ(natural : Type)
-              → λ(succ : natural → natural)
-              → λ(zero : natural)
-              → succ (succ (succ zero))
+            ( λ(natural : Type) →
+              λ(succ : natural → natural) →
+              λ(zero : natural) →
+                succ (succ (succ zero))
             )
         ≡ 3
 
 let example1 =
         assert
       :   build
-            (   λ(natural : Type)
-              → λ(succ : natural → natural)
-              → λ(zero : natural)
-              → zero
+            ( λ(natural : Type) →
+              λ(succ : natural → natural) →
+              λ(zero : natural) →
+                zero
             )
         ≡ 0
 

--- a/Prelude/Natural/enumerate
+++ b/Prelude/Natural/enumerate
@@ -4,20 +4,20 @@ number
 -}
 let enumerate
     : Natural → List Natural
-    =   λ(n : Natural)
-      → List/build
+    = λ(n : Natural) →
+        List/build
           Natural
-          (   λ(list : Type)
-            → λ(cons : Natural → list → list)
-            → List/fold
+          ( λ(list : Type) →
+            λ(cons : Natural → list → list) →
+              List/fold
                 { index : Natural, value : {} }
                 ( List/indexed
                     {}
                     ( List/build
                         {}
-                        (   λ(list : Type)
-                          → λ(cons : {} → list → list)
-                          → Natural/fold n list (cons {=})
+                        ( λ(list : Type) →
+                          λ(cons : {} → list → list) →
+                            Natural/fold n list (cons {=})
                         )
                     )
                 )

--- a/Prelude/Natural/fold
+++ b/Prelude/Natural/fold
@@ -5,11 +5,11 @@ If you treat the number `3` as `succ (succ (succ zero))` then a `fold` just
 replaces each `succ` and `zero` with something else
 -}
 let fold
-    :   Natural
-      → ∀(natural : Type)
-      → ∀(succ : natural → natural)
-      → ∀(zero : natural)
-      → natural
+    : Natural →
+      ∀(natural : Type) →
+      ∀(succ : natural → natural) →
+      ∀(zero : natural) →
+        natural
     = Natural/fold
 
 let example0 = assert : fold 3 Natural (λ(x : Natural) → 5 * x) 1 ≡ 125
@@ -21,15 +21,15 @@ let example1 =
 
 let example2 =
         assert
-      :   (   λ(natural : Type)
-            → λ(succ : natural → natural)
-            → λ(zero : natural)
-            → fold 3 natural succ zero
+      :   ( λ(natural : Type) →
+            λ(succ : natural → natural) →
+            λ(zero : natural) →
+              fold 3 natural succ zero
           )
-        ≡ (   λ(natural : Type)
-            → λ(succ : natural → natural)
-            → λ(zero : natural)
-            → succ (succ (succ zero))
+        ≡ ( λ(natural : Type) →
+            λ(succ : natural → natural) →
+            λ(zero : natural) →
+              succ (succ (succ zero))
           )
 
 in  fold

--- a/Prelude/Natural/listMax
+++ b/Prelude/Natural/listMax
@@ -12,8 +12,8 @@ let Optional/map =
 
 let listMax
     : List Natural → Optional Natural
-    =   λ(xs : List Natural)
-      → Optional/map
+    = λ(xs : List Natural) →
+        Optional/map
           Natural
           Natural
           (λ(n : Natural) → List/fold Natural xs Natural max n)

--- a/Prelude/Natural/listMin
+++ b/Prelude/Natural/listMin
@@ -12,12 +12,12 @@ let Optional/map =
 
 let listMin
     : List Natural → Optional Natural
-    =   λ(xs : List Natural)
-      → Optional/map
+    = λ(xs : List Natural) →
+        Optional/map
           Natural
           Natural
-          (   λ(n : Natural)
-            → if Natural/isZero n then n else List/fold Natural xs Natural min n
+          ( λ(n : Natural) →
+              if Natural/isZero n then n else List/fold Natural xs Natural min n
           )
           (List/head Natural xs)
 

--- a/Prelude/Natural/product
+++ b/Prelude/Natural/product
@@ -3,8 +3,8 @@ Multiply all the numbers in a `List`
 -}
 let product
     : List Natural → Natural
-    =   λ(xs : List Natural)
-      → List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l * r) 1
+    = λ(xs : List Natural) →
+        List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l * r) 1
 
 let example0 = assert : product [ 2, 3, 5 ] ≡ 30
 

--- a/Prelude/Natural/sort
+++ b/Prelude/Natural/sort
@@ -16,8 +16,8 @@ let List/partition =
 let Accumulator = { sorted : List Natural, rest : List Natural }
 
 let partitionMinima =
-        λ(xs : List Natural)
-      → merge
+      λ(xs : List Natural) →
+        merge
           { Some =
               λ(m : Natural) → List/partition Natural (greaterThanEqual m) xs
           , None = { true = [] : List Natural, false = [] : List Natural }
@@ -29,8 +29,8 @@ let test0 =
       : partitionMinima [ 2, 1, 1, 3 ] ≡ { true = [ 1, 1 ], false = [ 2, 3 ] }
 
 let step =
-        λ(x : Accumulator)
-      → let p = partitionMinima x.rest
+      λ(x : Accumulator) →
+        let p = partitionMinima x.rest
 
         in  { sorted = x.sorted # p.true, rest = p.false }
 
@@ -41,8 +41,8 @@ let test1 =
 
 let sort
     : List Natural → List Natural
-    =   λ(xs : List Natural)
-      → let x =
+    = λ(xs : List Natural) →
+        let x =
               Natural/fold
                 (List/length Natural xs)
                 Accumulator

--- a/Prelude/Natural/sum
+++ b/Prelude/Natural/sum
@@ -3,8 +3,8 @@ Add all the numbers in a `List`
 -}
 let sum
     : List Natural → Natural
-    =   λ(xs : List Natural)
-      → List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l + r) 0
+    = λ(xs : List Natural) →
+        List/fold Natural xs Natural (λ(l : Natural) → λ(r : Natural) → l + r) 0
 
 let example = assert : sum [ 2, 3, 5 ] ≡ 10
 

--- a/Prelude/Optional/all
+++ b/Prelude/Optional/all
@@ -4,10 +4,10 @@ and `True` otherwise:
 -}
 let all
     : ∀(a : Type) → (a → Bool) → Optional a → Bool
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : Optional a)
-      → merge { Some = f, None = True } xs
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : Optional a) →
+        merge { Some = f, None = True } xs
 
 let example0 = assert : all Natural Natural/even (Some 3) ≡ False
 

--- a/Prelude/Optional/any
+++ b/Prelude/Optional/any
@@ -4,10 +4,10 @@ Returns `True` if the supplied function returns `True` for a present element and
 -}
 let any
     : ∀(a : Type) → (a → Bool) → Optional a → Bool
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : Optional a)
-      → merge { Some = f, None = False } xs
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : Optional a) →
+        merge { Some = f, None = False } xs
 
 let example0 = assert : any Natural Natural/even (Some 2) ≡ True
 

--- a/Prelude/Optional/build
+++ b/Prelude/Optional/build
@@ -2,30 +2,30 @@
 `build` is the inverse of `fold`
 -}
 let build
-    :   ∀(a : Type)
-      → (   ∀(optional : Type)
-          → ∀(some : a → optional)
-          → ∀(none : optional)
-          → optional
-        )
-      → Optional a
-    =   λ(a : Type)
-      → λ ( build
-          :   ∀(optional : Type)
-            → ∀(some : a → optional)
-            → ∀(none : optional)
-            → optional
-          )
-      → build (Optional a) (λ(x : a) → Some x) (None a)
+    : ∀(a : Type) →
+      ( ∀(optional : Type) →
+        ∀(some : a → optional) →
+        ∀(none : optional) →
+          optional
+      ) →
+        Optional a
+    = λ(a : Type) →
+      λ ( build
+        : ∀(optional : Type) →
+          ∀(some : a → optional) →
+          ∀(none : optional) →
+            optional
+        ) →
+        build (Optional a) (λ(x : a) → Some x) (None a)
 
 let example0 =
         assert
       :   build
             Natural
-            (   λ(optional : Type)
-              → λ(some : Natural → optional)
-              → λ(none : optional)
-              → some 1
+            ( λ(optional : Type) →
+              λ(some : Natural → optional) →
+              λ(none : optional) →
+                some 1
             )
         ≡ Some 1
 
@@ -33,10 +33,10 @@ let example1 =
         assert
       :   build
             Natural
-            (   λ(optional : Type)
-              → λ(some : Natural → optional)
-              → λ(none : optional)
-              → none
+            ( λ(optional : Type) →
+              λ(some : Natural → optional) →
+              λ(none : optional) →
+                none
             )
         ≡ None Natural
 

--- a/Prelude/Optional/concat
+++ b/Prelude/Optional/concat
@@ -3,9 +3,9 @@ Flatten two `Optional` layers into a single `Optional` layer
 -}
 let concat
     : ∀(a : Type) → Optional (Optional a) → Optional a
-    =   λ(a : Type)
-      → λ(x : Optional (Optional a))
-      → merge { Some = λ(y : Optional a) → y, None = None a } x
+    = λ(a : Type) →
+      λ(x : Optional (Optional a)) →
+        merge { Some = λ(y : Optional a) → y, None = None a } x
 
 let example0 = assert : concat Natural (Some (Some 1)) ≡ Some 1
 

--- a/Prelude/Optional/default
+++ b/Prelude/Optional/default
@@ -3,10 +3,10 @@ Unpack an `Optional`, returning the default when it's `None`.
 -}
 let default
     : ∀(a : Type) → a → Optional a → a
-    =   λ(a : Type)
-      → λ(default : a)
-      → λ(o : Optional a)
-      → merge { Some = λ(x : a) → x, None = default } o
+    = λ(a : Type) →
+      λ(default : a) →
+      λ(o : Optional a) →
+        merge { Some = λ(x : a) → x, None = default } o
 
 let example0 = assert : default Bool False (None Bool) ≡ False
 

--- a/Prelude/Optional/filter
+++ b/Prelude/Optional/filter
@@ -3,23 +3,23 @@ Only keep an `Optional` element if the supplied function returns `True`
 -}
 let filter
     : ∀(a : Type) → (a → Bool) → Optional a → Optional a
-    =   λ(a : Type)
-      → λ(f : a → Bool)
-      → λ(xs : Optional a)
-      → (   λ(a : Type)
-          → λ ( build
-              :   ∀(optional : Type)
-                → ∀(some : a → optional)
-                → ∀(none : optional)
-                → optional
-              )
-          → build (Optional a) (λ(x : a) → Some x) (None a)
+    = λ(a : Type) →
+      λ(f : a → Bool) →
+      λ(xs : Optional a) →
+        ( λ(a : Type) →
+          λ ( build
+            : ∀(optional : Type) →
+              ∀(some : a → optional) →
+              ∀(none : optional) →
+                optional
+            ) →
+            build (Optional a) (λ(x : a) → Some x) (None a)
         )
           a
-          (   λ(optional : Type)
-            → λ(some : a → optional)
-            → λ(none : optional)
-            → merge
+          ( λ(optional : Type) →
+            λ(some : a → optional) →
+            λ(none : optional) →
+              merge
                 { Some = λ(x : a) → if f x then some x else none, None = none }
                 xs
           )

--- a/Prelude/Optional/fold
+++ b/Prelude/Optional/fold
@@ -2,18 +2,18 @@
 `fold` is the primitive function for consuming `Optional` values
 -}
 let fold
-    :   ∀(a : Type)
-      → Optional a
-      → ∀(optional : Type)
-      → ∀(some : a → optional)
-      → ∀(none : optional)
-      → optional
-    =   λ(a : Type)
-      → λ(o : Optional a)
-      → λ(optional : Type)
-      → λ(some : a → optional)
-      → λ(none : optional)
-      → merge { Some = some, None = none } o
+    : ∀(a : Type) →
+      Optional a →
+      ∀(optional : Type) →
+      ∀(some : a → optional) →
+      ∀(none : optional) →
+        optional
+    = λ(a : Type) →
+      λ(o : Optional a) →
+      λ(optional : Type) →
+      λ(some : a → optional) →
+      λ(none : optional) →
+        merge { Some = some, None = none } o
 
 let example0 = assert : fold Natural (Some 2) Natural (λ(x : Natural) → x) 0 ≡ 2
 

--- a/Prelude/Optional/head
+++ b/Prelude/Optional/head
@@ -3,15 +3,15 @@ Returns the first non-empty `Optional` value in a `List`
 -}
 let head
     : ∀(a : Type) → List (Optional a) → Optional a
-    =   λ(a : Type)
-      → λ(xs : List (Optional a))
-      → List/fold
+    = λ(a : Type) →
+      λ(xs : List (Optional a)) →
+        List/fold
           (Optional a)
           xs
           (Optional a)
-          (   λ(l : Optional a)
-            → λ(r : Optional a)
-            → merge { Some = λ(x : a) → Some x, None = r } l
+          ( λ(l : Optional a) →
+            λ(r : Optional a) →
+              merge { Some = λ(x : a) → Some x, None = r } l
           )
           (None a)
 

--- a/Prelude/Optional/last
+++ b/Prelude/Optional/last
@@ -3,15 +3,15 @@ Returns the last non-empty `Optional` value in a `List`
 -}
 let last
     : ∀(a : Type) → List (Optional a) → Optional a
-    =   λ(a : Type)
-      → λ(xs : List (Optional a))
-      → List/fold
+    = λ(a : Type) →
+      λ(xs : List (Optional a)) →
+        List/fold
           (Optional a)
           xs
           (Optional a)
-          (   λ(l : Optional a)
-            → λ(r : Optional a)
-            → merge { Some = λ(x : a) → Some x, None = l } r
+          ( λ(l : Optional a) →
+            λ(r : Optional a) →
+              merge { Some = λ(x : a) → Some x, None = l } r
           )
           (None a)
 

--- a/Prelude/Optional/length
+++ b/Prelude/Optional/length
@@ -3,9 +3,9 @@ Returns `1` if the `Optional` value is present and `0` if the value is absent
 -}
 let length
     : ∀(a : Type) → Optional a → Natural
-    =   λ(a : Type)
-      → λ(xs : Optional a)
-      → merge { Some = λ(_ : a) → 1, None = 0 } xs
+    = λ(a : Type) →
+      λ(xs : Optional a) →
+        merge { Some = λ(_ : a) → 1, None = 0 } xs
 
 let example0 = assert : length Natural (Some 2) ≡ 1
 

--- a/Prelude/Optional/map
+++ b/Prelude/Optional/map
@@ -3,11 +3,11 @@ Transform an `Optional` value with a function
 -}
 let map
     : ∀(a : Type) → ∀(b : Type) → (a → b) → Optional a → Optional b
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(f : a → b)
-      → λ(o : Optional a)
-      → merge { Some = λ(x : a) → Some (f x), None = None b } o
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → b) →
+      λ(o : Optional a) →
+        merge { Some = λ(x : a) → Some (f x), None = None b } o
 
 let example0 = assert : map Natural Bool Natural/even (Some 3) ≡ Some False
 

--- a/Prelude/Optional/null
+++ b/Prelude/Optional/null
@@ -3,9 +3,9 @@ Returns `True` if the `Optional` value is absent and `False` if present
 -}
 let null
     : ∀(a : Type) → Optional a → Bool
-    =   λ(a : Type)
-      → λ(xs : Optional a)
-      → merge { Some = λ(_ : a) → False, None = True } xs
+    = λ(a : Type) →
+      λ(xs : Optional a) →
+        merge { Some = λ(_ : a) → False, None = True } xs
 
 let example0 = assert : null Natural (Some 2) ≡ False
 

--- a/Prelude/Optional/toList
+++ b/Prelude/Optional/toList
@@ -3,9 +3,9 @@ Convert an `Optional` value into the equivalent `List`
 -}
 let toList
     : ∀(a : Type) → Optional a → List a
-    =   λ(a : Type)
-      → λ(o : Optional a)
-      → merge { Some = λ(x : a) → [ x ] : List a, None = [] : List a } o
+    = λ(a : Type) →
+      λ(o : Optional a) →
+        merge { Some = λ(x : a) → [ x ] : List a, None = [] : List a } o
 
 let example0 = assert : toList Natural (Some 1) ≡ [ 1 ]
 

--- a/Prelude/Optional/unzip
+++ b/Prelude/Optional/unzip
@@ -2,14 +2,14 @@
 Unzip an `Optional` value into two separate `Optional` values
 -}
 let unzip
-    :   ∀(a : Type)
-      → ∀(b : Type)
-      → Optional { _1 : a, _2 : b }
-      → { _1 : Optional a, _2 : Optional b }
-    =   λ(a : Type)
-      → λ(b : Type)
-      → λ(xs : Optional { _1 : a, _2 : b })
-      → { _1 =
+    : ∀(a : Type) →
+      ∀(b : Type) →
+      Optional { _1 : a, _2 : b } →
+        { _1 : Optional a, _2 : Optional b }
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(xs : Optional { _1 : a, _2 : b }) →
+        { _1 =
             merge
               { Some = λ(x : { _1 : a, _2 : b }) → Some x._1, None = None a }
               xs

--- a/Prelude/Text/concat
+++ b/Prelude/Text/concat
@@ -3,8 +3,8 @@ Concatenate all the `Text` values in a `List`
 -}
 let concat
     : List Text → Text
-    =   λ(xs : List Text)
-      → List/fold Text xs Text (λ(x : Text) → λ(y : Text) → x ++ y) ""
+    = λ(xs : List Text) →
+        List/fold Text xs Text (λ(x : Text) → λ(y : Text) → x ++ y) ""
 
 let example0 = assert : concat [ "ABC", "DEF", "GHI" ] ≡ "ABCDEFGHI"
 

--- a/Prelude/Text/concatMap
+++ b/Prelude/Text/concatMap
@@ -3,10 +3,10 @@ Transform each value in a `List` into `Text` and concatenate the result
 -}
 let concatMap
     : ∀(a : Type) → (a → Text) → List a → Text
-    =   λ(a : Type)
-      → λ(f : a → Text)
-      → λ(xs : List a)
-      → List/fold a xs Text (λ(x : a) → λ(y : Text) → f x ++ y) ""
+    = λ(a : Type) →
+      λ(f : a → Text) →
+      λ(xs : List a) →
+        List/fold a xs Text (λ(x : a) → λ(y : Text) → f x ++ y) ""
 
 let example0 =
         assert

--- a/Prelude/Text/concatMapSep
+++ b/Prelude/Text/concatMapSep
@@ -6,22 +6,22 @@ let Status = < Empty | NonEmpty : Text >
 
 let concatMapSep
     : ∀(separator : Text) → ∀(a : Type) → (a → Text) → List a → Text
-    =   λ(separator : Text)
-      → λ(a : Type)
-      → λ(f : a → Text)
-      → λ(elements : List a)
-      → let status =
+    = λ(separator : Text) →
+      λ(a : Type) →
+      λ(f : a → Text) →
+      λ(elements : List a) →
+        let status =
               List/fold
                 a
                 elements
                 Status
-                (   λ(x : a)
-                  → λ(status : Status)
-                  → merge
+                ( λ(x : a) →
+                  λ(status : Status) →
+                    merge
                       { Empty = Status.NonEmpty (f x)
                       , NonEmpty =
-                            λ(result : Text)
-                          → Status.NonEmpty (f x ++ separator ++ result)
+                          λ(result : Text) →
+                            Status.NonEmpty (f x ++ separator ++ result)
                       }
                       status
                 )

--- a/Prelude/Text/concatSep
+++ b/Prelude/Text/concatSep
@@ -5,20 +5,20 @@ let Status = < Empty | NonEmpty : Text >
 
 let concatSep
     : ∀(separator : Text) → ∀(elements : List Text) → Text
-    =   λ(separator : Text)
-      → λ(elements : List Text)
-      → let status =
+    = λ(separator : Text) →
+      λ(elements : List Text) →
+        let status =
               List/fold
                 Text
                 elements
                 Status
-                (   λ(element : Text)
-                  → λ(status : Status)
-                  → merge
+                ( λ(element : Text) →
+                  λ(status : Status) →
+                    merge
                       { Empty = Status.NonEmpty element
                       , NonEmpty =
-                            λ(result : Text)
-                          → Status.NonEmpty (element ++ separator ++ result)
+                          λ(result : Text) →
+                            Status.NonEmpty (element ++ separator ++ result)
                       }
                       status
                 )

--- a/Prelude/Text/defaultMap
+++ b/Prelude/Text/defaultMap
@@ -3,10 +3,10 @@ Transform the value in an `Optional` into `Text`, defaulting `None` to `""`
 -}
 let defaultMap
     : ∀(a : Type) → (a → Text) → Optional a → Text
-    =   λ(a : Type)
-      → λ(f : a → Text)
-      → λ(o : Optional a)
-      → merge { Some = f, None = "" } o
+    = λ(a : Type) →
+      λ(f : a → Text) →
+      λ(o : Optional a) →
+        merge { Some = f, None = "" } o
 
 let example0 = assert : defaultMap Natural Natural/show (Some 0) ≡ "0"
 

--- a/Prelude/XML/Type
+++ b/Prelude/XML/Type
@@ -46,17 +46,17 @@
 
 let XML/Type
     : Type
-    =   ∀(XML : Type)
-      → ∀ ( xml
-          : { text : Text → XML
-            , element :
-                  { attributes : List { mapKey : Text, mapValue : Text }
-                  , content : List XML
-                  , name : Text
-                  }
-                → XML
-            }
-          )
-      → XML
+    = ∀(XML : Type) →
+      ∀ ( xml
+        : { text : Text → XML
+          , element :
+              { attributes : List { mapKey : Text, mapValue : Text }
+              , content : List XML
+              , name : Text
+              } →
+                XML
+          }
+        ) →
+        XML
 
 in  XML/Type

--- a/Prelude/XML/element
+++ b/Prelude/XML/element
@@ -36,19 +36,19 @@ let Args =
 
 let element
     : Args → XML
-    =   λ(elem : Args)
-      → λ(XML : Type)
-      → λ ( xml
-          : { text : Text → XML
-            , element :
-                  { attributes : List { mapKey : Text, mapValue : Text }
-                  , content : List XML
-                  , name : Text
-                  }
-                → XML
-            }
-          )
-      → xml.element
+    = λ(elem : Args) →
+      λ(XML : Type) →
+      λ ( xml
+        : { text : Text → XML
+          , element :
+              { attributes : List { mapKey : Text, mapValue : Text }
+              , content : List XML
+              , name : Text
+              } →
+                XML
+          }
+        ) →
+        xml.element
           { attributes = elem.attributes
           , name = elem.name
           , content = List/map XML@1 XML (λ(x : XML@1) → x XML xml) elem.content

--- a/Prelude/XML/leaf
+++ b/Prelude/XML/leaf
@@ -18,13 +18,11 @@ let element =
       ? ./element
 
 let leaf
-    :   { attributes : List { mapKey : Text, mapValue : Text }, name : Text }
-      → XML
-    =   λ ( elem
-          : { attributes : List { mapKey : Text, mapValue : Text }
-            , name : Text
-            }
-          )
-      → element (elem ⫽ { content = [] : List XML })
+    : { attributes : List { mapKey : Text, mapValue : Text }, name : Text } →
+        XML
+    = λ ( elem
+        : { attributes : List { mapKey : Text, mapValue : Text }, name : Text }
+        ) →
+        element (elem ⫽ { content = [] : List XML })
 
 in  leaf

--- a/Prelude/XML/render
+++ b/Prelude/XML/render
@@ -40,25 +40,22 @@ let renderAttr = λ(x : Attr) → " ${x.mapKey}=\"${x.mapValue}\""
 
 let render
     : XML → Text
-    =   λ(x : XML)
-      → x
+    = λ(x : XML) →
+        x
           Text
           { text = λ(d : Text) → d
           , element =
-                λ ( elem
-                  : { attributes : List { mapKey : Text, mapValue : Text }
-                    , content : List Text
-                    , name : Text
-                    }
-                  )
-              → let attribs = Text/concatMap Attr renderAttr elem.attributes
+              λ ( elem
+                : { attributes : List { mapKey : Text, mapValue : Text }
+                  , content : List Text
+                  , name : Text
+                  }
+                ) →
+                let attribs = Text/concatMap Attr renderAttr elem.attributes
 
                 in      "<${elem.name}${attribs}"
-                    ++  (       if Natural/isZero
-                                     (List/length Text elem.content)
-
+                    ++  ( if    Natural/isZero (List/length Text elem.content)
                           then  "/>"
-
                           else  ">${Text/concat elem.content}</${elem.name}>"
                         )
           }

--- a/Prelude/XML/text
+++ b/Prelude/XML/text
@@ -20,18 +20,18 @@ let XML =
 
 let text
     : Text → XML
-    =   λ(d : Text)
-      → λ(XML : Type)
-      → λ ( xml
-          : { text : Text → XML
-            , element :
-                  { attributes : List { mapKey : Text, mapValue : Text }
-                  , content : List XML
-                  , name : Text
-                  }
-                → XML
-            }
-          )
-      → xml.text d
+    = λ(d : Text) →
+      λ(XML : Type) →
+      λ ( xml
+        : { text : Text → XML
+          , element :
+              { attributes : List { mapKey : Text, mapValue : Text }
+              , content : List XML
+              , name : Text
+              } →
+                XML
+          }
+        ) →
+        xml.text d
 
 in  text

--- a/docs/discussions/Core-language-features.md
+++ b/docs/discussions/Core-language-features.md
@@ -108,10 +108,8 @@ configuration file, which supports multi-line string literals (like YAML):
 ```dhall
 -- example0.dhall
 
-[ { name =
-      "dhall"
-  , author =
-      "Gabriel Gonzalez"
+[ { name = "dhall"
+  , author = "Gabriel Gonzalez"
   , license =
       ''
       Copyright 2017 Gabriel Gonzalez
@@ -142,10 +140,8 @@ configuration file, which supports multi-line string literals (like YAML):
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ''
   }
-, { name =
-      "conduit"
-  , author =
-      "Michael Snoyman"
+, { name = "conduit"
+  , author = "Michael Snoyman"
   , license =
       ''
       Copyright 2012 Michael Snoyman
@@ -169,10 +165,8 @@ configuration file, which supports multi-line string literals (like YAML):
       SOFTWARE.
       ''
   }
-, { name =
-      "async"
-  , author =
-      "Simon Marlow"
+, { name = "async"
+  , author = "Simon Marlow"
   , license =
       ''
       Copyright 2012 Simon Marlow
@@ -203,10 +197,8 @@ configuration file, which supports multi-line string literals (like YAML):
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ''
   }
-, { name =
-      "system-filepath"
-  , author =
-      "John Milikin"
+, { name = "system-filepath"
+  , author = "John Milikin"
   , license =
       ''
       Copyright 2010 John Milikin
@@ -270,10 +262,8 @@ We could add comments with the name of each license (since Dhall, unlike JSON,
 supports comments):
 
 ```dhall
-[ { name =
-      "dhall"
-  , author =
-      "Gabriel Gonzalez"
+[ { name = "dhall"
+  , author = "Gabriel Gonzalez"
 
     -- BSD 3-Clause
   , license =
@@ -285,10 +275,8 @@ supports comments):
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ''
   }
-, { name =
-      "conduit"
-  , author =
-      "Michael Snoyman"
+, { name = "conduit"
+  , author = "Michael Snoyman"
 
     -- MIT
   , license =
@@ -300,10 +288,8 @@ supports comments):
       SOFTWARE.
       ''
   }
-, { name =
-      "async"
-  , author =
-      "Simon Marlow"
+, { name = "async"
+  , author = "Simon Marlow"
 
     -- BSD 3-Clause
   , license =
@@ -315,10 +301,8 @@ supports comments):
       OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       ''
   }
-, { name =
-      "system-filepath"
-  , author =
-      "John Milikin"
+, { name = "system-filepath"
+  , author = "John Milikin"
 
     -- MIT
   , license =
@@ -339,87 +323,75 @@ supports comments):
 -- example1.dhall
 
 let BSD-3-Clause =
-          \(args : { year : Natural, author : Text })
-      ->  ''
-          Copyright ${Natural/show args.year} ${args.author}
+      \(args : { year : Natural, author : Text }) ->
+        ''
+        Copyright ${Natural/show args.year} ${args.author}
 
-          Redistribution and use in source and binary forms, with or without
-          modification, are permitted provided that the following conditions are met:
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
 
-          1. Redistributions of source code must retain the above copyright notice, this
-             list of conditions and the following disclaimer.
+        1. Redistributions of source code must retain the above copyright notice, this
+           list of conditions and the following disclaimer.
 
-          2. Redistributions in binary form must reproduce the above copyright notice,
-             this list of conditions and the following disclaimer in the documentation
-             and/or other materials provided with the distribution.
+        2. Redistributions in binary form must reproduce the above copyright notice,
+           this list of conditions and the following disclaimer in the documentation
+           and/or other materials provided with the distribution.
 
-          3. Neither the name of the copyright holder nor the names of its contributors
-             may be used to endorse or promote products derived from this software without
-             specific prior written permission.
+        3. Neither the name of the copyright holder nor the names of its contributors
+           may be used to endorse or promote products derived from this software without
+           specific prior written permission.
 
-          THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-          ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-          WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-          DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-          FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-          DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-          SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-          CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-          OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-          OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-          ''
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        ''
 
 let MIT =
-          \(args : { year : Natural, author : Text })
-      ->  ''
-          Copyright ${Natural/show args.year} ${args.author}
+      \(args : { year : Natural, author : Text }) ->
+        ''
+        Copyright ${Natural/show args.year} ${args.author}
 
-          Permission is hereby granted, free of charge, to any person obtaining a copy of
-          this software and associated documentation files (the "Software"), to deal in
-          the Software without restriction, including without limitation the rights to
-          use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-          of the Software, and to permit persons to whom the Software is furnished to do
-          so, subject to the following conditions:
+        Permission is hereby granted, free of charge, to any person obtaining a copy of
+        this software and associated documentation files (the "Software"), to deal in
+        the Software without restriction, including without limitation the rights to
+        use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+        of the Software, and to permit persons to whom the Software is furnished to do
+        so, subject to the following conditions:
 
-          The above copyright notice and this permission notice shall be included in all
-          copies or substantial portions of the Software.
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
 
-          THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-          IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-          FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-          AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-          LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-          OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-          SOFTWARE.
-          ''
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+        ''
 
-in  [ { name =
-          "dhall"
-      , author =
-          "Gabriel Gonzalez"
-      , license =
-          BSD-3-Clause { year = 2017, author = "Gabriel Gonzalez" }
+in  [ { name = "dhall"
+      , author = "Gabriel Gonzalez"
+      , license = BSD-3-Clause { year = 2017, author = "Gabriel Gonzalez" }
       }
-    , { name =
-          "conduit"
-      , author =
-          "Michael Snoyman"
-      , license =
-          MIT { year = 2012, author = "Michael Snoyman" }
+    , { name = "conduit"
+      , author = "Michael Snoyman"
+      , license = MIT { year = 2012, author = "Michael Snoyman" }
       }
-    , { name =
-          "async"
-      , author =
-          "Simon Marlow"
-      , license =
-          BSD-3-Clause { year = 2012, author = "Simon Marlow" }
+    , { name = "async"
+      , author = "Simon Marlow"
+      , license = BSD-3-Clause { year = 2012, author = "Simon Marlow" }
       }
-    , { name =
-          "system-filepath"
-      , author =
-          "John Milikin"
-      , license =
-          MIT { year = 2010, author = "John Milikin" }
+    , { name = "system-filepath"
+      , author = "John Milikin"
+      , license = MIT { year = 2010, author = "John Milikin" }
       }
     ]
 ```
@@ -460,62 +432,62 @@ files, like this:
 ```dhall
 -- BSD-3-Clause.dhall
 
-    \(args : { year : Natural, author : Text })
-->  ''
-    Copyright ${Natural/show args.year} ${args.author}
+\(args : { year : Natural, author : Text }) ->
+  ''
+  Copyright ${Natural/show args.year} ${args.author}
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this
-       list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
 
-    2. Redistributions in binary form must reproduce the above copyright notice,
-       this list of conditions and the following disclaimer in the documentation
-       and/or other materials provided with the distribution.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
 
-    3. Neither the name of the copyright holder nor the names of its contributors
-       may be used to endorse or promote products derived from this software without
-       specific prior written permission.
+  3. Neither the name of the copyright holder nor the names of its contributors
+     may be used to endorse or promote products derived from this software without
+     specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    ''
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ''
 ```
 
 ```dhall
 -- MIT.dhall
 
-    \(args : { year : Natural, author : Text })
-->  ''
-    Copyright ${Natural/show args.year} ${args.author}
+\(args : { year : Natural, author : Text }) ->
+  ''
+  Copyright ${Natural/show args.year} ${args.author}
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of
-    this software and associated documentation files (the "Software"), to deal in
-    the Software without restriction, including without limitation the rights to
-    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-    of the Software, and to permit persons to whom the Software is furnished to do
-    so, subject to the following conditions:
+  Permission is hereby granted, free of charge, to any person obtaining a copy of
+  this software and associated documentation files (the "Software"), to deal in
+  the Software without restriction, including without limitation the rights to
+  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+  of the Software, and to permit persons to whom the Software is furnished to do
+  so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in all
-    copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
-    ''
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+  ''
 ```
 
 ... and then refer to these files within our original configuration:
@@ -523,33 +495,21 @@ files, like this:
 ```dhall
 -- example2.dhall
 
-[ { name =
-      "dhall"
-  , author =
-      "Gabriel Gonzalez"
-  , license =
-      ./BSD-3-Clause.dhall { year = 2017, author = "Gabriel Gonzalez" }
+[ { name = "dhall"
+  , author = "Gabriel Gonzalez"
+  , license = ./BSD-3-Clause.dhall { year = 2017, author = "Gabriel Gonzalez" }
   }
-, { name =
-      "conduit"
-  , author =
-      "Michael Snoyman"
-  , license =
-      ./MIT.dhall { year = 2012, author = "Michael Snoyman" }
+, { name = "conduit"
+  , author = "Michael Snoyman"
+  , license = ./MIT.dhall { year = 2012, author = "Michael Snoyman" }
   }
-, { name =
-      "async"
-  , author =
-      "Simon Marlow"
-  , license =
-      ./BSD-3-Clause.dhall { year = 2012, author = "Simon Marlow" }
+, { name = "async"
+  , author = "Simon Marlow"
+  , license = ./BSD-3-Clause.dhall { year = 2012, author = "Simon Marlow" }
   }
-, { name =
-      "system-filepath"
-  , author =
-      "John Milikin"
-  , license =
-      ./MIT.dhall { year = 2010, author = "John Milikin" }
+, { name = "system-filepath"
+  , author = "John Milikin"
+  , license = ./MIT.dhall { year = 2010, author = "John Milikin" }
   }
 ]
 ```
@@ -568,65 +528,42 @@ We can automate that away, too:
 -- example3.dhall
 
 let makePackage =
-          \ ( args
-            : { name :
-                  Text
-              , author :
-                  Text
-              , year :
-                  Natural
-              , makeLicense :
-                  { year : Natural, author : Text } -> Text
-              }
-            )
-      ->  { name =
-              args.name
-          , author =
-              args.author
-          , license =
-              args.makeLicense { year = args.year, author = args.author }
+      \ ( args
+        : { name : Text
+          , author : Text
+          , year : Natural
+          , makeLicense : { year : Natural, author : Text } -> Text
           }
+        ) ->
+        { name = args.name
+        , author = args.author
+        , license = args.makeLicense { year = args.year, author = args.author }
+        }
 
 in  [ makePackage
-      { name =
-          "dhall"
-      , author =
-          "Gabriel Gonzalez"
-      , year =
-          2017
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
+        { name = "dhall"
+        , author = "Gabriel Gonzalez"
+        , year = 2017
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
     , makePackage
-      { name =
-          "conduit"
-      , author =
-          "Michael Snoyman"
-      , year =
-          2012
-      , makeLicense =
-          ./MIT.dhall
-      }
+        { name = "conduit"
+        , author = "Michael Snoyman"
+        , year = 2012
+        , makeLicense = ./MIT.dhall
+        }
     , makePackage
-      { name =
-          "async"
-      , author =
-          "Simon Marlow"
-      , year =
-          2012
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
+        { name = "async"
+        , author = "Simon Marlow"
+        , year = 2012
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
     , makePackage
-      { name =
-          "system-filepath"
-      , author =
-          "John Milikin"
-      , year =
-          2010
-      , makeLicense =
-          ./MIT.dhall
-      }
+        { name = "system-filepath"
+        , author = "John Milikin"
+        , year = 2010
+        , makeLicense = ./MIT.dhall
+        }
     ]
 ```
 
@@ -645,74 +582,47 @@ with the same function (such as `makePackage`):
 let map = https://prelude.dhall-lang.org/List/map
 
 let makePackage =
-          \ ( args
-            : { name :
-                  Text
-              , author :
-                  Text
-              , year :
-                  Natural
-              , makeLicense :
-                  { year : Natural, author : Text } -> Text
-              }
-            )
-      ->  { name =
-              args.name
-          , author =
-              args.author
-          , license =
-              args.makeLicense { year = args.year, author = args.author }
+      \ ( args
+        : { name : Text
+          , author : Text
+          , year : Natural
+          , makeLicense : { year : Natural, author : Text } -> Text
           }
+        ) ->
+        { name = args.name
+        , author = args.author
+        , license = args.makeLicense { year = args.year, author = args.author }
+        }
 
 in  map
-    { name :
-        Text
-    , author :
-        Text
-    , year :
-        Natural
-    , makeLicense :
-        { year : Natural, author : Text } -> Text
-    }
-    { name : Text, author : Text, license : Text }
-    makePackage
-    [ { name =
-          "dhall"
-      , author =
-          "Gabriel Gonzalez"
-      , year =
-          2017
-      , makeLicense =
-          ./BSD-3-Clause.dhall
+      { name : Text
+      , author : Text
+      , year : Natural
+      , makeLicense : { year : Natural, author : Text } -> Text
       }
-    , { name =
-          "conduit"
-      , author =
-          "Michael Snoyman"
-      , year =
-          2012
-      , makeLicense =
-          ./MIT.dhall
-      }
-    , { name =
-          "async"
-      , author =
-          "Simon Marlow"
-      , year =
-          2012
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
-    , { name =
-          "system-filepath"
-      , author =
-          "John Milikin"
-      , year =
-          2010
-      , makeLicense =
-          ./MIT.dhall
-      }
-    ]
+      { name : Text, author : Text, license : Text }
+      makePackage
+      [ { name = "dhall"
+        , author = "Gabriel Gonzalez"
+        , year = 2017
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "conduit"
+        , author = "Michael Snoyman"
+        , year = 2012
+        , makeLicense = ./MIT.dhall
+        }
+      , { name = "async"
+        , author = "Simon Marlow"
+        , year = 2012
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "system-filepath"
+        , author = "John Milikin"
+        , year = 2010
+        , makeLicense = ./MIT.dhall
+        }
+      ]
 ```
 
 You can import functions, values, and types from URLs the same way that you
@@ -738,18 +648,18 @@ Examples:
 = [] : List Bool
 
 -}
-    let map
-        : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(f : a → b)
-          → λ(xs : List a)
-          → List/build
-            b
-            (   λ(list : Type)
-              → λ(cons : b → list → list)
-              → List/fold a xs list (λ(x : a) → cons (f x))
-            )
+let map
+    : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → b) →
+      λ(xs : List a) →
+        List/build
+          b
+          ( λ(list : Type) →
+            λ(cons : b → list → list) →
+              List/fold a xs list (λ(x : a) → cons (f x))
+          )
 
 in  map
 ```
@@ -805,83 +715,56 @@ You can use `let` expressions to define "type synonyms":
 let map = https://prelude.dhall-lang.org/List/map
 
 let Input =
-      { name :
-          Text
-      , author :
-          Text
-      , year :
-          Natural
-      , makeLicense :
-          { year : Natural, author : Text } -> Text
+      { name : Text
+      , author : Text
+      , year : Natural
+      , makeLicense : { year : Natural, author : Text } -> Text
       }
 
 let Output = { name : Text, author : Text, license : Text }
 
 let makePackage =
-          \(args : Input)
-      ->  { name =
-              args.name
-          , author =
-              args.author
-          , license =
-              args.makeLicense { year = args.year, author = args.author }
-          }
+      \(args : Input) ->
+        { name = args.name
+        , author = args.author
+        , license = args.makeLicense { year = args.year, author = args.author }
+        }
 
 in  map
-    Input
-    Output
-    makePackage
-    [ { name =
-          "dhall"
-      , author =
-          "Gabriel Gonzalez"
-      , year =
-          2017
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
-    , { name =
-          "conduit"
-      , author =
-          "Michael Snoyman"
-      , year =
-          2012
-      , makeLicense =
-          ./MIT.dhall
-      }
-    , { name =
-          "async"
-      , author =
-          "Simon Marlow"
-      , year =
-          2012
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
-    , { name =
-          "system-filepath"
-      , author =
-          "John Milikin"
-      , year =
-          2010
-      , makeLicense =
-          ./MIT.dhall
-      }
-    ]
+      Input
+      Output
+      makePackage
+      [ { name = "dhall"
+        , author = "Gabriel Gonzalez"
+        , year = 2017
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "conduit"
+        , author = "Michael Snoyman"
+        , year = 2012
+        , makeLicense = ./MIT.dhall
+        }
+      , { name = "async"
+        , author = "Simon Marlow"
+        , year = 2012
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "system-filepath"
+        , author = "John Milikin"
+        , year = 2010
+        , makeLicense = ./MIT.dhall
+        }
+      ]
 ```
 
 ... or you can store the types in files:
 
 ```dhall
 -- Input.dhall
-{ name :
-    Text
-, author :
-    Text
-, year :
-    Natural
-, makeLicense :
-    { year : Natural, author : Text } -> Text
+{ name : Text
+, author : Text
+, year : Natural
+, makeLicense : { year : Natural, author : Text } -> Text
 }
 ```
 
@@ -898,56 +781,37 @@ in  map
 let map = https://prelude.dhall-lang.org/List/map
 
 let makePackage =
-          \(args : ./Input.dhall)
-      ->  { name =
-              args.name
-          , author =
-              args.author
-          , license =
-              args.makeLicense { year = args.year, author = args.author }
-          }
+      \(args : ./Input.dhall) ->
+        { name = args.name
+        , author = args.author
+        , license = args.makeLicense { year = args.year, author = args.author }
+        }
 
 in  map
-    ./Input.dhall
-    ./Output.dhall
-    makePackage
-    [ { name =
-          "dhall"
-      , author =
-          "Gabriel Gonzalez"
-      , year =
-          2017
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
-    , { name =
-          "conduit"
-      , author =
-          "Michael Snoyman"
-      , year =
-          2012
-      , makeLicense =
-          ./MIT.dhall
-      }
-    , { name =
-          "async"
-      , author =
-          "Simon Marlow"
-      , year =
-          2012
-      , makeLicense =
-          ./BSD-3-Clause.dhall
-      }
-    , { name =
-          "system-filepath"
-      , author =
-          "John Milikin"
-      , year =
-          2010
-      , makeLicense =
-          ./MIT.dhall
-      }
-    ]
+      ./Input.dhall
+      ./Output.dhall
+      makePackage
+      [ { name = "dhall"
+        , author = "Gabriel Gonzalez"
+        , year = 2017
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "conduit"
+        , author = "Michael Snoyman"
+        , year = 2012
+        , makeLicense = ./MIT.dhall
+        }
+      , { name = "async"
+        , author = "Simon Marlow"
+        , year = 2012
+        , makeLicense = ./BSD-3-Clause.dhall
+        }
+      , { name = "system-filepath"
+        , author = "John Milikin"
+        , year = 2010
+        , makeLicense = ./MIT.dhall
+        }
+      ]
 ```
 
 ... whichever you prefer.

--- a/docs/discussions/Design-choices.md
+++ b/docs/discussions/Design-choices.md
@@ -57,12 +57,12 @@ failing at runtime .  For example, instead of this code:
 
 let isWeekDay
     : String -> Bool
-    =     \(d : String)
-      ->      d == "Monday"
-          ||  d == "Tuesday"
-          ||  d == "Wednesday"
-          ||  d == "Thursday"
-          ||  d == "Friday"
+    = \(d : String) ->
+            d == "Monday"
+        ||  d == "Tuesday"
+        ||  d == "Wednesday"
+        ||  d == "Thursday"
+        ||  d == "Friday"
 
 in  isWeekDay "thursday" -- Oops!
 ```
@@ -75,22 +75,15 @@ let DayOfWeek =
 
 let isWeekDay
     : DayOfWeek -> Bool
-    =     \(d : DayOfWeek)
-      ->  merge
-          { Sunday =
-              False
-          , Monday =
-              True
-          , Tuesday =
-              True
-          , Wednesday =
-              True
-          , Thursday =
-              True
-          , Friday =
-              True
-          , Saturday =
-              False
+    = \(d : DayOfWeek) ->
+        merge
+          { Sunday = False
+          , Monday = True
+          , Tuesday = True
+          , Wednesday = True
+          , Thursday = True
+          , Friday = True
+          , Saturday = False
           }
           d
 

--- a/docs/discussions/Programmable-configuration-files.md
+++ b/docs/discussions/Programmable-configuration-files.md
@@ -151,21 +151,18 @@ Dhall configuration:
 -- config0.dhall
 
 let ordinaryUser =
-          \(user : Text)
-      ->  let privateKey = "/home/${user}/.ssh/id_rsa"
+      \(user : Text) ->
+        let privateKey = "/home/${user}/.ssh/id_rsa"
 
-          let publicKey = "${privateKey}.pub"
+        let publicKey = "${privateKey}.pub"
 
-          in  { privateKey = privateKey, publicKey = publicKey, user = user }
+        in  { privateKey, publicKey, user }
 
 in  [ ordinaryUser "john"
     , ordinaryUser "jane"
-    , { privateKey =
-          "/etc/jenkins/jenkins_rsa"
-      , publicKey =
-          "/etc/jenkins/jenkins_rsa.pub"
-      , user =
-          "jenkins"
+    , { privateKey = "/etc/jenkins/jenkins_rsa"
+      , publicKey = "/etc/jenkins/jenkins_rsa.pub"
+      , user = "jenkins"
       }
     , ordinaryUser "chad"
     ]
@@ -214,21 +211,18 @@ Now adding a new user like `alice` is a one-line change since we can reuse our
 -- config1.dhall
 
 let ordinaryUser =
-          \(user : Text)
-      ->  let privateKey = "/home/${user}/.ssh/id_rsa"
+      \(user : Text) ->
+        let privateKey = "/home/${user}/.ssh/id_rsa"
 
-          let publicKey = "${privateKey}.pub"
+        let publicKey = "${privateKey}.pub"
 
-          in  { privateKey = privateKey, publicKey = publicKey, user = user }
+        in  { privateKey, publicKey, user }
 
 in  [ ordinaryUser "john"
     , ordinaryUser "jane"
-    , { privateKey =
-          "/etc/jenkins/jenkins_rsa"
-      , publicKey =
-          "/etc/jenkins/jenkins_rsa.pub"
-      , user =
-          "jenkins"
+    , { privateKey = "/etc/jenkins/jenkins_rsa"
+      , publicKey = "/etc/jenkins/jenkins_rsa.pub"
+      , user = "jenkins"
       }
     , ordinaryUser "chad"
     , ordinaryUser "alice"
@@ -242,33 +236,21 @@ change:
 -- config2.dhall
 
 let ordinaryUser =
-          \(user : Text)
-      ->  let home = "/home/${user}"
+      \(user : Text) ->
+        let home = "/home/${user}"
 
-          let privateKey = "${home}/.ssh/id_rsa"
+        let privateKey = "${home}/.ssh/id_rsa"
 
-          let publicKey = "${privateKey}.pub"
+        let publicKey = "${privateKey}.pub"
 
-          in  { home =
-                  home
-              , privateKey =
-                  privateKey
-              , publicKey =
-                  publicKey
-              , user =
-                  user
-              }
+        in  { home, privateKey, publicKey, user }
 
 in  [ ordinaryUser "john"
     , ordinaryUser "jane"
-    , { home =
-          "/home/jenkins"
-      , privateKey =
-          "/etc/jenkins/jenkins_rsa"
-      , publicKey =
-          "/etc/jenkins/jenkins_rsa.pub"
-      , user =
-          "jenkins"
+    , { home = "/home/jenkins"
+      , privateKey = "/etc/jenkins/jenkins_rsa"
+      , publicKey = "/etc/jenkins/jenkins_rsa.pub"
+      , user = "jenkins"
       }
     , ordinaryUser "chad"
     , ordinaryUser "alice"
@@ -331,50 +313,30 @@ input, evaluates the expression, and prints the result to standard output:
 $ dhall <<< './config2.dhall'
 ```
 ```dhall
-[ { home =
-      "/home/john"
-  , privateKey =
-      "/home/john/.ssh/id_rsa"
-  , publicKey =
-      "/home/john/.ssh/id_rsa.pub"
-  , user =
-      "john"
+[ { home = "/home/john"
+  , privateKey = "/home/john/.ssh/id_rsa"
+  , publicKey = "/home/john/.ssh/id_rsa.pub"
+  , user = "john"
   }
-, { home =
-      "/home/jane"
-  , privateKey =
-      "/home/jane/.ssh/id_rsa"
-  , publicKey =
-      "/home/jane/.ssh/id_rsa.pub"
-  , user =
-      "jane"
+, { home = "/home/jane"
+  , privateKey = "/home/jane/.ssh/id_rsa"
+  , publicKey = "/home/jane/.ssh/id_rsa.pub"
+  , user = "jane"
   }
-, { home =
-      "/home/jenkins"
-  , privateKey =
-      "/etc/jenkins/jenkins_rsa"
-  , publicKey =
-      "/etc/jenkins/jenkins_rsa.pub"
-  , user =
-      "jenkins"
+, { home = "/home/jenkins"
+  , privateKey = "/etc/jenkins/jenkins_rsa"
+  , publicKey = "/etc/jenkins/jenkins_rsa.pub"
+  , user = "jenkins"
   }
-, { home =
-      "/home/chad"
-  , privateKey =
-      "/home/chad/.ssh/id_rsa"
-  , publicKey =
-      "/home/chad/.ssh/id_rsa.pub"
-  , user =
-      "chad"
+, { home = "/home/chad"
+  , privateKey = "/home/chad/.ssh/id_rsa"
+  , publicKey = "/home/chad/.ssh/id_rsa.pub"
+  , user = "chad"
   }
-, { home =
-      "/home/alice"
-  , privateKey =
-      "/home/alice/.ssh/id_rsa"
-  , publicKey =
-      "/home/alice/.ssh/id_rsa.pub"
-  , user =
-      "alice"
+, { home = "/home/alice"
+  , privateKey = "/home/alice/.ssh/id_rsa"
+  , publicKey = "/home/alice/.ssh/id_rsa.pub"
+  , user = "alice"
   }
 ]
 ```

--- a/docs/discussions/Safety-guarantees.md
+++ b/docs/discussions/Safety-guarantees.md
@@ -59,12 +59,13 @@ The following configuration file is a valid Dhall expression that:
 * imports a type from a relative file located at `./schema.dhall`
 
 ```dhall
-let concatSep = http://prelude.dhall-lang.org/Text/concatSep
+let concatSep = https://prelude.dhall-lang.org/Text/concatSep
 
-in  { name = env:USER as Text
-    , age  = 23
-    , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
-    } : ./schema.dhall
+in    { name = env:USER as Text
+      , age = 23
+      , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
+      }
+    : ./schema.dhall
 ```
 
 Normally importing values from external sources is potentially unsafe,
@@ -84,33 +85,31 @@ command-line interpreter named `dhall` to retrieve, type-check, and remove all
 indirection in the expression, like this:
 
 ```console
-$ dhall --annotate <<< 'http://prelude.dhall-lang.org/Text/concatSep'
+$ dhall --annotate <<< 'https://prelude.dhall-lang.org/Text/concatSep'
 ```
 
 ```dhall
-  (   λ(separator : Text)
-    → λ(elements : List Text)
-    → merge
-      { Empty = λ(_ : {}) → "", NonEmpty = λ(result : Text) → result }
-      ( List/fold
-        Text
-        elements
-        < Empty : {} | NonEmpty : Text >
-        (   λ(element : Text)
-          → λ(status : < Empty : {} | NonEmpty : Text >)
-          → merge
-            { Empty =
-                λ(_ : {}) → < NonEmpty = element | Empty : {} >
-            , NonEmpty =
-                  λ(result : Text)
-                → < NonEmpty = element ++ separator ++ result | Empty : {} >
-            }
-            status
-            : < Empty : {} | NonEmpty : Text >
+  ( λ(separator : Text) →
+    λ(elements : List Text) →
+      merge
+        { Empty = "", NonEmpty = λ(result : Text) → result }
+        ( List/fold
+            Text
+            elements
+            < Empty | NonEmpty : Text >
+            ( λ(element : Text) →
+              λ(status : < Empty | NonEmpty : Text >) →
+                merge
+                  { Empty = < Empty | NonEmpty : Text >.NonEmpty element
+                  , NonEmpty =
+                      λ(result : Text) →
+                        < Empty | NonEmpty : Text >.NonEmpty
+                          "${element}${separator}${result}"
+                  }
+                  status
+            )
+            < Empty | NonEmpty : Text >.Empty
         )
-        < Empty = {=} | NonEmpty : Text >
-      )
-      : Text
   )
 : ∀(separator : Text) → ∀(elements : List Text) → Text
 ```
@@ -132,7 +131,7 @@ If you understand and trust what you see then you can freeze the import using
 an integrity check.  If you replace the `dhall` command with `dhall hash`:
 
 ```dhall
-$ dhall hash <<< 'http://prelude.dhall-lang.org/Text/concatSep'
+$ dhall hash <<< 'https://prelude.dhall-lang.org/Text/concatSep'
 ```
 
 ```
@@ -143,12 +142,14 @@ sha256:fa909c0b2fd4f9edb46df7ff72ae105ad0bd0ae00baa7fe53b0e43863f9bd34a
 imported expression, like this:
 
 ```dhall
-let concatSep = http://prelude.dhall-lang.org/Prelude/Text/concatSep sha256:fa909c0b2fd4f9edb46df7ff72ae105ad0bd0ae00baa7fe53b0e43863f9bd34a
+let concatSep =
+      https://prelude.dhall-lang.org/Prelude/Text/concatSep sha256:fa909c0b2fd4f9edb46df7ff72ae105ad0bd0ae00baa7fe53b0e43863f9bd34a
 
-in  { name = env:USER as Text
-    , age  = 23
-    , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
-    } : ./schema.dhall
+in    { name = env:USER as Text
+      , age = 23
+      , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
+      }
+    : ./schema.dhall
 ```
 
 You can also automatically freeze all imports within a file using
@@ -213,17 +214,19 @@ information about your environment or exfiltrate data to an untrusted source.
 Revisiting our previous example:
 
 ```dhall
-let concatSep = http://prelude.dhall-lang.org/Prelude/Text/concatSep sha256:fa909c0b2fd4f9edb46df7ff72ae105ad0bd0ae00baa7fe53b0e43863f9bd34a
+let concatSep =
+      https://prelude.dhall-lang.org/Prelude/Text/concatSep sha256:fa909c0b2fd4f9edb46df7ff72ae105ad0bd0ae00baa7fe53b0e43863f9bd34a
 
-in  { name = env:USER as Text
-    , age  = 23
-    , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
-    } : ./schema.dhall
+in    { name = env:USER as Text
+      , age = 23
+      , hobbies = concatSep ", " [ "piano", "reading", "skiing" ]
+      }
+    : ./schema.dhall
 ```
 
-... the host at `http://prelude.dhall-lang.org` would be able to detect the first
+... the host at `https://prelude.dhall-lang.org` would be able to detect the first
 time we interpret our Dhall program by detecting an HTTP request for
-`http://prelude.dhall-lang.org/Prelude/Text/concatSep`.  Leaking the
+`https://prelude.dhall-lang.org/Prelude/Text/concatSep`.  Leaking the
 presence of an HTTP request at least once is unavoidable if you do not control the
 web service hosting the URL.  However, when you protect an import with a semantic
 integrity check the import is permanently locally cached after the first request,
@@ -303,7 +306,7 @@ https://raw.githubusercontent.com/yourCompany/somePrivateRepository/master/someE
     using [ { header = "Authorization", value = "token ${env:GITHUB_TOKEN as Text}" } ]
 ```
 
-... and `http://.../someExpression.dhall` contains a relative import of
+... and `https://.../someExpression.dhall` contains a relative import of
 `./anotherExpression.dhall` then:
 
 * the interpreter will canonicalize the relative import
@@ -485,7 +488,7 @@ You will get a type error if you try to do so, such as in the following
 anonymous function:
 
 ```dhall
-\(x : Optional Natural) → x + 3  -- Type error
+\(x : Optional Natural) -> x + 3  -- Type error
 ```
 
 This is automatically an error even if you have not yet called the function
@@ -497,11 +500,11 @@ specifying what do to if the value is absent, typically by using
 `Optional/fold`:
 
 ```dhall
-    \(o : Optional Natural)
-    -- Default `x` to `0` if `x` is absent
-->  let x = Optional/fold Natural o Natural (\(n : Natural) -> n) 0
+\(o : Optional Natural) ->
+  -- Default `x` to `0` if `x` is absent
+  let x = Optional/fold Natural o Natural (\(n : Natural) -> n) 0
 
-    in  x + 3
+  in x + 3
 ```
 
 This benefit also applies to your configuration file's schema.  If your
@@ -542,11 +545,11 @@ expansion to this document.
 [danluu]: https://danluu.com/postmortem-lessons/
 [django]: https://docs.djangoproject.com/en/2.0/topics/settings/
 [hcl]: https://www.terraform.io/docs/configuration/syntax.html
-[jsonnet]: http://jsonnet.org/
-[json-schema]: http://json-schema.org/
+[jsonnet]: https://jsonnet.org/
+[json-schema]: https://json-schema.org/
 [json-tutorial]: https://github.com/dhall-lang/dhall-lang/wiki/Getting-started:-Generate-JSON-or-YAML
 [programmable]: https://github.com/dhall-lang/dhall-lang/wiki/Programmable-configuration-files
-[sass]: http://sass-lang.com/
+[sass]: https://sass-lang.com/
 [sbt]: https://www.scala-sbt.org/
 [webpack]: https://webpack.js.org/configuration/configuration-languages/
 [total]: https://en.wikipedia.org/wiki/Total_functional_programming

--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -233,11 +233,11 @@
     λ(inputArgument : inputType) → outputResult : ∀(inputArgument : inputType) → outputType  -- Unicode syntax
 
     let describe =
-        λ(name : Text)
-      → λ(age : Natural)
-      → "Name: ${name}, Age: ${Natural/show age}"
+      λ(name : Text) →
+      λ(age : Natural) →
+        "Name: ${name}, Age: ${Natural/show age}"
 
-    in  describe "John Doe" 21 = "Name: John Doe, Age: 21"
+    in  describe "John Doe" 21 -- "Name: John Doe, Age: 21"
     ```
 
 *   Polymorphism

--- a/docs/howtos/FAQ.md
+++ b/docs/howtos/FAQ.md
@@ -80,8 +80,8 @@ The Dhall equivalent of the above code would be:
 
 ```dhall
 let greet =
-          \(args : { greeting : Text, name : Text })
-      ->  "${args.greeting}, ${args.name}!"
+      \(args : { greeting : Text, name : Text }) ->
+        "${args.greeting}, ${args.name}!"
 
 let Greeting =
       { Type = { greeting : Text, name : Text }
@@ -122,24 +122,13 @@ Hola, Jane!
 
 ## How do I update nested fields in a record?
 
-You have to nest updates, like this:
+You can use the `with` keyword for this purpose:
 
 ```dhall
 let example = { coordinate = { x = 5, y = 3 }, element = "Hg" }
 
-in  example // {
-      coordinate = example.coordinate // {
-        x = example.coordinate.x + 1
-      }
-    }
-```
-
-You can also use the `with` keyword as a more concise syntactic sugar for the same expression:
-
-```dhall
-let example = { coordinate = { x = 5, y = 3 }, element = "Hg" }
 in  example
-  with coordinate.x = (example.coordinate.x + 1)
+  with coordinate.x = example.coordinate.x + 1
 ```
 
 See [Add support for `with` keyword](https://github.com/dhall-lang/dhall-lang/pull/923) for more details.

--- a/docs/howtos/How-to-integrate-Dhall.md
+++ b/docs/howtos/How-to-integrate-Dhall.md
@@ -98,7 +98,8 @@ These are my favorite fruits:
 ```dhall
 -- ./json.dhall
 
-let JSON = https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/JSON/package.dhall
+let JSON =
+      https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/Prelude/JSON/package.dhall
 
 in  JSON.render (JSON.array [ JSON.number 1.0, JSON.bool True ])
 ```

--- a/docs/howtos/How-to-translate-recursive-code-to-Dhall.md
+++ b/docs/howtos/How-to-translate-recursive-code-to-Dhall.md
@@ -55,35 +55,36 @@ The equivalent Dhall code would be:
 
 let Person
     : Type
-    =   ∀(Person : Type)
-      → ∀(MakePerson : { children : List Person, name : Text } → Person)
-      → Person
+    = ∀(Person : Type) →
+      ∀(MakePerson : { children : List Person, name : Text } → Person) →
+        Person
 
 let example
     : Person
-    =   λ(Person : Type)
-      → λ(MakePerson : { children : List Person, name : Text } → Person)
-      → MakePerson
-        { children =
+    = λ(Person : Type) →
+      λ(MakePerson : { children : List Person, name : Text } → Person) →
+        MakePerson
+          { children =
             [ MakePerson { children = [] : List Person, name = "Mary" }
             , MakePerson { children = [] : List Person, name = "Jane" }
             ]
-        , name =
-            "John"
-        }
+          , name = "John"
+          }
 
 let everybody
     : Person → List Text
     = let concat = http://prelude.dhall-lang.org/List/concat
 
-      in    λ(x : Person)
-          → x
-            (List Text)
-            (   λ(p : { children : List (List Text), name : Text })
-              → [ p.name ] # concat Text p.children
-            )
+      in  λ(x : Person) →
+            x
+              (List Text)
+              ( λ(p : { children : List (List Text), name : Text }) →
+                  [ p.name ] # concat Text p.children
+              )
 
-let result : List Text = everybody example
+let result
+    : List Text
+    = everybody example
 
 in  result
 ```
@@ -104,35 +105,36 @@ underscore (i.e. `_Person`):
 ```dhall
 let Person
     : Type
-    =   ∀(_Person : Type)
-      → ∀(MakePerson : { children : List _Person, name : Text } → _Person)
-      → _Person
+    = ∀(_Person : Type) →
+      ∀(MakePerson : { children : List _Person, name : Text } → _Person) →
+        _Person
 
 let example
     : Person
-    =   λ(_Person : Type)
-      → λ(MakePerson : { children : List _Person, name : Text } → _Person)
-      → MakePerson
-        { children =
+    = λ(_Person : Type) →
+      λ(MakePerson : { children : List _Person, name : Text } → _Person) →
+        MakePerson
+          { children =
             [ MakePerson { children = [] : List _Person, name = "Mary" }
             , MakePerson { children = [] : List _Person, name = "Jane" }
             ]
-        , name =
-            "John"
-        }
+          , name = "John"
+          }
 
 let everybody
     : Person → List Text
     = let concat = http://prelude.dhall-lang.org/List/concat
 
-      in    λ(x : Person)
-          → x
-            (List Text)
-            (   λ(p : { children : List (List Text), name : Text })
-              → [ p.name ] # concat Text p.children
-            )
+      in  λ(x : Person) →
+            x
+              (List Text)
+              ( λ(p : { children : List (List Text), name : Text }) →
+                  [ p.name ] # concat Text p.children
+              )
 
-let result : List Text = everybody example
+let result
+    : List Text
+    = everybody example
 
 in  result
 ```
@@ -145,8 +147,8 @@ performing substitution.  In this specific case, `everybody` is:
     anonymous function:
 
     ```dhall
-       λ(p : { children : List (List Text), name : Text })
-    → [ p.name ] # concat Text p.children
+    λ(p : { children : List (List Text), name : Text }) →
+      [ p.name ] # concat Text p.children
     ```
 
 ... which means that our previous example could also have been written like
@@ -155,22 +157,23 @@ this:
 ```dhall
 let concat = http://prelude.dhall-lang.org/List/concat
 
-let Person : Type = List Text
+let Person
+    : Type
+    = List Text
 
 let MakePerson
     : { children : List Person, name : Text } → Person
-    =   λ(p : { children : List Person, name : Text })
-      → [ p.name ] # concat Text p.children
+    = λ(p : { children : List Person, name : Text }) →
+        [ p.name ] # concat Text p.children
 
 let result =
       MakePerson
-      { children =
+        { children =
           [ MakePerson { children = [] : List Person, name = "Mary" }
           , MakePerson { children = [] : List Person, name = "Jane" }
           ]
-      , name =
-          "John"
-      }
+        , name = "John"
+        }
 
 in  result
 ```
@@ -212,20 +215,24 @@ $ ghci Example1.hs
 ```dhall
 -- example1.dhall
 
-let Nat : Type = ∀(Nat : Type) → ∀(Zero : Nat) → ∀(Succ : Nat → Nat) → Nat
+let Nat
+    : Type
+    = ∀(Nat : Type) → ∀(Zero : Nat) → ∀(Succ : Nat → Nat) → Nat
 
 let example
     : Nat
-    =   λ(Nat : Type)
-      → λ(Zero : Nat)
-      → λ(Succ : Nat → Nat)
-      → Succ (Succ (Succ Zero))
+    = λ(Nat : Type) →
+      λ(Zero : Nat) →
+      λ(Succ : Nat → Nat) →
+        Succ (Succ (Succ Zero))
 
 let toNatural
     : Nat → Natural
     = λ(x : Nat) → x Natural 0 (λ(n : Natural) → 1 + n)
 
-let result : Natural = toNatural example
+let result
+    : Natural
+    = toNatural example
 
 in  result
 ```
@@ -250,11 +257,17 @@ Like before, our recursive `toNatural` function is performing substitution by:
 ```dhall
 let Nat = Natural
 
-let Zero : Nat = 0
+let Zero
+    : Nat
+    = 0
 
-let Succ : Nat → Nat = λ(n : Nat) → 1 + n
+let Succ
+    : Nat → Nat
+    = λ(n : Nat) → 1 + n
 
-let result : Nat = Succ (Succ (Succ Zero))
+let result
+    : Nat
+    = Succ (Succ (Succ Zero))
 
 in  result
 ```
@@ -300,26 +313,26 @@ $ ghci Example2.hs
 ```dhall
 let Odd
     : Type
-    =   ∀(Even : Type)
-      → ∀(Odd : Type)
-      → ∀(Zero : Even)
-      → ∀(SuccEven : Odd → Even)
-      → ∀(SuccOdd : Even → Odd)
-      → Odd
+    = ∀(Even : Type) →
+      ∀(Odd : Type) →
+      ∀(Zero : Even) →
+      ∀(SuccEven : Odd → Even) →
+      ∀(SuccOdd : Even → Odd) →
+        Odd
 
 let example
     : Odd
-    =   λ(Even : Type)
-      → λ(Odd : Type)
-      → λ(Zero : Even)
-      → λ(SuccEven : Odd → Even)
-      → λ(SuccOdd : Even → Odd)
-      → SuccOdd (SuccEven (SuccOdd Zero))
+    = λ(Even : Type) →
+      λ(Odd : Type) →
+      λ(Zero : Even) →
+      λ(SuccEven : Odd → Even) →
+      λ(SuccOdd : Even → Odd) →
+        SuccOdd (SuccEven (SuccOdd Zero))
 
 let oddToNatural
     : Odd → Natural
-    =   λ(o : Odd)
-      → o Natural Natural 0 (λ(n : Natural) → 1 + n) (λ(n : Natural) → 1 + n)
+    = λ(o : Odd) →
+        o Natural Natural 0 (λ(n : Natural) → 1 + n) (λ(n : Natural) → 1 + n)
 
 let result = oddToNatural example
 
@@ -353,15 +366,25 @@ by:
 ... which means that we could have equivalently written:
 
 ```dhall
-let Odd : Type = Natural
+let Odd
+    : Type
+    = Natural
 
-let Even : Type = Natural
+let Even
+    : Type
+    = Natural
 
-let Zero : Even = 0
+let Zero
+    : Even
+    = 0
 
-let SuccEven : Odd → Even = λ(n : Odd) → 1 + n
+let SuccEven
+    : Odd → Even
+    = λ(n : Odd) → 1 + n
 
-let SuccOdd : Even → Odd = λ(n : Even) → 1 + n
+let SuccOdd
+    : Even → Odd
+    = λ(n : Even) → 1 + n
 
 let result = SuccOdd (SuccEven (SuccOdd Zero))
 

--- a/docs/howtos/How-to-type-check-and-normalize-incomplete-code.md
+++ b/docs/howtos/How-to-type-check-and-normalize-incomplete-code.md
@@ -14,11 +14,9 @@ implemented yet:
 
 ```dhall
   λ(TODO : ∀(a : Type) → a)
-→ let List/map =
-        https://prelude.dhall-lang.org/List/map
+→ let List/map = https://prelude.dhall-lang.org/List/map
 
-  let Text/concatSep =
-        https://prelude.dhall-lang.org/Text/concatSep
+  let Text/concatSep = https://prelude.dhall-lang.org/Text/concatSep
 
   let Person = { name : Text, age : Natural }
 
@@ -30,14 +28,14 @@ implemented yet:
 
   let renderPeople
       : List Person → Text
-      =   λ(people : List Person)
-        → renderList (List/map Person Text renderPerson people)
+      = λ(people : List Person) →
+          renderList (List/map Person Text renderPerson people)
 
   in  renderPeople
-      [ { name = "John", age = 23 }
-      , TODO Person  -- ← You can also leave values unimplemented
-      , { name = "Mary", age = 24 }
-      ]
+        [ { name = "John", age = 23 }
+        , TODO Person  -- ← You can also leave values unimplemented
+        , { name = "Mary", age = 24 }
+        ]
 ```
 
 The type `∀(a : Type) → a` is an impossible type that can never be created in Dhall,
@@ -48,19 +46,19 @@ still type-check the function and normalize the function body:
 $ dhall --annotate <<< './example.dhall'
 ```
 ```dhall
-  (   λ(TODO : ∀(a : Type) → a)
-    →     "["
+  ( λ(TODO : ∀(a : Type) → a) →
+          "["
       ++  (     TODO
-                ({ age : Natural, name : Text } → Text)
-                { age = 23, name = "John" }
+                  ({ age : Natural, name : Text } → Text)
+                  { age = 23, name = "John" }
             ++  ", "
             ++  TODO
-                ({ age : Natural, name : Text } → Text)
-                (TODO { age : Natural, name : Text })
+                  ({ age : Natural, name : Text } → Text)
+                  (TODO { age : Natural, name : Text })
             ++  ", "
             ++  TODO
-                ({ age : Natural, name : Text } → Text)
-                { age = 24, name = "Mary" }
+                  ({ age : Natural, name : Text } → Text)
+                  { age = 24, name = "Mary" }
           )
       ++  "]"
   )

--- a/docs/references/Built-in-types.md
+++ b/docs/references/Built-in-types.md
@@ -1120,10 +1120,10 @@ List/head a ([] : List a) = None a
 
 List/head a (xs # ys) =
       let combine =
-              λ(a : Type)
-            → λ(l : Optional a)
-            → λ(r : Optional a)
-            → Optional/fold a l (Optional a) (λ(x : a) → Some x) r
+            λ(a : Type) →
+            λ(l : Optional a) →
+            λ(r : Optional a) →
+              Optional/fold a l (Optional a) (λ(x : a) → Some x) r
   in  combine a (List/head a xs) (List/head a ys)
 
 List/head a [ x ] = Some x
@@ -1154,10 +1154,10 @@ List/last a ([] : List a) = None a
 
 List/last a (xs # ys) =
       let combine =
-              λ(a : Type)
-            → λ(l : Optional a)
-            → λ(r : Optional a)
-            → Optional/fold a r (Optional a) (λ(x : a) → Some x) l
+            λ(a : Type) →
+            λ(l : Optional a) →
+            λ(r : Optional a) →
+              Optional/fold a r (Optional a) (λ(x : a) → Some x) l
   in  combine a (List/last a xs) (List/last a ys)
 
 List/last a [ x ] = Some x
@@ -1188,15 +1188,15 @@ List/indexed a ([] : List a) = [] : List { index : Natural, value : a }
 
 List/indexed a (xs # ys) =
       let combine =
-          λ(a : Type)
-        → λ(xs : List { index : Natural, value : a })
-        → λ(ys : List { index : Natural, value : a })
-        →   xs
+        λ(a : Type) →
+        λ(xs : List { index : Natural, value : a }) →
+        λ(ys : List { index : Natural, value : a }) →
+            xs
           # List/build
             { index : Natural, value : a }
-            (   λ(list : Type)
-              → λ(cons : { index : Natural, value : a } → list → list)
-              → List/fold
+            ( λ(list : Type) →
+              λ(cons : { index : Natural, value : a } → list → list) →
+                List/fold
                 { index : Natural, value : a }
                 ys
                 list

--- a/docs/tutorials/Getting-started_Generate-JSON-or-YAML.md
+++ b/docs/tutorials/Getting-started_Generate-JSON-or-YAML.md
@@ -531,28 +531,28 @@ $ dhall-to-json <<< 'let twice = \(x : Natural) -> [x, x] in twice 2'
 >
 > ```dhall
 > let smallServer =
->           \(hostName : Text)
->       ->  { cpus = 1
->           , gigabytesOfRAM = 1
->           , hostName = hostName
->           , terabytesOfDisk = 1
->           }
+>       \(hostName : Text) ->
+>         { cpus = 1
+>         , gigabytesOfRAM = 1
+>         , hostName = hostName
+>         , terabytesOfDisk = 1
+>         }
 > 
 > let mediumServer =
->           \(hostName : Text)
->       ->  { cpus = 8
->           , gigabytesOfRAM = 16
->           , hostName = hostName
->           , terabytesOfDisk = 4
->           }
+>       \(hostName : Text) ->
+>         { cpus = 8
+>         , gigabytesOfRAM = 16
+>         , hostName = hostName
+>         , terabytesOfDisk = 4
+>         }
 > 
 > let largeServer =
->           \(hostName : Text)
->       ->  { cpus = 64
->           , gigabytesOfRAM = 256
->           , hostName = hostName
->           , terabytesOfDisk = 16
->           }
+>       \(hostName : Text) ->
+>         { cpus = 64
+>         , gigabytesOfRAM = 256
+>         , hostName = hostName
+>         , terabytesOfDisk = 16
+>         }
 > 
 > in  [ smallServer "eu-west.example.com"
 >     , largeServer "us-east.example.com"
@@ -582,13 +582,13 @@ $ dhall-to-json <<< 'let both = \(x : Natural) -> \(y : Natural) -> [x, y] in bo
 >
 > ```dhall
 > let educationalBook =
->           \(publisher : Text)
->       ->  \(title : Text)
->       ->  { category = "Nonfiction"
->           , department = "Books"
->           , publisher = publisher
->           , title = title
->           }
+>       \(publisher : Text) ->
+>       \(title : Text) ->
+>         { category = "Nonfiction"
+>         , department = "Books"
+>         , publisher = publisher
+>         , title = title
+>         }
 > 
 > let makeOreilly = educationalBook "O'Reilly Media"
 > 

--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -812,7 +812,7 @@ The language provides built-in support for testing that two expressions are
 equal using the `assert` keyword, like this:
 
 ```dhall
-⊢ assert : (2 + 2) === 4
+⊢ assert : 2 + 2 === 4
 
 assert : 4 ≡ 4
 ```
@@ -824,14 +824,14 @@ If the expressions do not match then type-checking will fail and the
 interpreter will display a diff:
 
 ```dhall
-⊢ assert : (2 + 2) === 5
+⊢ assert : 2 + 2 === 5
 
 Error: Assertion failed
 
 - 4
 + 5
 
-1│ assert : (2 + 2) === 5
+1│ assert : 2 + 2 === 5
 
 (input):1:1
 ```
@@ -1530,12 +1530,12 @@ let Example = < Number : Natural | Boolean : Bool >
 
 let renderExample
     : Example -> Text
-    =     \(example : Example)
-      ->  merge
-            { Number = \(n : Natural) -> Natural/show n
-            , Boolean = \(b : Bool) -> if b then "True" else "False"
-            }
-            example
+    = \(example : Example) ->
+        merge
+          { Number = \(n : Natural) -> Natural/show n
+          , Boolean = \(b : Bool) -> if b then "True" else "False"
+          }
+          example
 
 let example0 = assert : renderExample (Example.Number 42) === "42"
 
@@ -1579,17 +1579,17 @@ let DayOfWeek =
 
 let isWeekend
     : DayOfWeek -> Bool
-    =     \(day : DayOfWeek)
-      ->  merge
-            { Sunday = True
-            , Monday = False
-            , Tuesday = False
-            , Wednesday = False
-            , Thursday = False
-            , Friday = False
-            , Saturday = True
-            }
-            day
+    = \(day : DayOfWeek) ->
+        merge
+          { Sunday = True
+          , Monday = False
+          , Tuesday = False
+          , Wednesday = False
+          , Thursday = False
+          , Friday = False
+          , Saturday = True
+          }
+          day
 
 in  isWeekend DayOfWeek.Sunday
 ```
@@ -1620,8 +1620,8 @@ values *as if* they had the above type:
 
 ```dhall
 let default =
-          \(o : Optional Natural)
-      ->  merge { Some = \(n : Natural) -> n, None = 0 } o
+      \(o : Optional Natural) ->
+        merge { Some = \(n : Natural) -> n, None = 0 } o
 
 let example0 = assert : default (Some 42) === 42
 

--- a/docs/tutorials/string-matrix.md
+++ b/docs/tutorials/string-matrix.md
@@ -36,8 +36,8 @@ let List/map =
       https://prelude.dhall-lang.org/v11.1.0/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
 
 let generate-test-name =
-          \(prefix : Text)
-      ->  List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
+      \(prefix : Text) ->
+        List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
 
 in  generate-test-name "variantA" [ "suffixA", "suffixB" ]
 ```
@@ -105,17 +105,17 @@ let List/map =
       https://prelude.dhall-lang.org/v11.1.0/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
 
 let generate-test-name =
-          \(prefix : Text)
-      ->  List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
+      \(prefix : Text) ->
+        List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
 
 let generate-test-suite =
-          \(prefixes : List Text)
-      ->  \(suffixes : List Text)
-      ->  List/map
-            Text
-            (List Text)
-            (\(prefix : Text) -> generate-test-name prefix suffixes)
-            prefixes
+      \(prefixes : List Text) ->
+      \(suffixes : List Text) ->
+        List/map
+          Text
+          (List Text)
+          (\(prefix : Text) -> generate-test-name prefix suffixes)
+          prefixes
 
 in  generate-test-suite [ "variantA", "variantB" ] [ "suffixA", "suffixB" ]
 ```
@@ -168,21 +168,21 @@ Therefore, we can implement a `flatten-list-text` function like so:
 -- ./concat-example.dhall
 let {- Convert [[a, b], [c, d]] to [a, b, c, d] -}
     flatten-list-text =
-          \(to-fold : List (List Text))
-      ->    List/fold
-              (List Text)
-              to-fold
-              (List Text)
-              (\(a : List Text) -> \(b : List Text) -> a # b)
-              ([] : List Text)
-          : List Text
+      \(to-fold : List (List Text)) ->
+          List/fold
+            (List Text)
+            to-fold
+            (List Text)
+            (\(a : List Text) -> \(b : List Text) -> a # b)
+            ([] : List Text)
+        : List Text
 
 let example =
-          \(a : Text)
-      ->  \(b : Text)
-      ->  \(c : Text)
-      ->  \(d : Text)
-      ->  assert : flatten-list-text [ [ a, b ], [ c, d ] ] === [ a, b, c, d ]
+      \(a : Text) ->
+      \(b : Text) ->
+      \(c : Text) ->
+      \(d : Text) ->
+        assert : flatten-list-text [ [ a, b ], [ c, d ] ] === [ a, b, c, d ]
 
 in  flatten-list-text [ [ "A", "B" ], [ "C", "D" ] ]
 ```
@@ -227,21 +227,21 @@ let List/map =
       https://prelude.dhall-lang.org/v11.1.0/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
 
 let generate-test-name =
-          \(prefix : Text)
-      ->  List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
+      \(prefix : Text) ->
+        List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
 
 let generate-test-suite =
-          \(prefixes : List Text)
-      ->  \(suffixes : List Text)
-      ->  let flatten-list-text = https://prelude.dhall-lang.org/List/concat Text
+      \(prefixes : List Text) ->
+      \(suffixes : List Text) ->
+        let flatten-list-text = https://prelude.dhall-lang.org/List/concat Text
 
-          in  flatten-list-text
-                ( List/map
-                    Text
-                    (List Text)
-                    (\(prefix : Text) -> generate-test-name prefix suffixes)
-                    prefixes
-                )
+        in  flatten-list-text
+              ( List/map
+                  Text
+                  (List Text)
+                  (\(prefix : Text) -> generate-test-name prefix suffixes)
+                  prefixes
+              )
 
 in  generate-test-suite [ "variantA", "variantB" ] [ "suffixA", "suffixB" ]
 ```
@@ -297,26 +297,26 @@ let List/map =
       https://prelude.dhall-lang.org/v11.1.0/List/map sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
 
 let generate-test-name =
-          \(prefix : Text)
-      ->  List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
+      \(prefix : Text) ->
+        List/map Text Text (\(suffix : Text) -> "${prefix}-${suffix}")
 
 let generate-test-suite =
-          \(prefixes : List Text)
-      ->  \(suffixes : List Text)
-      ->  let flatten-list-text = https://prelude.dhall-lang.org/List/concat Text
+      \(prefixes : List Text) ->
+      \(suffixes : List Text) ->
+        let flatten-list-text = https://prelude.dhall-lang.org/List/concat Text
 
-          in  flatten-list-text
-                ( List/map
-                    Text
-                    (List Text)
-                    (\(prefix : Text) -> generate-test-name prefix suffixes)
-                    prefixes
-                )
+        in  flatten-list-text
+              ( List/map
+                  Text
+                  (List Text)
+                  (\(prefix : Text) -> generate-test-name prefix suffixes)
+                  prefixes
+              )
 
 let generate-test-matrix =
-          \(variations : List (List Text))
-      ->  \(last : List Text)
-      ->  List/fold (List Text) variations (List Text) generate-test-suite last
+      \(variations : List (List Text)) ->
+      \(last : List Text) ->
+        List/fold (List Text) variations (List Text) generate-test-suite last
 
 in  generate-test-matrix
       [ [ "tox" ], [ "py27", "py38" ], [ "postgresql", "sqlite" ] ]

--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,7 +1,9 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "5b29700e1c080ad19278616e0f9dfcab389e539b",
-  "date": "2020-02-22T00:14:11+00:00",
-  "sha256": "0adbiwbd22f38b2gkhl590151w57q6n86m2345h77hk22mrskj59",
-  "fetchSubmodules": true
+  "rev": "9afffaea7108a86df197cb97b64a9504fe37ecfc",
+  "date": "2020-05-08T15:50:29+00:00",
+  "sha256": "1qn6d1lsw5aky9s5g9v77l1khnl12g2ihj8q865x33d7k4gnrxqd",
+  "fetchSubmodules": true,
+  "deepClone": false,
+  "leaveDotGit": false
 }

--- a/release.nix
+++ b/release.nix
@@ -27,7 +27,10 @@ let
       in
         import "${dhall-haskell}/default.nix";
 
-    inherit (pkgsNew.dhall-haskell-derivations) dhall dhall-try;
+    inherit (pkgsNew.dhall-haskell-derivations) dhall-try;
+
+    dhall =
+      pkgsNew.haskell.lib.dontCheck pkgsNew.dhall-haskell-derivations.dhall;
 
     instaparse-check = pkgsNew.writeText "build.boot" ''
       (require '[instaparse.core :refer [parser]])

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -13,13 +13,13 @@
 , Double : { show : Double → Text }
 , Function :
     { compose :
-          ∀(A : Type)
-        → ∀(B : Type)
-        → ∀(C : Type)
-        → ∀(f : A → B)
-        → ∀(g : B → C)
-        → ∀(x : A)
-        → C
+        ∀(A : Type) →
+        ∀(B : Type) →
+        ∀(C : Type) →
+        ∀(f : A → B) →
+        ∀(g : B → C) →
+        ∀(x : A) →
+          C
     , identity : ∀(a : Type) → ∀(x : a) → a
     }
 , Integer :
@@ -47,250 +47,248 @@
     , Tagged : ∀(a : Type) → Type
     , Type : Type
     , array :
-          ∀ ( x
-            : List
-                (   ∀(JSON : Type)
-                  → ∀ ( json
-                      : { array : List JSON → JSON
-                        , bool : Bool → JSON
-                        , double : Double → JSON
-                        , integer : Integer → JSON
-                        , null : JSON
-                        , object :
-                            List { mapKey : Text, mapValue : JSON } → JSON
-                        , string : Text → JSON
-                        }
-                      )
-                  → JSON
-                )
-            )
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀ ( x
+          : List
+              ( ∀(JSON : Type) →
+                ∀ ( json
+                  : { array : List JSON → JSON
+                    , bool : Bool → JSON
+                    , double : Double → JSON
+                    , integer : Integer → JSON
+                    , null : JSON
+                    , object : List { mapKey : Text, mapValue : JSON } → JSON
+                    , string : Text → JSON
+                    }
+                  ) →
+                  JSON
+              )
+          ) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , bool :
-          ∀(x : Bool)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Bool) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , double :
-          ∀(x : Double)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Double) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , integer :
-          ∀(x : Integer)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Integer) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , keyText :
         ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
     , keyValue :
-          ∀(v : Type)
-        → ∀(key : Text)
-        → ∀(value : v)
-        → { mapKey : Text, mapValue : v }
+        ∀(v : Type) →
+        ∀(key : Text) →
+        ∀(value : v) →
+          { mapKey : Text, mapValue : v }
     , natural :
-          ∀(x : Natural)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Natural) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , null :
-          ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , number :
-          ∀(x : Double)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Double) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , object :
-          ∀ ( x
-            : List
-                { mapKey : Text
-                , mapValue :
-                      ∀(JSON : Type)
-                    → ∀ ( json
-                        : { array : List JSON → JSON
-                          , bool : Bool → JSON
-                          , double : Double → JSON
-                          , integer : Integer → JSON
-                          , null : JSON
-                          , object :
-                              List { mapKey : Text, mapValue : JSON } → JSON
-                          , string : Text → JSON
-                          }
-                        )
-                    → JSON
-                }
-            )
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
+        ∀ ( x
+          : List
+              { mapKey : Text
+              , mapValue :
+                  ∀(JSON : Type) →
+                  ∀ ( json
+                    : { array : List JSON → JSON
+                      , bool : Bool → JSON
+                      , double : Double → JSON
+                      , integer : Integer → JSON
+                      , null : JSON
+                      , object : List { mapKey : Text, mapValue : JSON } → JSON
+                      , string : Text → JSON
+                      }
+                    ) →
+                    JSON
               }
-            )
-        → JSON
+          ) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , omitNullFields :
-          ∀ ( old
-            :   ∀(JSON : Type)
-              → ∀ ( json
-                  : { array : List JSON → JSON
-                    , bool : Bool → JSON
-                    , double : Double → JSON
-                    , integer : Integer → JSON
-                    , null : JSON
-                    , object : List { mapKey : Text, mapValue : JSON } → JSON
-                    , string : Text → JSON
-                    }
-                  )
-              → JSON
-            )
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀ ( old
+          : ∀(JSON : Type) →
+            ∀ ( json
+              : { array : List JSON → JSON
+                , bool : Bool → JSON
+                , double : Double → JSON
+                , integer : Integer → JSON
+                , null : JSON
+                , object : List { mapKey : Text, mapValue : JSON } → JSON
+                , string : Text → JSON
+                }
+              ) →
+              JSON
+          ) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , render :
-          ∀ ( json
-            :   ∀(JSON : Type)
-              → ∀ ( json
-                  : { array : List JSON → JSON
-                    , bool : Bool → JSON
-                    , double : Double → JSON
-                    , integer : Integer → JSON
-                    , null : JSON
-                    , object : List { mapKey : Text, mapValue : JSON } → JSON
-                    , string : Text → JSON
-                    }
-                  )
-              → JSON
-            )
-        → Text
+        ∀ ( json
+          : ∀(JSON : Type) →
+            ∀ ( json
+              : { array : List JSON → JSON
+                , bool : Bool → JSON
+                , double : Double → JSON
+                , integer : Integer → JSON
+                , null : JSON
+                , object : List { mapKey : Text, mapValue : JSON } → JSON
+                , string : Text → JSON
+                }
+              ) →
+              JSON
+          ) →
+          Text
     , renderInteger : ∀(integer : Integer) → Text
     , renderYAML :
-          ∀ ( json
-            :   ∀(JSON : Type)
-              → ∀ ( json
-                  : { array : List JSON → JSON
-                    , bool : Bool → JSON
-                    , double : Double → JSON
-                    , integer : Integer → JSON
-                    , null : JSON
-                    , object : List { mapKey : Text, mapValue : JSON } → JSON
-                    , string : Text → JSON
-                    }
-                  )
-              → JSON
-            )
-        → Text
+        ∀ ( json
+          : ∀(JSON : Type) →
+            ∀ ( json
+              : { array : List JSON → JSON
+                , bool : Bool → JSON
+                , double : Double → JSON
+                , integer : Integer → JSON
+                , null : JSON
+                , object : List { mapKey : Text, mapValue : JSON } → JSON
+                , string : Text → JSON
+                }
+              ) →
+              JSON
+          ) →
+          Text
     , string :
-          ∀(x : Text)
-        → ∀(JSON : Type)
-        → ∀ ( json
-            : { array : List JSON → JSON
-              , bool : Bool → JSON
-              , double : Double → JSON
-              , integer : Integer → JSON
-              , null : JSON
-              , object : List { mapKey : Text, mapValue : JSON } → JSON
-              , string : Text → JSON
-              }
-            )
-        → JSON
+        ∀(x : Text) →
+        ∀(JSON : Type) →
+        ∀ ( json
+          : { array : List JSON → JSON
+            , bool : Bool → JSON
+            , double : Double → JSON
+            , integer : Integer → JSON
+            , null : JSON
+            , object : List { mapKey : Text, mapValue : JSON } → JSON
+            , string : Text → JSON
+            }
+          ) →
+          JSON
     , tagInline :
-          ∀(tagFieldName : Text)
-        → ∀(a : Type)
-        → ∀(contents : a)
-        → { contents : a, field : Text, nesting : < Inline | Nested : Text > }
+        ∀(tagFieldName : Text) →
+        ∀(a : Type) →
+        ∀(contents : a) →
+          { contents : a, field : Text, nesting : < Inline | Nested : Text > }
     , tagNested :
-          ∀(contentsFieldName : Text)
-        → ∀(tagFieldName : Text)
-        → ∀(a : Type)
-        → ∀(contents : a)
-        → { contents : a, field : Text, nesting : < Inline | Nested : Text > }
+        ∀(contentsFieldName : Text) →
+        ∀(tagFieldName : Text) →
+        ∀(a : Type) →
+        ∀(contents : a) →
+          { contents : a, field : Text, nesting : < Inline | Nested : Text > }
     }
 , List :
     { all : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : List a) → Bool
     , any : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : List a) → Bool
     , build :
-          ∀(a : Type)
-        → (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list)
-        → List a
+        ∀(a : Type) →
+        (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list) →
+          List a
     , concat : ∀(a : Type) → ∀(xss : List (List a)) → List a
     , concatMap :
         ∀(a : Type) → ∀(b : Type) → ∀(f : a → List b) → ∀(xs : List a) → List b
@@ -299,12 +297,12 @@
     , empty : ∀(a : Type) → List a
     , filter : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : List a) → List a
     , fold :
-          ∀(a : Type)
-        → List a
-        → ∀(list : Type)
-        → ∀(cons : a → list → list)
-        → ∀(nil : list)
-        → list
+        ∀(a : Type) →
+        List a →
+        ∀(list : Type) →
+        ∀(cons : a → list → list) →
+        ∀(nil : list) →
+          list
     , generate : ∀(n : Natural) → ∀(a : Type) → ∀(f : Natural → a) → List a
     , head : ∀(a : Type) → List a → Optional a
     , index : ∀(n : Natural) → ∀(a : Type) → ∀(xs : List a) → Optional a
@@ -315,28 +313,28 @@
     , map : ∀(a : Type) → ∀(b : Type) → ∀(f : a → b) → ∀(xs : List a) → List b
     , null : ∀(a : Type) → ∀(xs : List a) → Bool
     , partition :
-          ∀(a : Type)
-        → ∀(f : a → Bool)
-        → ∀(xs : List a)
-        → { false : List a, true : List a }
+        ∀(a : Type) →
+        ∀(f : a → Bool) →
+        ∀(xs : List a) →
+          { false : List a, true : List a }
     , replicate : ∀(n : Natural) → ∀(a : Type) → ∀(x : a) → List a
     , reverse : ∀(a : Type) → List a → List a
     , shifted :
-          ∀(a : Type)
-        → ∀(kvss : List (List { index : Natural, value : a }))
-        → List { index : Natural, value : a }
+        ∀(a : Type) →
+        ∀(kvss : List (List { index : Natural, value : a })) →
+          List { index : Natural, value : a }
     , take : ∀(n : Natural) → ∀(a : Type) → ∀(xs : List a) → List a
     , unzip :
-          ∀(a : Type)
-        → ∀(b : Type)
-        → ∀(xs : List { _1 : a, _2 : b })
-        → { _1 : List a, _2 : List b }
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(xs : List { _1 : a, _2 : b }) →
+          { _1 : List a, _2 : List b }
     , zip :
-          ∀(a : Type)
-        → ∀(xa : List a)
-        → ∀(b : Type)
-        → ∀(xb : List b)
-        → List { _1 : a, _2 : b }
+        ∀(a : Type) →
+        ∀(xa : List a) →
+        ∀(b : Type) →
+        ∀(xb : List b) →
+          List { _1 : a, _2 : b }
     }
 , Location : { Type : Type }
 , Map :
@@ -346,46 +344,46 @@
     , keyText :
         ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
     , keyValue :
-          ∀(v : Type)
-        → ∀(key : Text)
-        → ∀(value : v)
-        → { mapKey : Text, mapValue : v }
+        ∀(v : Type) →
+        ∀(key : Text) →
+        ∀(value : v) →
+          { mapKey : Text, mapValue : v }
     , keys :
-          ∀(k : Type)
-        → ∀(v : Type)
-        → ∀(xs : List { mapKey : k, mapValue : v })
-        → List k
+        ∀(k : Type) →
+        ∀(v : Type) →
+        ∀(xs : List { mapKey : k, mapValue : v }) →
+          List k
     , map :
-          ∀(k : Type)
-        → ∀(a : Type)
-        → ∀(b : Type)
-        → ∀(f : a → b)
-        → ∀(m : List { mapKey : k, mapValue : a })
-        → List { mapKey : k, mapValue : b }
+        ∀(k : Type) →
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(f : a → b) →
+        ∀(m : List { mapKey : k, mapValue : a }) →
+          List { mapKey : k, mapValue : b }
     , values :
-          ∀(k : Type)
-        → ∀(v : Type)
-        → ∀(xs : List { mapKey : k, mapValue : v })
-        → List v
+        ∀(k : Type) →
+        ∀(v : Type) →
+        ∀(xs : List { mapKey : k, mapValue : v }) →
+          List v
     }
 , Monoid : ∀(m : Type) → Type
 , Natural :
     { build :
-          (   ∀(natural : Type)
-            → ∀(succ : natural → natural)
-            → ∀(zero : natural)
-            → natural
-          )
-        → Natural
+        ( ∀(natural : Type) →
+          ∀(succ : natural → natural) →
+          ∀(zero : natural) →
+            natural
+        ) →
+          Natural
     , enumerate : ∀(n : Natural) → List Natural
     , equal : ∀(a : Natural) → ∀(b : Natural) → Bool
     , even : Natural → Bool
     , fold :
-          Natural
-        → ∀(natural : Type)
-        → ∀(succ : natural → natural)
-        → ∀(zero : natural)
-        → natural
+        Natural →
+        ∀(natural : Type) →
+        ∀(succ : natural → natural) →
+        ∀(zero : natural) →
+          natural
     , greaterThan : ∀(x : Natural) → ∀(y : Natural) → Bool
     , greaterThanEqual : ∀(x : Natural) → ∀(y : Natural) → Bool
     , isZero : Natural → Bool
@@ -408,50 +406,50 @@
     { all : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : Optional a) → Bool
     , any : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : Optional a) → Bool
     , build :
-          ∀(a : Type)
-        → ∀ ( build
-            :   ∀(optional : Type)
-              → ∀(some : a → optional)
-              → ∀(none : optional)
-              → optional
-            )
-        → Optional a
+        ∀(a : Type) →
+        ∀ ( build
+          : ∀(optional : Type) →
+            ∀(some : a → optional) →
+            ∀(none : optional) →
+              optional
+          ) →
+          Optional a
     , concat : ∀(a : Type) → ∀(x : Optional (Optional a)) → Optional a
     , default : ∀(a : Type) → ∀(default : a) → ∀(o : Optional a) → a
     , filter : ∀(a : Type) → ∀(f : a → Bool) → ∀(xs : Optional a) → Optional a
     , fold :
-          ∀(a : Type)
-        → ∀(o : Optional a)
-        → ∀(optional : Type)
-        → ∀(some : a → optional)
-        → ∀(none : optional)
-        → optional
+        ∀(a : Type) →
+        ∀(o : Optional a) →
+        ∀(optional : Type) →
+        ∀(some : a → optional) →
+        ∀(none : optional) →
+          optional
     , head : ∀(a : Type) → ∀(xs : List (Optional a)) → Optional a
     , last : ∀(a : Type) → ∀(xs : List (Optional a)) → Optional a
     , length : ∀(a : Type) → ∀(xs : Optional a) → Natural
     , map :
-          ∀(a : Type)
-        → ∀(b : Type)
-        → ∀(f : a → b)
-        → ∀(o : Optional a)
-        → Optional b
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(f : a → b) →
+        ∀(o : Optional a) →
+          Optional b
     , null : ∀(a : Type) → ∀(xs : Optional a) → Bool
     , toList : ∀(a : Type) → ∀(o : Optional a) → List a
     , unzip :
-          ∀(a : Type)
-        → ∀(b : Type)
-        → ∀(xs : Optional { _1 : a, _2 : b })
-        → { _1 : Optional a, _2 : Optional b }
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(xs : Optional { _1 : a, _2 : b }) →
+          { _1 : Optional a, _2 : Optional b }
     }
 , Text :
     { concat : ∀(xs : List Text) → Text
     , concatMap : ∀(a : Type) → ∀(f : a → Text) → ∀(xs : List a) → Text
     , concatMapSep :
-          ∀(separator : Text)
-        → ∀(a : Type)
-        → ∀(f : a → Text)
-        → ∀(elements : List a)
-        → Text
+        ∀(separator : Text) →
+        ∀(a : Type) →
+        ∀(f : a → Text) →
+        ∀(elements : List a) →
+          Text
     , concatSep : ∀(separator : Text) → ∀(elements : List Text) → Text
     , default : ∀(o : Optional Text) → Text
     , defaultMap : ∀(a : Type) → ∀(f : a → Text) → ∀(o : Optional a) → Text
@@ -464,87 +462,87 @@
     , attribute :
         ∀(key : Text) → ∀(value : Text) → { mapKey : Text, mapValue : Text }
     , element :
-          ∀ ( elem
-            : { attributes : List { mapKey : Text, mapValue : Text }
-              , content :
-                  List
-                    (   ∀(XML : Type)
-                      → ∀ ( xml
-                          : { element :
-                                  { attributes :
-                                      List { mapKey : Text, mapValue : Text }
-                                  , content : List XML
-                                  , name : Text
-                                  }
-                                → XML
-                            , text : Text → XML
-                            }
-                          )
-                      → XML
-                    )
-              , name : Text
-              }
-            )
-        → ∀(XML : Type)
-        → ∀ ( xml
-            : { element :
-                    { attributes : List { mapKey : Text, mapValue : Text }
-                    , content : List XML
-                    , name : Text
-                    }
-                  → XML
-              , text : Text → XML
-              }
-            )
-        → XML
+        ∀ ( elem
+          : { attributes : List { mapKey : Text, mapValue : Text }
+            , content :
+                List
+                  ( ∀(XML : Type) →
+                    ∀ ( xml
+                      : { element :
+                            { attributes :
+                                List { mapKey : Text, mapValue : Text }
+                            , content : List XML
+                            , name : Text
+                            } →
+                              XML
+                        , text : Text → XML
+                        }
+                      ) →
+                      XML
+                  )
+            , name : Text
+            }
+          ) →
+        ∀(XML : Type) →
+        ∀ ( xml
+          : { element :
+                { attributes : List { mapKey : Text, mapValue : Text }
+                , content : List XML
+                , name : Text
+                } →
+                  XML
+            , text : Text → XML
+            }
+          ) →
+          XML
     , emptyAttributes : List { mapKey : Text, mapValue : Text }
     , leaf :
-          ∀ ( elem
-            : { attributes : List { mapKey : Text, mapValue : Text }
-              , name : Text
-              }
-            )
-        → ∀(XML : Type)
-        → ∀ ( xml
-            : { element :
-                    { attributes : List { mapKey : Text, mapValue : Text }
-                    , content : List XML
-                    , name : Text
-                    }
-                  → XML
-              , text : Text → XML
-              }
-            )
-        → XML
+        ∀ ( elem
+          : { attributes : List { mapKey : Text, mapValue : Text }
+            , name : Text
+            }
+          ) →
+        ∀(XML : Type) →
+        ∀ ( xml
+          : { element :
+                { attributes : List { mapKey : Text, mapValue : Text }
+                , content : List XML
+                , name : Text
+                } →
+                  XML
+            , text : Text → XML
+            }
+          ) →
+          XML
     , render :
-          ∀ ( x
-            :   ∀(XML : Type)
-              → ∀ ( xml
-                  : { element :
-                          { attributes : List { mapKey : Text, mapValue : Text }
-                          , content : List XML
-                          , name : Text
-                          }
-                        → XML
-                    , text : Text → XML
-                    }
-                  )
-              → XML
-            )
-        → Text
-    , text :
-          ∀(d : Text)
-        → ∀(XML : Type)
-        → ∀ ( xml
-            : { element :
+        ∀ ( x
+          : ∀(XML : Type) →
+            ∀ ( xml
+              : { element :
                     { attributes : List { mapKey : Text, mapValue : Text }
                     , content : List XML
                     , name : Text
-                    }
-                  → XML
-              , text : Text → XML
-              }
-            )
-        → XML
+                    } →
+                      XML
+                , text : Text → XML
+                }
+              ) →
+              XML
+          ) →
+          Text
+    , text :
+        ∀(d : Text) →
+        ∀(XML : Type) →
+        ∀ ( xml
+          : { element :
+                { attributes : List { mapKey : Text, mapValue : Text }
+                , content : List XML
+                , name : Text
+                } →
+                  XML
+            , text : Text → XML
+            }
+          ) →
+          XML
     }
 }


### PR DESCRIPTION
The main difference this entails is formatting changes, as you can
see from the diff

I also manually applied the formatter to the documentation, too.