### PR TITLE
Use `dhall-docs` comment format for Prelude

### DIFF
--- a/Prelude/Bool/and.dhall
+++ b/Prelude/Bool/and.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 The `and` function returns `False` if there are any `False` elements in the
 `List` and returns `True` otherwise
 -}

--- a/Prelude/Bool/build.dhall
+++ b/Prelude/Bool/build.dhall
@@ -1,6 +1,4 @@
-{-
-`build` is the inverse of `fold`
--}
+--| `build` is the inverse of `fold`
 let build
     : (∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) → Bool
     = λ(f : ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool) →

--- a/Prelude/Bool/even.dhall
+++ b/Prelude/Bool/even.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` if there are an even number of `False` elements in the list and
 returns `False` otherwise.
 

--- a/Prelude/Bool/fold.dhall
+++ b/Prelude/Bool/fold.dhall
@@ -1,6 +1,4 @@
-{-
-`fold` is essentially the same as `if`/`then`/`else` except as a function
--}
+--| `fold` is essentially the same as `if`/`then`/`else` except as a function
 let fold
     : ∀(b : Bool) → ∀(bool : Type) → ∀(true : bool) → ∀(false : bool) → bool
     = λ(b : Bool) →

--- a/Prelude/Bool/not.dhall
+++ b/Prelude/Bool/not.dhall
@@ -1,6 +1,4 @@
-{-
-Flip the value of a `Bool`
--}
+--| Flip the value of a `Bool`
 let not
     : Bool → Bool
     = λ(b : Bool) → b == False

--- a/Prelude/Bool/odd.dhall
+++ b/Prelude/Bool/odd.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` if there are an odd number of `True` elements in the list and
 returns `False` otherwise.
 

--- a/Prelude/Bool/or.dhall
+++ b/Prelude/Bool/or.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 The `or` function returns `True` if there are any `True` elements in the `List`
 and returns `False` otherwise
 -}

--- a/Prelude/Bool/show.dhall
+++ b/Prelude/Bool/show.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Render a `Bool` as `Text` using the same representation as Dhall source code
 (i.e. beginning with a capital letter)
 -}

--- a/Prelude/Double/show.dhall
+++ b/Prelude/Double/show.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Render a `Double` as `Text` using the same representation as Dhall source
 code (i.e. a decimal floating point number with a leading `-` sign if negative)
 -}

--- a/Prelude/Function/compose.dhall
+++ b/Prelude/Function/compose.dhall
@@ -1,6 +1,4 @@
-{-
-Compose two functions into one.
--}
+--| Compose two functions into one.
 let compose
     : ∀(a : Type) → ∀(b : Type) → ∀(c : Type) → (a → b) → (b → c) → a → c
     = λ(A : Type) →

--- a/Prelude/Function/identity.dhall
+++ b/Prelude/Function/identity.dhall
@@ -1,6 +1,4 @@
-{-
-The identity function simply returns its input
--}
+--| The identity function simply returns its input
 let identity
     : ∀(a : Type) → ∀(x : a) → a
     = λ(a : Type) → λ(x : a) → x

--- a/Prelude/Integer/abs.dhall
+++ b/Prelude/Integer/abs.dhall
@@ -1,6 +1,4 @@
-{-
-Returns the absolute value of an `Integer`, i.e. its non-negative value.
--}
+--| Returns the absolute value of an `Integer`, i.e. its non-negative value.
 let abs
     : Integer → Natural
     = λ(n : Integer) →

--- a/Prelude/Integer/add.dhall
+++ b/Prelude/Integer/add.dhall
@@ -1,6 +1,4 @@
-{-
-`add m n` computes `m + n`.
--}
+--| `add m n` computes `m + n`.
 let Integer/subtract =
         ./subtract sha256:a34d36272fa8ae4f1ec8b56222fe8dc8a2ec55ec6538b840de0cbe207b006fda
       ? ./subtract

--- a/Prelude/Integer/clamp.dhall
+++ b/Prelude/Integer/clamp.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Convert an `Integer` to a `Natural` number, with negative numbers becoming zero.
 -}
 let clamp

--- a/Prelude/Integer/equal.dhall
+++ b/Prelude/Integer/equal.dhall
@@ -1,6 +1,4 @@
-{-
-`equal` checks if two Integers are equal.
--}
+--| `equal` checks if two Integers are equal.
 let Natural/equal =
         ../Natural/equal sha256:7f108edfa35ddc7cebafb24dc073478e93a802e13b5bc3fd22f4768c9b066e60
       ? ../Natural/equal

--- a/Prelude/Integer/greaterThan.dhall
+++ b/Prelude/Integer/greaterThan.dhall
@@ -1,6 +1,4 @@
-{-
-`greaterThan` checks if one Integer is greater than another.
--}
+--| `greaterThan` checks if one Integer is greater than another.
 let Bool/not =
         ../Bool/not sha256:723df402df24377d8a853afed08d9d69a0a6d86e2e5b2bac8960b0d4756c7dc4
       ? ../Bool/not

--- a/Prelude/Integer/greaterThanEqual.dhall
+++ b/Prelude/Integer/greaterThanEqual.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `greaterThanEqual` checks if one Integer is greater than or equal to another.
 -}
 let lessThanEqual =

--- a/Prelude/Integer/lessThan.dhall
+++ b/Prelude/Integer/lessThan.dhall
@@ -1,6 +1,4 @@
-{-
-`lessThan` checks if one Integer is less than another.
--}
+--| `lessThan` checks if one Integer is less than another.
 let greaterThan =
         ./greaterThan sha256:d23affd73029fc9aaf867c2c7b86510ca2802d3f0d1f3e1d1a93ffd87b7cb64b
       ? ./greaterThan

--- a/Prelude/Integer/lessThanEqual.dhall
+++ b/Prelude/Integer/lessThanEqual.dhall
@@ -1,6 +1,4 @@
-{-
-`lessThanEqual` checks if one Integer is less than or equal to another.
--}
+--| `lessThanEqual` checks if one Integer is less than or equal to another.
 let Natural/greaterThanEqual =
         ../Natural/greaterThanEqual sha256:30ebfab0febd7aa0ccccfdf3dc36ee6d50f0117f35dd4a9b034750b7e885a1a4
       ? ../Natural/greaterThanEqual

--- a/Prelude/Integer/multiply.dhall
+++ b/Prelude/Integer/multiply.dhall
@@ -1,6 +1,4 @@
-{-
-`multiply m n` computes `m * n`.
--}
+--| `multiply m n` computes `m * n`.
 
 let nonPositive =
         ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b

--- a/Prelude/Integer/negate.dhall
+++ b/Prelude/Integer/negate.dhall
@@ -1,6 +1,4 @@
-{-
-Invert the sign of an `Integer`, with zero remaining unchanged.
--}
+--| Invert the sign of an `Integer`, with zero remaining unchanged.
 let negate
     : Integer → Integer
     = Integer/negate

--- a/Prelude/Integer/negative.dhall
+++ b/Prelude/Integer/negative.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` for any `Integer` less than `+0`.
 
 `negative` is more efficient than `./lessThan +0` or `./lessThanEqual -1`.

--- a/Prelude/Integer/nonNegative.dhall
+++ b/Prelude/Integer/nonNegative.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` for `+0` and any positive `Integer`.
 
 `nonNegative` is more efficient than `./greaterThanEqual +0` or `./greaterThan -1`.

--- a/Prelude/Integer/nonPositive.dhall
+++ b/Prelude/Integer/nonPositive.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` for `+0` and any negative `Integer`.
 
 `nonPositive` is more efficient than `./lessThanEqual +0` or `./lessThan +1`.

--- a/Prelude/Integer/positive.dhall
+++ b/Prelude/Integer/positive.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` for any `Integer` greater than `+0`.
 
 `positive` is more efficient than `./greaterThan +0` or `./greaterThanEqual +1`.

--- a/Prelude/Integer/show.dhall
+++ b/Prelude/Integer/show.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Render an `Integer` as `Text` using the same representation as Dhall source
 code (i.e. a decimal number with a leading `-` sign if negative and a leading
 `+` sign if non-negative)

--- a/Prelude/Integer/subtract.dhall
+++ b/Prelude/Integer/subtract.dhall
@@ -1,6 +1,4 @@
-{-
-`subtract m n` computes `n - m`.
--}
+--| `subtract m n` computes `n - m`.
 let nonPositive =
         ./nonPositive sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
       ? ./nonPositive

--- a/Prelude/Integer/toDouble.dhall
+++ b/Prelude/Integer/toDouble.dhall
@@ -1,6 +1,4 @@
-{-
-Convert an `Integer` to the corresponding `Double`
--}
+--| Convert an `Integer` to the corresponding `Double`
 let toDouble
     : Integer → Double
     = Integer/toDouble

--- a/Prelude/Integer/toNatural.dhall
+++ b/Prelude/Integer/toNatural.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Convert an `Integer` to an `Optional Natural`, with negative numbers becoming `None Natural`.
 -}
 let nonNegative =

--- a/Prelude/JSON/Format.dhall
+++ b/Prelude/JSON/Format.dhall
@@ -1,7 +1,8 @@
-{- An internal type used by `./renderAs` to select the output format.
+{-|
+An internal type used by `./renderAs` to select the output format.
 
-   You should not need to use this type directly, simply use `./render`
-   or `./renderYAML` as appropriate.
+You should not need to use this type directly, simply use `./render`
+or `./renderYAML` as appropriate.
 -}
 
 < YAML | JSON >

--- a/Prelude/JSON/Nesting.dhall
+++ b/Prelude/JSON/Nesting.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 This type is used as part of `dhall-json`'s support for preserving alternative
 names
 
@@ -24,7 +24,7 @@ in  { field =
 {
   "foo": 2,
   "name": "Left"
- }
+}
 ```
 
 -}

--- a/Prelude/JSON/Tagged.dhall
+++ b/Prelude/JSON/Tagged.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 This is a convenient type-level function when using `dhall-to-json`'s support
 for preserving alternative names
 

--- a/Prelude/JSON/Type.dhall
+++ b/Prelude/JSON/Type.dhall
@@ -1,13 +1,13 @@
 {-|
 Dhall encoding of an arbitrary JSON value
 
-   For example, the following JSON value:
+For example, the following JSON value:
 
 ```
 [ { "foo": null, "bar": [ 1.0, true ] } ]
 ```
 
-   ... corresponds to the following Dhall expression:
+... corresponds to the following Dhall expression:
 
 ```
 λ(JSON : Type) →

--- a/Prelude/JSON/Type.dhall
+++ b/Prelude/JSON/Type.dhall
@@ -1,4 +1,5 @@
-{- Dhall encoding of an arbitrary JSON value
+{-|
+Dhall encoding of an arbitrary JSON value
 
    For example, the following JSON value:
 

--- a/Prelude/JSON/array.dhall
+++ b/Prelude/JSON/array.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON array from a `List` of JSON values
+{-|
+Create a JSON array from a `List` of JSON values
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/bool.dhall
+++ b/Prelude/JSON/bool.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON bool from a Dhall `Bool`
+{-|
+Create a JSON bool from a Dhall `Bool`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/core.dhall.dhall
+++ b/Prelude/JSON/core.dhall.dhall
@@ -1,12 +1,13 @@
-{- A record of functions useful for constructing `JSON` values.
+{-|
+A record of functions useful for constructing `JSON` values.
 
-   This is only a subset of what `package.dhall` exports. If you are
-   not writing a JSON prelude function, you should use the
-   `package.dhall` file instead.
+This is only a subset of what `package.dhall` exports. If you are
+not writing a JSON prelude function, you should use the
+`package.dhall` file instead.
 
-   It is used internally by `render`, `renderYAML` and
-   `omitNullFields` instead of `package.dhall` to avoid import
-   cycles.
+It is used internally by `render`, `renderYAML` and
+`omitNullFields` instead of `package.dhall` to avoid import
+cycles.
 -}
 { Type =
       ./Type sha256:40edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759

--- a/Prelude/JSON/double.dhall
+++ b/Prelude/JSON/double.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON number from a Dhall `Double`
+{-|
+Create a JSON number from a Dhall `Double`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/integer.dhall
+++ b/Prelude/JSON/integer.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON number from a Dhall `Integer`
+{-|
+Create a JSON number from a Dhall `Integer`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/natural.dhall
+++ b/Prelude/JSON/natural.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON number from a Dhall `Natural`
+{-|
+Create a JSON number from a Dhall `Natural`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/null.dhall
+++ b/Prelude/JSON/null.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON null
+{-|
+Create a JSON null
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/number.dhall
+++ b/Prelude/JSON/number.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON number from a Dhall `Double`
+{-|
+Create a JSON number from a Dhall `Double`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/object.dhall
+++ b/Prelude/JSON/object.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON object from a Dhall `Map`
+{-|
+Create a JSON object from a Dhall `Map`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/omitNullFields.dhall
+++ b/Prelude/JSON/omitNullFields.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 This utility omits all `null` record fields, which is often the idiomatic way
 for a configuration to encode absent fields
 -}

--- a/Prelude/JSON/render.dhall
+++ b/Prelude/JSON/render.dhall
@@ -1,8 +1,8 @@
-{- Render a `JSON` value as `Text`
+{-|
+Render a `JSON` value as `Text`
 
-   This is useful for debugging `JSON` values or for tests.  For anything
-   more sophisticated you should use `dhall-to-json` or `dhall-to-yaml`
-
+This is useful for debugging `JSON` values or for tests.  For anything
+more sophisticated you should use `dhall-to-json` or `dhall-to-yaml`
 -}
 let JSON =
         ./core.dhall sha256:5dc1135d5481cfd6fde625aaed9fcbdb7aa7c14f2e76726aa5fdef028a5c10f5

--- a/Prelude/JSON/renderAs.dhall
+++ b/Prelude/JSON/renderAs.dhall
@@ -1,4 +1,4 @@
-{- Render a `JSON` value as `Text` in either JSON or YAML format. -}
+--| Render a `JSON` value as `Text` in either JSON or YAML format.
 
 let JSON =
         ./core.dhall sha256:5dc1135d5481cfd6fde625aaed9fcbdb7aa7c14f2e76726aa5fdef028a5c10f5

--- a/Prelude/JSON/renderInteger.dhall.dhall
+++ b/Prelude/JSON/renderInteger.dhall.dhall
@@ -1,5 +1,6 @@
-{- Render an `Integer` value as a `JSON number`, according to the JSON
-   standard, in which a number may not start with a plus sign (`+`).
+{-|
+Render an `Integer` value as a `JSON number`, according to the JSON
+standard, in which a number may not start with a plus sign (`+`).
 -}
 
 let Integer/nonNegative =

--- a/Prelude/JSON/renderYAML.dhall
+++ b/Prelude/JSON/renderYAML.dhall
@@ -1,12 +1,12 @@
-{- Render a `JSON` value as `Text` in YAML format.
+{-|
+Render a `JSON` value as `Text` in YAML format.
 
-   The generated YAML text will only contain escaped object keys and
-   string values and might therefore not be very human readable.
+The generated YAML text will only contain escaped object keys and
+string values and might therefore not be very human readable.
 
-   However, it is useful for debugging `JSON` values or for tests.
-   For anything more sophisticated you should use `dhall-to-json` or
-   `dhall-to-yaml`.
-
+However, it is useful for debugging `JSON` values or for tests.
+For anything more sophisticated you should use `dhall-to-json` or
+`dhall-to-yaml`.
 -}
 
 let JSON =

--- a/Prelude/JSON/string.dhall
+++ b/Prelude/JSON/string.dhall
@@ -1,4 +1,5 @@
-{- Create a JSON string from Dhall `Text`
+{-|
+Create a JSON string from Dhall `Text`
 
 ```
 let JSON = ./package.dhall

--- a/Prelude/JSON/tagInline.dhall
+++ b/Prelude/JSON/tagInline.dhall
@@ -1,5 +1,4 @@
-{- Prepare a union value for JSON- or YAML-encoding with the inline layout
--}
+--| Prepare a union value for JSON- or YAML-encoding with the inline layout
 let Nesting =
         ./Nesting sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
       ? ./Nesting

--- a/Prelude/JSON/tagNested.dhall
+++ b/Prelude/JSON/tagNested.dhall
@@ -1,5 +1,4 @@
-{- Prepare a union value for JSON- or YAML-encoding with the nested layout
--}
+--| Prepare a union value for JSON- or YAML-encoding with the nested layout
 let Nesting =
         ./Nesting sha256:6284802edd41d5d725aa1ec7687e614e21ad1be7e14dd10996bfa9625105c335
       ? ./Nesting

--- a/Prelude/List/all.dhall
+++ b/Prelude/List/all.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` if the supplied function returns `True` for all elements in the
 `List`
 -}

--- a/Prelude/List/any.dhall
+++ b/Prelude/List/any.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` if the supplied function returns `True` for any element in the
 `List`
 -}

--- a/Prelude/List/build.dhall
+++ b/Prelude/List/build.dhall
@@ -1,6 +1,4 @@
-{-
-`build` is the inverse of `fold`
--}
+--| `build` is the inverse of `fold`
 let build
     : ∀(a : Type) →
       (∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list) →

--- a/Prelude/List/concat.dhall
+++ b/Prelude/List/concat.dhall
@@ -1,6 +1,4 @@
-{-
-Concatenate a `List` of `List`s into a single `List`
--}
+--| Concatenate a `List` of `List`s into a single `List`
 let concat
     : ∀(a : Type) → List (List a) → List a
     = λ(a : Type) →

--- a/Prelude/List/concatMap.dhall
+++ b/Prelude/List/concatMap.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Transform a list by applying a function to each element and flattening the
 results
 -}

--- a/Prelude/List/default.dhall
+++ b/Prelude/List/default.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Unpack an `Optional` containing a `List`, defaulting to an empty list when the
 `Optional` is `None`
 -}

--- a/Prelude/List/drop.dhall
+++ b/Prelude/List/drop.dhall
@@ -1,4 +1,4 @@
--- Remove first `n` elements of a list
+--| Remove first `n` elements of a list
 let Natural/greaterThanEqual =
         ../Natural/greaterThanEqual sha256:30ebfab0febd7aa0ccccfdf3dc36ee6d50f0117f35dd4a9b034750b7e885a1a4
       ? ../Natural/greaterThanEqual

--- a/Prelude/List/empty.dhall
+++ b/Prelude/List/empty.dhall
@@ -1,6 +1,4 @@
-{-
-An empty list of the given type
--}
+--| An empty list of the given type
 let empty
     : ∀(a : Type) → List a
     = λ(a : Type) → [] : List a

--- a/Prelude/List/filter.dhall
+++ b/Prelude/List/filter.dhall
@@ -1,8 +1,4 @@
-{-
-Only keep elements of the list where the supplied function returns `True`
-
-Examples:
--}
+--| Only keep elements of the list where the supplied function returns `True`
 let filter
     : ∀(a : Type) → (a → Bool) → List a → List a
     = λ(a : Type) →

--- a/Prelude/List/fold.dhall
+++ b/Prelude/List/fold.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `fold` is the primitive function for consuming `List`s
 
 If you treat the list `[ x, y, z ]` as `cons x (cons y (cons z nil))`, then a

--- a/Prelude/List/generate.dhall
+++ b/Prelude/List/generate.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Build a list by calling the supplied function on all `Natural` numbers from `0`
 up to but not including the supplied `Natural` number
 -}

--- a/Prelude/List/head.dhall
+++ b/Prelude/List/head.dhall
@@ -1,6 +1,4 @@
-{-
-Retrieve the first element of the list
--}
+--| Retrieve the first element of the list
 let head
     : ∀(a : Type) → List a → Optional a
     = List/head

--- a/Prelude/List/index.dhall
+++ b/Prelude/List/index.dhall
@@ -1,6 +1,4 @@
-{-
-Retrieve an element from a `List` using its 0-based index
--}
+--| Retrieve an element from a `List` using its 0-based index
 let drop =
         ./drop sha256:af983ba3ead494dd72beed05c0f3a17c36a4244adedf7ced502c6512196ed0cf
       ? ./drop

--- a/Prelude/List/indexed.dhall
+++ b/Prelude/List/indexed.dhall
@@ -1,6 +1,4 @@
-{-
-Tag each element of the list with its index
--}
+--| Tag each element of the list with its index
 let indexed
     : ∀(a : Type) → List a → List { index : Natural, value : a }
     = List/indexed

--- a/Prelude/List/iterate.dhall
+++ b/Prelude/List/iterate.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Generate a list of the specified length given a seed value and transition
 function
 -}

--- a/Prelude/List/last.dhall
+++ b/Prelude/List/last.dhall
@@ -1,6 +1,4 @@
-{-
-Retrieve the last element of the list
--}
+--| Retrieve the last element of the list
 let last
     : ∀(a : Type) → List a → Optional a
     = List/last

--- a/Prelude/List/length.dhall
+++ b/Prelude/List/length.dhall
@@ -1,6 +1,4 @@
-{-
-Returns the number of elements in a list
--}
+--| Returns the number of elements in a list
 let length
     : ∀(a : Type) → List a → Natural
     = List/length

--- a/Prelude/List/map.dhall
+++ b/Prelude/List/map.dhall
@@ -1,6 +1,4 @@
-{-
-Transform a list by applying a function to each element
--}
+--| Transform a list by applying a function to each element
 let map
     : ∀(a : Type) → ∀(b : Type) → (a → b) → List a → List b
     = λ(a : Type) →

--- a/Prelude/List/null.dhall
+++ b/Prelude/List/null.dhall
@@ -1,6 +1,4 @@
-{-
-Returns `True` if the `List` is empty and `False` otherwise
--}
+--| Returns `True` if the `List` is empty and `False` otherwise
 let null
     : ∀(a : Type) → List a → Bool
     = λ(a : Type) → λ(xs : List a) → Natural/isZero (List/length a xs)

--- a/Prelude/List/partition.dhall
+++ b/Prelude/List/partition.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `partition` divides a `List` of elements into those that satisfy a predicate
 and those that do not
 -}

--- a/Prelude/List/replicate.dhall
+++ b/Prelude/List/replicate.dhall
@@ -1,6 +1,4 @@
-{-
-Build a list by copying the given element the specified number of times
--}
+--| Build a list by copying the given element the specified number of times
 let replicate
     : Natural → ∀(a : Type) → a → List a
     = λ(n : Natural) →

--- a/Prelude/List/reverse.dhall
+++ b/Prelude/List/reverse.dhall
@@ -1,6 +1,4 @@
-{-
-Reverse a list
--}
+--| Reverse a list
 let reverse
     : ∀(a : Type) → List a → List a
     = List/reverse

--- a/Prelude/List/shifted.dhall
+++ b/Prelude/List/shifted.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Combine a `List` of `List`s, offsetting the `index` of each element by the
 number of elements in preceding lists
 -}

--- a/Prelude/List/take.dhall
+++ b/Prelude/List/take.dhall
@@ -1,4 +1,4 @@
--- Truncate a list to the first `n` elements
+--| Truncate a list to the first `n` elements
 let Natural/lessThan =
         ../Natural/lessThan sha256:3381b66749290769badf8855d8a3f4af62e8de52d1364d838a9d1e20c94fa70c
       ? ../Natural/lessThan

--- a/Prelude/List/unpackOptionals.dhall
+++ b/Prelude/List/unpackOptionals.dhall
@@ -1,6 +1,4 @@
-{-
-Unpack Optionals in a List, omitting None items.
--}
+--| Unpack Optionals in a List, omitting None items.
 
 let List/concatMap =
         ./concatMap sha256:3b2167061d11fda1e4f6de0522cbe83e0d5ac4ef5ddf6bb0b2064470c5d3fb64

--- a/Prelude/List/unzip.dhall
+++ b/Prelude/List/unzip.dhall
@@ -1,6 +1,4 @@
-{-
-Unzip a `List` into two separate `List`s
--}
+--| Unzip a `List` into two separate `List`s
 let unzip
     : ∀(a : Type) →
       ∀(b : Type) →

--- a/Prelude/List/zip.dhall
+++ b/Prelude/List/zip.dhall
@@ -1,7 +1,7 @@
-{-
+{-|
 Zip two `List` into a single `List`
 
-Resulting `List` will have the length of the shortest of its arguments.
+The resulting `List` will have the length of the shortest of its arguments.
 -}
 let List/index =
         ./index sha256:e657b55ecae4d899465c3032cb1a64c6aa6dc2aa3034204f3c15ce5c96c03e63

--- a/Prelude/Location/Type.dhall
+++ b/Prelude/Location/Type.dhall
@@ -1,5 +1,4 @@
-{- This is the union type returned when you import something `as Location`
--}
+--| This is the union type returned when you import something `as Location`
 let Location
     : Type
     = < Environment : Text | Local : Text | Missing | Remote : Text >

--- a/Prelude/Map/Entry.dhall
+++ b/Prelude/Map/Entry.dhall
@@ -1,5 +1,4 @@
-{- The type of each key-value pair in a `Map`
--}
+--| The type of each key-value pair in a `Map`
 let Entry
     : Type → Type → Type
     = λ(k : Type) → λ(v : Type) → { mapKey : k, mapValue : v }

--- a/Prelude/Map/Type.dhall
+++ b/Prelude/Map/Type.dhall
@@ -1,21 +1,22 @@
-{- This is the canonical way to encode a dynamic list of key-value pairs.
+{-|
+This is the canonical way to encode a dynamic list of key-value pairs.
 
-   Tools (such as `dhall-to-json`/`dhall-to-yaml` will recognize values of this
-   type and convert them to maps/dictionaries/hashes in the target language
+Tools (such as `dhall-to-json`/`dhall-to-yaml` will recognize values of this
+type and convert them to maps/dictionaries/hashes in the target language
 
-   For example, `dhall-to-json` converts a Dhall value like this:
+For example, `dhall-to-json` converts a Dhall value like this:
 
-   ```
-   [ { mapKey = "foo", mapValue = 1 }
-   , { mapKey = "bar", mapValue = 2 }
-   ] : ./Map Text Natural
-   ```
+```
+[ { mapKey = "foo", mapValue = 1 }
+, { mapKey = "bar", mapValue = 2 }
+] : ./Map Text Natural
+```
 
-   ... to a JSON value like this:
+... to a JSON value like this:
 
-   ```
-   { "foo": 1, "bar", 2 }
-   ```
+```
+{ "foo": 1, "bar", 2 }
+```
 -}
 let Map
     : Type → Type → Type

--- a/Prelude/Map/empty.dhall
+++ b/Prelude/Map/empty.dhall
@@ -1,6 +1,4 @@
-{-
-An empty `Map` of the given key and value types
--}
+--| An empty `Map` of the given key and value types
 let Map =
         ./Type sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
       ? ./Type

--- a/Prelude/Map/keyText.dhall
+++ b/Prelude/Map/keyText.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Builds a key-value record such that a `List` of them will be converted to a
 homogeneous record by dhall-to-json and dhall-to-yaml.
 

--- a/Prelude/Map/keyValue.dhall
+++ b/Prelude/Map/keyValue.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Builds a key-value record such that a List of them will be converted to a
 homogeneous record by dhall-to-json and dhall-to-yaml.
 -}

--- a/Prelude/Map/keys.dhall
+++ b/Prelude/Map/keys.dhall
@@ -1,6 +1,4 @@
-{-
-Get all of the keys of a `Map` as a `List`
--}
+--| Get all of the keys of a `Map` as a `List`
 let Map =
         ./Type sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
       ? ./Type

--- a/Prelude/Map/map.dhall
+++ b/Prelude/Map/map.dhall
@@ -1,6 +1,4 @@
-{-
-Transform a `Map` by applying a function to each value
--}
+--| Transform a `Map` by applying a function to each value
 let Map =
         ./Type sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
       ? ./Type

--- a/Prelude/Map/values.dhall
+++ b/Prelude/Map/values.dhall
@@ -1,6 +1,4 @@
-{-
-Get all of the values of a `Map` as a `List`
--}
+--| Get all of the values of a `Map` as a `List`
 let Map =
         ./Type sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
       ? ./Type

--- a/Prelude/Monoid.dhall
+++ b/Prelude/Monoid.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Any function `f` that is a `Monoid` must satisfy the following law:
 
 ```

--- a/Prelude/Natural/build.dhall
+++ b/Prelude/Natural/build.dhall
@@ -1,6 +1,4 @@
-{-
-`build` is the inverse of `fold`
--}
+--| `build` is the inverse of `fold`
 let build
     : ( ∀(natural : Type) →
         ∀(succ : natural → natural) →

--- a/Prelude/Natural/enumerate.dhall
+++ b/Prelude/Natural/enumerate.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Generate a list of numbers from `0` up to but not including the specified
 number
 -}

--- a/Prelude/Natural/equal.dhall
+++ b/Prelude/Natural/equal.dhall
@@ -1,6 +1,4 @@
-{-
-`equal` checks if two Naturals are equal.
--}
+--| `equal` checks if two Naturals are equal.
 let lessThanEqual =
         ./lessThanEqual sha256:1a5caa2b80a42b9f58fff58e47ac0d9a9946d0b2d36c54034b8ddfe3cb0f3c99
       ? ./lessThanEqual

--- a/Prelude/Natural/even.dhall
+++ b/Prelude/Natural/even.dhall
@@ -1,6 +1,4 @@
-{-
-Returns `True` if a number if even and returns `False` otherwise
--}
+--| Returns `True` if a number if even and returns `False` otherwise
 let even
     : Natural → Bool
     = Natural/even

--- a/Prelude/Natural/fold.dhall
+++ b/Prelude/Natural/fold.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `fold` is the primitive function for consuming `Natural` numbers
 
 If you treat the number `3` as `succ (succ (succ zero))` then a `fold` just

--- a/Prelude/Natural/greaterThan.dhall
+++ b/Prelude/Natural/greaterThan.dhall
@@ -1,6 +1,4 @@
-{-
-`greaterThan` checks if one Natural is strictly greater than another.
--}
+--| `greaterThan` checks if one Natural is strictly greater than another.
 let lessThan =
         ./lessThan sha256:3381b66749290769badf8855d8a3f4af62e8de52d1364d838a9d1e20c94fa70c
       ? ./lessThan

--- a/Prelude/Natural/greaterThanEqual.dhall
+++ b/Prelude/Natural/greaterThanEqual.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `greaterThanEqual` checks if one Natural is greater than or equal to another.
 -}
 let lessThanEqual =

--- a/Prelude/Natural/isZero.dhall
+++ b/Prelude/Natural/isZero.dhall
@@ -1,6 +1,4 @@
-{-
-Returns `True` if a number is `0` and returns `False` otherwise
--}
+--| Returns `True` if a number is `0` and returns `False` otherwise
 let isZero
     : Natural → Bool
     = Natural/isZero

--- a/Prelude/Natural/lessThan.dhall
+++ b/Prelude/Natural/lessThan.dhall
@@ -1,6 +1,4 @@
-{-
-`lessThan` checks if one Natural is strictly less than another.
--}
+--| `lessThan` checks if one Natural is strictly less than another.
 let greaterThanEqual =
         ./greaterThanEqual sha256:30ebfab0febd7aa0ccccfdf3dc36ee6d50f0117f35dd4a9b034750b7e885a1a4
       ? ./greaterThanEqual

--- a/Prelude/Natural/lessThanEqual.dhall
+++ b/Prelude/Natural/lessThanEqual.dhall
@@ -1,6 +1,4 @@
-{-
-`lessThanEqual` checks if one Natural is less than or equal to another.
--}
+--| `lessThanEqual` checks if one Natural is less than or equal to another.
 let lessThanEqual
     : Natural → Natural → Bool
     = λ(x : Natural) → λ(y : Natural) → Natural/isZero (Natural/subtract y x)

--- a/Prelude/Natural/listMax.dhall
+++ b/Prelude/Natural/listMax.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `listMax` returns the largest element of a `List` or `None Natural` if the
 `List` is empty
 -}

--- a/Prelude/Natural/listMin.dhall
+++ b/Prelude/Natural/listMin.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 `listMin` returns the smallest element of a `List` or `None Natural` if the
 `List` is empty
 -}

--- a/Prelude/Natural/max.dhall
+++ b/Prelude/Natural/max.dhall
@@ -1,6 +1,4 @@
-{-
-`max a b` returns the larger of `a` or `b`
--}
+--| `max a b` returns the larger of `a` or `b`
 let lessThanEqual =
         ./lessThanEqual sha256:1a5caa2b80a42b9f58fff58e47ac0d9a9946d0b2d36c54034b8ddfe3cb0f3c99
       ? ./lessThanEqual

--- a/Prelude/Natural/min.dhall
+++ b/Prelude/Natural/min.dhall
@@ -1,6 +1,4 @@
-{-
-`min a b` returns the smaller of `a` or `b`
--}
+--| `min a b` returns the smaller of `a` or `b`
 let lessThanEqual =
         ./lessThanEqual sha256:1a5caa2b80a42b9f58fff58e47ac0d9a9946d0b2d36c54034b8ddfe3cb0f3c99
       ? ./lessThanEqual

--- a/Prelude/Natural/odd.dhall
+++ b/Prelude/Natural/odd.dhall
@@ -1,6 +1,4 @@
-{-
-Returns `True` if a number is odd and returns `False` otherwise
--}
+--| Returns `True` if a number is odd and returns `False` otherwise
 let odd
     : Natural → Bool
     = Natural/odd

--- a/Prelude/Natural/product.dhall
+++ b/Prelude/Natural/product.dhall
@@ -1,6 +1,4 @@
-{-
-Multiply all the numbers in a `List`
--}
+--| Multiply all the numbers in a `List`
 let product
     : List Natural → Natural
     = λ(xs : List Natural) →

--- a/Prelude/Natural/show.dhall
+++ b/Prelude/Natural/show.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Render a `Natural` number as `Text` using the same representation as Dhall
 source code (i.e. a decimal number)
 -}

--- a/Prelude/Natural/sort.dhall
+++ b/Prelude/Natural/sort.dhall
@@ -1,6 +1,4 @@
-{-
-`sort` sorts a `List` of `Natural`s in ascending order
--}
+--| `sort` sorts a `List` of `Natural`s in ascending order
 let greaterThanEqual =
         ./greaterThanEqual sha256:30ebfab0febd7aa0ccccfdf3dc36ee6d50f0117f35dd4a9b034750b7e885a1a4
       ? ./greaterThanEqual

--- a/Prelude/Natural/subtract.dhall
+++ b/Prelude/Natural/subtract.dhall
@@ -1,6 +1,4 @@
-{-
-`subtract m n` computes `n - m`, truncating to `0` if `m > n`
--}
+--| `subtract m n` computes `n - m`, truncating to `0` if `m > n`
 let subtract
     : Natural → Natural → Natural
     = Natural/subtract

--- a/Prelude/Natural/sum.dhall
+++ b/Prelude/Natural/sum.dhall
@@ -1,6 +1,4 @@
-{-
-Add all the numbers in a `List`
--}
+--| Add all the numbers in a `List`
 let sum
     : List Natural → Natural
     = λ(xs : List Natural) →

--- a/Prelude/Natural/toDouble.dhall
+++ b/Prelude/Natural/toDouble.dhall
@@ -1,6 +1,4 @@
-{-
-Convert a `Natural` number to the corresponding `Double`
--}
+--| Convert a `Natural` number to the corresponding `Double`
 let toDouble
     : Natural → Double
     = λ(n : Natural) → Integer/toDouble (Natural/toInteger n)

--- a/Prelude/Natural/toInteger.dhall
+++ b/Prelude/Natural/toInteger.dhall
@@ -1,6 +1,4 @@
-{-
-Convert a `Natural` number to the corresponding `Integer`
--}
+--| Convert a `Natural` number to the corresponding `Integer`
 let toInteger
     : Natural → Integer
     = Natural/toInteger

--- a/Prelude/Optional/all.dhall
+++ b/Prelude/Optional/all.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `False` if the supplied function returns `False` for a present element
 and `True` otherwise:
 -}

--- a/Prelude/Optional/any.dhall
+++ b/Prelude/Optional/any.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `True` if the supplied function returns `True` for a present element and
 `False` otherwise
 -}

--- a/Prelude/Optional/build.dhall
+++ b/Prelude/Optional/build.dhall
@@ -1,6 +1,4 @@
-{-
-`build` is the inverse of `fold`
--}
+--| `build` is the inverse of `fold`
 let build
     : ∀(a : Type) →
       ( ∀(optional : Type) →

--- a/Prelude/Optional/concat.dhall
+++ b/Prelude/Optional/concat.dhall
@@ -1,6 +1,4 @@
-{-
-Flatten two `Optional` layers into a single `Optional` layer
--}
+--| Flatten two `Optional` layers into a single `Optional` layer
 let concat
     : ∀(a : Type) → Optional (Optional a) → Optional a
     = λ(a : Type) →

--- a/Prelude/Optional/default.dhall
+++ b/Prelude/Optional/default.dhall
@@ -1,6 +1,4 @@
-{-
-Unpack an `Optional`, returning the default when it's `None`.
--}
+--| Unpack an `Optional`, returning the default when it's `None`.
 let default
     : ∀(a : Type) → a → Optional a → a
     = λ(a : Type) →

--- a/Prelude/Optional/filter.dhall
+++ b/Prelude/Optional/filter.dhall
@@ -1,6 +1,4 @@
-{-
-Only keep an `Optional` element if the supplied function returns `True`
--}
+--| Only keep an `Optional` element if the supplied function returns `True`
 let filter
     : ∀(a : Type) → (a → Bool) → Optional a → Optional a
     = λ(a : Type) →

--- a/Prelude/Optional/fold.dhall
+++ b/Prelude/Optional/fold.dhall
@@ -1,6 +1,4 @@
-{-
-`fold` is the primitive function for consuming `Optional` values
--}
+--| `fold` is the primitive function for consuming `Optional` values
 let fold
     : ∀(a : Type) →
       Optional a →

--- a/Prelude/Optional/head.dhall
+++ b/Prelude/Optional/head.dhall
@@ -1,6 +1,4 @@
-{-
-Returns the first non-empty `Optional` value in a `List`
--}
+--| Returns the first non-empty `Optional` value in a `List`
 let head
     : ∀(a : Type) → List (Optional a) → Optional a
     = λ(a : Type) →

--- a/Prelude/Optional/last.dhall
+++ b/Prelude/Optional/last.dhall
@@ -1,6 +1,4 @@
-{-
-Returns the last non-empty `Optional` value in a `List`
--}
+--| Returns the last non-empty `Optional` value in a `List`
 let last
     : ∀(a : Type) → List (Optional a) → Optional a
     = λ(a : Type) →

--- a/Prelude/Optional/length.dhall
+++ b/Prelude/Optional/length.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Returns `1` if the `Optional` value is present and `0` if the value is absent
 -}
 let length

--- a/Prelude/Optional/map.dhall
+++ b/Prelude/Optional/map.dhall
@@ -1,6 +1,4 @@
-{-
-Transform an `Optional` value with a function
--}
+--| Transform an `Optional` value with a function
 let map
     : ∀(a : Type) → ∀(b : Type) → (a → b) → Optional a → Optional b
     = λ(a : Type) →

--- a/Prelude/Optional/null.dhall
+++ b/Prelude/Optional/null.dhall
@@ -1,6 +1,4 @@
-{-
-Returns `True` if the `Optional` value is absent and `False` if present
--}
+--| Returns `True` if the `Optional` value is absent and `False` if present
 let null
     : ∀(a : Type) → Optional a → Bool
     = λ(a : Type) →

--- a/Prelude/Optional/toList.dhall
+++ b/Prelude/Optional/toList.dhall
@@ -1,6 +1,4 @@
-{-
-Convert an `Optional` value into the equivalent `List`
--}
+--| Convert an `Optional` value into the equivalent `List`
 let toList
     : ∀(a : Type) → Optional a → List a
     = λ(a : Type) →

--- a/Prelude/Optional/unzip.dhall
+++ b/Prelude/Optional/unzip.dhall
@@ -1,6 +1,4 @@
-{-
-Unzip an `Optional` value into two separate `Optional` values
--}
+--| Unzip an `Optional` value into two separate `Optional` values
 let unzip
     : ∀(a : Type) →
       ∀(b : Type) →

--- a/Prelude/Text/concat.dhall
+++ b/Prelude/Text/concat.dhall
@@ -1,6 +1,4 @@
-{-
-Concatenate all the `Text` values in a `List`
--}
+--| Concatenate all the `Text` values in a `List`
 let concat
     : List Text → Text
     = λ(xs : List Text) →

--- a/Prelude/Text/concatMap.dhall
+++ b/Prelude/Text/concatMap.dhall
@@ -1,6 +1,4 @@
-{-
-Transform each value in a `List` into `Text` and concatenate the result
--}
+--| Transform each value in a `List` into `Text` and concatenate the result
 let concatMap
     : ∀(a : Type) → (a → Text) → List a → Text
     = λ(a : Type) →

--- a/Prelude/Text/concatMapSep.dhall
+++ b/Prelude/Text/concatMapSep.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Transform each value in a `List` to `Text` and then concatenate them with a
 separator in between each value
 -}

--- a/Prelude/Text/concatSep.dhall
+++ b/Prelude/Text/concatSep.dhall
@@ -1,6 +1,4 @@
-{-
-Concatenate a `List` of `Text` values with a separator in between each value
--}
+--| Concatenate a `List` of `Text` values with a separator in between each value
 let Status = < Empty | NonEmpty : Text >
 
 let concatSep

--- a/Prelude/Text/default.dhall
+++ b/Prelude/Text/default.dhall
@@ -1,6 +1,4 @@
-{-
-Unwrap an `Optional` `Text` value, defaulting `None` to `""`
--}
+--| Unwrap an `Optional` `Text` value, defaulting `None` to `""`
 let default
     : Optional Text → Text
     = λ(o : Optional Text) → merge { Some = λ(t : Text) → t, None = "" } o

--- a/Prelude/Text/defaultMap.dhall
+++ b/Prelude/Text/defaultMap.dhall
@@ -1,6 +1,4 @@
-{-
-Transform the value in an `Optional` into `Text`, defaulting `None` to `""`
--}
+--| Transform the value in an `Optional` into `Text`, defaulting `None` to `""`
 let defaultMap
     : ∀(a : Type) → (a → Text) → Optional a → Text
     = λ(a : Type) →

--- a/Prelude/Text/replicate.dhall
+++ b/Prelude/Text/replicate.dhall
@@ -1,6 +1,4 @@
-{-
-Build a Text by copying the given Text the specified number of times
--}
+--| Build a Text by copying the given Text the specified number of times
 
 let concat =
         ./concat sha256:731265b0288e8a905ecff95c97333ee2db614c39d69f1514cb8eed9259745fc0

--- a/Prelude/Text/spaces.dhall
+++ b/Prelude/Text/spaces.dhall
@@ -1,8 +1,8 @@
-{-
+{-|
 Return a Text with the number of spaces specified.
 
-This function is particularly helpful when trying to generate Text where whitespace
-is significant, i.e. with nested indentation.
+This function is particularly helpful when trying to generate Text where
+whitespace is significant, i.e. with nested indentation.
 -}
 
 let replicate =

--- a/Prelude/XML/Type.dhall
+++ b/Prelude/XML/Type.dhall
@@ -1,12 +1,13 @@
-{- Dhall encoding of an arbitrary XML element
+{-|
+Dhall encoding of an arbitrary XML element
 
-   For example, the following XML element:
+For example, the following XML element:
 
 ```
 <foo n="1"><bar>baz</bar></foo>
 ```
 
-   ... corresponds to the following Dhall expression:
+... corresponds to the following Dhall expression:
 
 
 ```

--- a/Prelude/XML/attribute.dhall
+++ b/Prelude/XML/attribute.dhall
@@ -1,4 +1,4 @@
-{- Builds a key-value record with a Text key and value. -}
+--| Builds a key-value record with a Text key and value.
 
 let attribute
     : Text → Text → { mapKey : Text, mapValue : Text }

--- a/Prelude/XML/element.dhall
+++ b/Prelude/XML/element.dhall
@@ -1,4 +1,5 @@
-{- Create an XML element value.
+{-|
+Create an XML element value.
 
 ```
 let XML = ./package.dhall

--- a/Prelude/XML/emptyAttributes.dhall
+++ b/Prelude/XML/emptyAttributes.dhall
@@ -1,3 +1,3 @@
-{- Create an empty XML attribute List. -}
+--| Create an empty XML attribute List.
 
 [] : List { mapKey : Text, mapValue : Text }

--- a/Prelude/XML/leaf.dhall
+++ b/Prelude/XML/leaf.dhall
@@ -1,4 +1,5 @@
-{- Create an XML element value without child elements.
+{-|
+Create an XML element value without child elements.
 
 ```
 let XML = ./package.dhall

--- a/Prelude/XML/render.dhall
+++ b/Prelude/XML/render.dhall
@@ -1,11 +1,12 @@
-{- Render an `XML` value as `Text`
+{-|
+Render an `XML` value as `Text`
 
-   *WARNING:* rendering does not include any XML injection mitigations,
-   therefore it should not be used to process arbitrary strings into
-   element attributes or element data.
+*WARNING:* rendering does not include any XML injection mitigations,
+therefore it should not be used to process arbitrary strings into
+element attributes or element data.
 
-   For indentation and schema validation, see the `xmllint` utility
-   bundled with libxml2.
+For indentation and schema validation, see the `xmllint` utility
+bundled with libxml2.
 
 ```
 let XML = ./package.dhall

--- a/Prelude/XML/text.dhall
+++ b/Prelude/XML/text.dhall
@@ -1,4 +1,5 @@
-{- Create a Text value to be inserted into an XML element as content.
+{-|
+Create a Text value to be inserted into an XML element as content.
 
 ```
 let XML = ./package.dhall


### PR DESCRIPTION
... so that the comment headers are included in the generated documentation