### PR TITLE
Fix typo in re-escaping rule of multiline strings

### DIFF
--- a/standard/multiline.md
+++ b/standard/multiline.md
@@ -52,7 +52,7 @@ that need to be escaped for double-quoted literals:
 
     re-escape("ss₀…") = "ss₁…"
     ──────────────────────────────  ; c₀ ∈ { ", $, \ }
-    re-escape("c₀ss₀…") = "c₀ss₁…"
+    re-escape("c₀ss₀…") = "\c₀ss₁…"
 
 
 For all other characters, re-escape leaves them unmodified:


### PR DESCRIPTION
There seems to be a typo in the rule for the re-escaping of characters `\`, `$` and `"`. I think the rule lacks the addition of a leading backslash to escape the given character, because currently it just preserves the original character at it is, and is exactly the same as the following rule for non-special characters.