### PR TITLE
Allow hydra to send email

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -64,7 +64,7 @@
     };
 
     policydSPFExtraConfig = ''
-      skip_addresses = 172.17.0.2/32
+      skip_addresses = 172.17.0.2/32,127.0.0.0/8,::ffff:127.0.0.0/104,::1
     '';
   };
 


### PR DESCRIPTION
Currently, policyd-spf is blocking email from hydra because it appears
to come from `::1`, and `::1` is not a valid domain to send email from
`@dhall-lang.org` email addresses.

We have a fix for this for discourse, which uses a different IP address
to send local traffic from, for some reason, but it removes the default
value for `skip_addresses` which would have allowed hydra's mail.

This commit prepends the Discourse IP address to the original default
value for `skip_addresses` which permits any localhost-type IP address.