### PR TITLE
docs/Language-Tour.md: Differentiate /\ and with

### DIFF
--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3266,8 +3266,8 @@ this:
 >
 > </details>
 
-> **Exercise:** Louis Reasoner claims that the `with` expression is unnecessary,
-> because he can use the `/\` operator to perform deep record updates. Is he right?
+> **Exercise:** Your colleague claims that the `with` expression is unnecessary,
+> because the `/\` operator can perform deep record updates. Is that right?
 >
 > <details>
 > <summary>Solution</summary>

--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3266,6 +3266,32 @@ this:
 >
 > </details>
 
+> **Exercise:** Louis Reasoner claims that the `with` expression is unnecessary,
+> because he can use the `/\` operator to perform deep record updates. Is he right?
+>
+> <details>
+> <summary>Solution</summary>
+>
+> No, because `/\` will not replace fields:
+>
+> ```dhall
+> ⊢ { a.b = 1 } /\ { a.b = 2 }
+>
+> Error: Field collision on: a.b
+>
+> 1│             /\ { a.b = 2 }
+> ```
+>
+> `with`, on the other hand, will:
+>
+> ```dhall
+> ⊢ { a.b = 1 } with a.b = 2
+>
+> { a.b = 2 }
+> ```
+>
+> </details>
+   
 ## Record completion
 
 The language includes one last record operator useful for working with large


### PR DESCRIPTION
It wasn't clear to me why we needed `with` when we already had `/\`, and when I worked it out I thought I'd add an example.