### PR TITLE
Use Text/replace to implement XML escaping

### DIFF
--- a/Prelude/XML/package.dhall
+++ b/Prelude/XML/package.dhall
@@ -5,7 +5,7 @@
       ./attribute.dhall sha256:f7b6c802ca5764d03d5e9a6e48d9cb167c01392f775d9c2c87b83cdaa60ea0cc
     ? ./attribute.dhall
 , render =
-      ./render.dhall sha256:8d034f7f97cded14a96147565d489be840e5678480d175b962b2600d85a3230e
+      ./render.dhall sha256:aff7efe61ce299381edca023e24bb5aaa0656c41bfa45dd705dab63519b7c5db
     ? ./render.dhall
 , element =
       ./element.dhall sha256:e0b948053c8cd8ccca9c39244d89e3f42db43d222531c18151551dfc75208b4b

--- a/Prelude/XML/render
+++ b/Prelude/XML/render
@@ -1,2 +1,2 @@
-  ./render.dhall sha256:8d034f7f97cded14a96147565d489be840e5678480d175b962b2600d85a3230e
+  ./render.dhall sha256:aff7efe61ce299381edca023e24bb5aaa0656c41bfa45dd705dab63519b7c5db
 ? ./render.dhall

--- a/Prelude/XML/render.dhall
+++ b/Prelude/XML/render.dhall
@@ -34,16 +34,38 @@ let Text/concat =
         ../Text/concat.dhall sha256:731265b0288e8a905ecff95c97333ee2db614c39d69f1514cb8eed9259745fc0
       ? ../Text/concat.dhall
 
+let element =
+        ./element.dhall sha256:e0b948053c8cd8ccca9c39244d89e3f42db43d222531c18151551dfc75208b4b
+      ? ./element.dhall
+
+let text =
+        ./text.dhall sha256:c83cd721d32d7dc28c04ce429c0cb22812639e572637ec348578a58ffb68844f
+      ? ./text.dhall
+
+let emptyAttributes =
+        ./emptyAttributes.dhall sha256:11b86e2d3f3c75d47a1d580213d2a03fd2c36d64f3e9b6381de0ba23472f64d5
+      ? ./emptyAttributes.dhall
+
 let Attr = { mapKey : Text, mapValue : Text }
 
-let renderAttr = λ(x : Attr) → " ${x.mapKey}=\"${x.mapValue}\""
+let `escape"` = Text/replace "\"" "\\\""
+
+let `escape<` = Text/replace "<" "\\<"
+
+let `escape&` = Text/replace "&" "\\&"
+
+let escapeText = λ(text : Text) → `escape<` (`escape&` text)
+
+let escapeAttr = λ(text : Text) → `escape"` (`escape<` (`escape&` text))
+
+let renderAttr = λ(x : Attr) → " ${x.mapKey}=\"${escapeAttr x.mapValue}\""
 
 let render
     : XML → Text
     = λ(x : XML) →
         x
           Text
-          { text = λ(d : Text) → d
+          { text = escapeText
           , element =
               λ ( elem
                 : { attributes : List { mapKey : Text, mapValue : Text }
@@ -59,5 +81,51 @@ let render
                           else  ">${Text/concat elem.content}</${elem.name}>"
                         )
           }
+
+let simple =
+      λ(name : Text) →
+      λ(content : List XML) →
+        element { name, attributes = emptyAttributes, content }
+
+let example0 =
+        assert
+      :   render
+            ( simple
+                "note"
+                [ simple "to" [ text "Tove" ]
+                , simple "from" [ text "Jani" ]
+                , simple "heading" [ text "Reminder" ]
+                , simple "body" [ text "Don't forget me this weekend!" ]
+                ]
+            )
+        ≡ Text/replace
+            "\n"
+            ""
+            ''
+            <note>
+            <to>Tove</to>
+            <from>Jani</from>
+            <heading>Reminder</heading>
+            <body>Don't forget me this weekend!</body>
+            </note>
+            ''
+
+let example1 =
+        assert
+      :   render
+            ( element
+                { name = "escape"
+                , attributes = toMap { attribute = "<>'\"&" }
+                , content = [ text "<>'\"&" ]
+                }
+            )
+        ≡ Text/replace
+            "\n"
+            ""
+            ''
+            <escape attribute="\<>'\"\&">
+            \<>'"\&
+            </escape>
+            ''
 
 in  render

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -38,6 +38,6 @@
       ./Text/package.dhall sha256:46c53957c10bd4c332a5716d6e06068cd24ae1392ca171e6da31e30b9b33c07c
     ? ./Text/package.dhall
 , XML =
-      ./XML/package.dhall sha256:137e7b106b2e9743970e5d37b21a165f2e40f56ab593a4dd10605c9acd686fc6
+      ./XML/package.dhall sha256:8f57bda3087cbb34568d58e5dd5ee6860a50576caf48ebe49a5fc60b9af9a1fa
     ? ./XML/package.dhall
 }


### PR DESCRIPTION
Now we properly sanitize attributes and text by escaping special
characters