### PR TITLE
Test that we typecheck `let` annotations

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -97,6 +97,13 @@ The tests should:
 
 ### Running `type-inference` tests
 
+Note: if your implementation does not implement typechecking
+correctly, some of the `type-inference/failure` tests may not
+terminate.  This is because typechecking is central to Dhall's
+guarantees of totality: only expressions which typecheck are
+guaranteed to terminate.  As a result, you may want to guard against
+nontermination, such as by adding a timeout to these tests.
+
 The tests should:
 - parse `A` and `B`
 - if not running `simple` or `unit` tests, resolve the imports in `A` without using the cache

--- a/tests/type-inference/failure/unit/LetWithNonterminatingAnnotation.dhall
+++ b/tests/type-inference/failure/unit/LetWithNonterminatingAnnotation.dhall
@@ -1,0 +1,14 @@
+-- When you check if an inferred type is equivalent to an annotation,
+-- you must alpha-beta-normalize both sides first.  But it is not safe
+-- to beta-normalise an expression which hasn't first been
+-- typechecked.
+--
+-- This test contains an annotation which doesn't typecheck, and
+-- which, when beta-normalized, doesn't terminate.  It exists to
+-- verify that implementations typecheck the annotation before
+-- checking equivalence.
+let a
+    : (λ(x : Natural) → x x) (λ(x : Natural) → x x)
+    = 3
+
+in  5


### PR DESCRIPTION
This testcase came up in a PR on dhall-golang:
https://github.com/philandstuff/dhall-golang/pull/40

See the test comment for details.