### PR TITLE
Normalize Text/replace for empty needle, abstact replacement/haystack

### DIFF
--- a/standard/beta-normalization.md
+++ b/standard/beta-normalization.md
@@ -670,9 +670,9 @@ In the case that the substring to replace is empty (`""`), then no replacement
 is performed:
 
 
-    f ⇥ Text/replace "" replacement   a ⇥ "foo"   ; No replacement performed if
-    ────────────────────────────────────────────  ; the search string is empty,
-    f a ⇥ "foo"                                   ; to avoid an infinite loop.
+    f ⇥ Text/replace "" replacement   a₀ ⇥ a₁  ; No replacement performed if
+    ─────────────────────────────────────────  ; the search string is empty,
+    f a₀ ⇥ a₁                                  ; to avoid an infinite loop.
 
 
     f ⇥ Text/replace "NEEDLE" replacement  ; If the "NEEDLE" is not found within

--- a/tests/normalization/success/unit/TextReplaceEmptyA.dhall
+++ b/tests/normalization/success/unit/TextReplaceEmptyA.dhall
@@ -1,1 +1,3 @@
-Text/replace "" "bar" "foo"
+λ(replacement : Text) →
+λ(haystack : Text) →
+  Text/replace "" replacement haystack

--- a/tests/normalization/success/unit/TextReplaceEmptyB.dhall
+++ b/tests/normalization/success/unit/TextReplaceEmptyB.dhall
@@ -1,1 +1,1 @@
-"foo"
+λ(replacement : Text) → λ(haystack : text) → haystack

--- a/tests/normalization/success/unit/TextReplaceEmptyB.dhall
+++ b/tests/normalization/success/unit/TextReplaceEmptyB.dhall
@@ -1,1 +1,1 @@
-λ(replacement : Text) → λ(haystack : text) → haystack
+λ(replacement : Text) → λ(haystack : Text) → haystack


### PR DESCRIPTION
If the needle is empty, we don't care about the specific content of
the replacement or haystack at all, so they can be abstract.