### PR TITLE
Language Tour: change // description from type merge to value merge

### DIFF
--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3145,7 +3145,7 @@ record types:
   This operator recursively merges two records, but fails with a type error if
   any two non-record fields "collide".
 
-* `//` - Shallow right-biased record type merge - Unicode: `⫽` (U+2AFD)
+* `//` - Shallow right-biased record value merge - Unicode: `⫽` (U+2AFD)
 
   ```dhall
   ⊢ { a = { b = 1 } } // { a = 1, d = True }


### PR DESCRIPTION
I believe `//` is a value level merge?

Assuming that is correct, a followup question: how difficult would it be to add a type level operator that does the same thing? Maybe this is already possible in another way I couldn't figure out? That along with another operator to select a subset of record fields to create a new record type from an existing one I feel like would be nice.

Thanks for the great project!