### PR TITLE
Bring `README` up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,44 +43,48 @@ For an even longer hands-on tutorial, read:
 
 * [Getting started: Generate JSON or YAML][dhall-json-tutorial-wiki]
 
-## Features:
+... and for an even longer tutorial, read:
 
-* Total - Evaluation always terminates and never hangs or infinitely loops
-* Safe - Evaluation never crashes or throws exceptions
-* Distributed - Expressions can reference other expressions by URL or path
-* Strongly normalizing - All expressions (even functions) have a normal form
-* Statically typed - Configurations can be validated ahead-of-time
-* Strongly typed - No coercions, casts or subtyping
-* Built-in data types - Includes lists, anonymous records and anonymous unions
-
-## Documentation
-
-The Dhall language originated as a Haskell-specific configuration file format
-and is expanding to support more languages and file formats.  Consequently, the
-Haskell package for Dhall still hosts the official tutorial and language manual:
-
-* [Dhall tutorial and manual][dhall-haskell-tutorial]
-
-... which will eventually become a language-agnostic tutorial
-
-You can also read about the original motivation behind the language here:
-
-* [Dhall - A non-Turing-complete configuration language][dhall-haskell-post]
+* [Language Tour][language-tour]
 
 Finally, we have a cheatsheet for a very condensed overview and quick lookup:
 
 * [Dhall Cheatsheet][dhall-cheatsheet]
 
-## Standard Library
+## What is this repository?
 
-Dhall's Standard Library is called `Prelude`. It implements various utilities to
-work with the builtin types. Where to find it:
+The Dhall configuration language has multiple implementations so that Dhall
+configuration files can be understood natively by several programming
+languages.  You can find the latest list of the language bindings and their
+respective repositories here:
 
-* [Official link - https://prelude.dhall-lang.org](https://prelude.dhall-lang.org)
-* [Github repo](https://github.com/dhall-lang/dhall-lang/tree/master/Prelude)
-* [Nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/dhall/build-dhall-package.nix):
-  both `dhall` and `dhall.prelude` derivations are built, install the `Prelude`
-  with e.g. `nix-env -iA nixpkgs.dhall.prelude`
+* [How to integrate Dhall - Language support][language-support]
+
+This repository contains language-independent functionality, such as:
+
+* The [grammar and formal semantics](./standard/README.md)
+
+  Dhall is a formally-specified language standard, and language bindings follow
+  the specification in order to ensure portability of Dhall configuration files
+  across language bindings.
+
+* The [standard test suite](./tests/README.md)
+
+  This repository contains a test suite that language bindings can use to
+  check compliance against the standard.
+
+* The [Prelude](./Prelude/README.md)
+
+  One Dhall package named the Prelude is versioned with and distributed
+  alongside the language standard.  This package contains general-purpose
+  utilities.
+
+* [Shared infrastructure](./nixops/README.md) for the Dhall ecosystem
+
+  Several services support Dhall developers and this repository contains a
+  [NixOps](https://nixos.org/nixops/manual/) specification of that
+  infrastructure that automatically deploys changes merged to that
+  configuration.
 
 ## Development status
 
@@ -88,11 +92,11 @@ The current version and versioning policy is detailed in the
 [Versioning document](./standard/versioning.md), and you can see the latest
 changes [in the Changelog](CHANGELOG.md).
 
-There is an effort under way to formalize the language semantics for Dhall, to
-help with porting it to [other languages](#language-bindings).
-If you would like to assist with either standardizing the language or creating
-new bindings just open a new issue or contribute to existing ones in the [issue
-tracker][issue-tracker].
+The Dhall configuration language slowly evolves in response to user feedback
+and if you would like to participate in the language evolution process then
+you should read:
+
+* [`CONTRIBUTING.md` - How do I change the language](.github/CONTRIBUTING.md)
 
 ## Design philosophy
 
@@ -149,11 +153,6 @@ Dhall is a very minimal programming language.  For example: you cannot even
 compare strings for equality.  The language also forbids many other common
 operations in order to force users to keep things simple
 
-The biggest issue with using Dhall as a configuration language is that there are
-currently only Haskell bindings.  If you would like to contribute bindings to
-another language then go for it, otherwise I will do my best to contribute them
-as time permits.
-
 ## Name
 
 The language is named after a
@@ -163,6 +162,36 @@ analog of Dhall's quill.
 
 The name rhymes with "tall"/"call"/"hall" (i.e. "dɔl" for a US speaker or
 "dɔːl" for a UK speaker using the International Phonetic Alphabet).
+
+## Contributors
+
+### Code Contributors
+
+This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
+<a href="https://github.com/dhall-lang/dhall-lang/graphs/contributors"><img src="https://opencollective.com/dhall/contributors.svg?width=890&button=false" /></a>
+
+### Financial Contributors
+
+Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/dhall/contribute)]
+
+#### Individuals
+
+<a href="https://opencollective.com/dhall"><img src="https://opencollective.com/dhall/individuals.svg?width=890"></a>
+
+#### Organizations
+
+Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/dhall/contribute)]
+
+<a href="https://opencollective.com/dhall/organization/0/website"><img src="https://opencollective.com/dhall/organization/0/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/1/website"><img src="https://opencollective.com/dhall/organization/1/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/2/website"><img src="https://opencollective.com/dhall/organization/2/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/3/website"><img src="https://opencollective.com/dhall/organization/3/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/4/website"><img src="https://opencollective.com/dhall/organization/4/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/5/website"><img src="https://opencollective.com/dhall/organization/5/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/6/website"><img src="https://opencollective.com/dhall/organization/6/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/7/website"><img src="https://opencollective.com/dhall/organization/7/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/8/website"><img src="https://opencollective.com/dhall/organization/8/avatar.svg"></a>
+<a href="https://opencollective.com/dhall/organization/9/website"><img src="https://opencollective.com/dhall/organization/9/avatar.svg"></a>
 
 [dhall-haskell]: https://github.com/dhall-lang/dhall-haskell
 [dhall-haskell-tutorial]: https://hackage.haskell.org/package/dhall/docs/Dhall-Tutorial.html
@@ -198,33 +227,5 @@ The name rhymes with "tall"/"call"/"hall" (i.e. "dɔl" for a US speaker or
 [dhall-json-tutorial-wiki]: https://docs.dhall-lang.org/tutorials/Getting-started_Generate-JSON-or-YAML.html
 [dhall-integration-howto]: https://docs.dhall-lang.org/howtos/How-to-integrate-Dhall.html
 [dhall-cheatsheet]: https://docs.dhall-lang.org/howtos/Cheatsheet.html
-
-## Contributors
-
-### Code Contributors
-
-This project exists thanks to all the people who contribute. [[Contribute](.github/CONTRIBUTING.md)].
-<a href="https://github.com/dhall-lang/dhall-lang/graphs/contributors"><img src="https://opencollective.com/dhall/contributors.svg?width=890&button=false" /></a>
-
-### Financial Contributors
-
-Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/dhall/contribute)]
-
-#### Individuals
-
-<a href="https://opencollective.com/dhall"><img src="https://opencollective.com/dhall/individuals.svg?width=890"></a>
-
-#### Organizations
-
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/dhall/contribute)]
-
-<a href="https://opencollective.com/dhall/organization/0/website"><img src="https://opencollective.com/dhall/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/1/website"><img src="https://opencollective.com/dhall/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/2/website"><img src="https://opencollective.com/dhall/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/3/website"><img src="https://opencollective.com/dhall/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/4/website"><img src="https://opencollective.com/dhall/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/5/website"><img src="https://opencollective.com/dhall/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/6/website"><img src="https://opencollective.com/dhall/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/7/website"><img src="https://opencollective.com/dhall/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/8/website"><img src="https://opencollective.com/dhall/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/dhall/organization/9/website"><img src="https://opencollective.com/dhall/organization/9/avatar.svg"></a>
+[language-tour]: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+[language-support]: https://docs.dhall-lang.org/howtos/How-to-integrate-Dhall.html#language-support


### PR DESCRIPTION
There were several stale passages in the `README`, which this change
fixes, and I also took this opportunity to trim things down since
many of the things covered in the `README` are already covered by
dhall-lang.org.