### PR TITLE
Remove names from Text/replace's type in type inference rules

### DIFF
--- a/standard/type-inference.md
+++ b/standard/type-inference.md
@@ -279,7 +279,7 @@ The `Text/replace` function has the following type:
 
 
     ───────────────────────────────────────────────────────────────────────────────────────
-    Γ ⊢ Text/replace : ∀(needle : Text) → ∀(replacement : Text) → ∀(haystack : Text) → Text
+    Γ ⊢ Text/replace : Text → Text → Text → Text
 
 
 The `Text` concatenation operator takes arguments of type `Text` and returns a

--- a/tests/type-inference/success/unit/TextReplaceB.dhall
+++ b/tests/type-inference/success/unit/TextReplaceB.dhall
@@ -1,1 +1,1 @@
-∀(needle : Text) → ∀(replacement : Text) → ∀(haystack : Text) → Text
+Text → Text → Text → Text


### PR DESCRIPTION
This PR is really more of a question, since I'm not clear on whether there's a principled way to decide when function type parameters should be given names in the type inference rules.

I was just updating Dhall for Java to 19.0.0 and noticed that the type inference rule for the new `Text/replace` builtin seems to be inconsistent with e.g. `Text/show`, which uses the shorthand `Text → Text` instead of naming the parameters.

```
Γ ⊢ Text/replace : ∀(needle : Text) → ∀(replacement : Text) → ∀(haystack : Text) → Text
```

For the most part the type inference rules in the standard only name parameters in function types when they're types that are referred to later in the rule. For example:

```
Γ ⊢ List/head : ∀(a : Type) → List a → Optional a
```

There are exceptions, though, like `List/build` and `List/fold`, where some (but not all) non-`Type` parameters are named:

```
Γ ⊢ List/fold : ∀(a : Type) → List a → ∀(list : Type) → ∀(cons : a → list → list) → ∀(nil : list) → list
```

In some cases there are type signatures that include the same parameter types multiple times without giving them names (e.g. `Natural/subtract`), while in others (like `List/fold` here) there are unique parameter types that _are_ given names. 

I think there are at least a couple of possible choices here:

* Names are used when needed for clarity (in some more or less hand-wavy sense). In this case we can leave the rules unchanged and maybe just note that this is the principle being applied.
* Names are only used when needed elsewhere in the rule. In this case we'd probably also want to un-name the named non-`Type` parameters in `List/build`, `List/fold`, etc.

I don't really have a strong opinion here, just wanted to flag the possible inconsistency.