### PR TITLE
Fix Hydra builds

### DIFF
--- a/nixops/README.md
+++ b/nixops/README.md
@@ -219,13 +219,6 @@ somehow need to recreate everything from scratch:
     $ echo "${TOKEN}" > /etc/hydra/authorization/dhall-lang
     ```
 
-*   Update NixOS configuration to match the SSH public key for `dhall-lang.org`
-
-    Note that this configuration change needs to be merged into `master` by
-    creating a pull request to modify the following option:
-
-    * [`programs.ssh.knownHosts`](https://github.com/dhall-lang/dhall-lang/blob/b20476014e508be2218adbafa656996d0fd217bc/nixops/logical.nix#L106-L109)
-
 *   Create an administrative user for `hydra`:
 
     ```bash

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -48,7 +48,7 @@ in
           "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
           "hydra/machines".text = ''
-            hydra-queue-runner@dhall-lang.org x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local,big-parallel
+            localhost x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local,big-parallel
           '';
         };
   };

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -48,7 +48,7 @@ in
           "hydra/jobsets.nix".text = builtins.readFile ./jobsets.nix;
 
           "hydra/machines".text = ''
-            localhost x86_64-linux,builtin /etc/keys/hydra-queue-runner/hydra-queue-runner_rsa 4 1 local,big-parallel
+            localhost x86_64-linux,builtin - 4 1 local,big-parallel
           '';
         };
   };
@@ -117,13 +117,8 @@ in
     in
       [ modifyHydra ];
 
-  programs.ssh.knownHosts = {
-    "github.com".publicKey =
+  programs.ssh.knownHosts."github.com".publicKey =
       "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==";
-
-    "dhall-lang.org".publicKey =
-      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBp/WR0q2LUjpzHDwm03CijnpUyvHS9CDnJYvR0YNBpT";
-  };
 
   security = {
     acme = {
@@ -513,44 +508,6 @@ in
 
           wants = [ "docker.service" ];
         };
-
-    generate-hydra-queue-runner-key-pair = {
-      script =
-        let
-          keyDirectory = "/etc/keys/hydra-queue-runner";
-
-          user = "hydra-queue-runner";
-
-          group = "hydra";
-
-          privateKey = "${keyDirectory}/${user}_rsa";
-
-          publicKey = "${privateKey}.pub";
-
-          authorizedKeysDirectory = "/etc/ssh/authorized_keys.d";
-
-          authorizedKeysFile = "${authorizedKeysDirectory}/${user}";
-        in
-          ''
-            if ! [ -e ${privateKey} ] || ! [ -e ${publicKey} ]; then
-              mkdir -p ${keyDirectory}
-
-              ${pkgs.openssh}/bin/ssh-keygen -t rsa -N "" -f ${privateKey} -C "${user}@hydra" >/dev/null
-
-              chown -R ${user}:${group} ${keyDirectory}
-            fi
-
-            if ! [ -e ${authorizedKeysFile} ]; then
-              mkdir -p "${authorizedKeysDirectory}"
-
-              cp ${publicKey} ${authorizedKeysFile}
-            fi
-          '';
-
-      serviceConfig.Type = "oneshot";
-
-      wantedBy = [ "multi-user.target" ];
-    };
 
     kick-hydra-evaluator = {
       script = ''


### PR DESCRIPTION
Hydra started to get stuck after being upgraded in #1114.  Specifically,
builds would get stuck on the "Receiving outputs" step.

The reason this was happening was because of how we were instructing
Hydra to build things on the local machine.  The correct way to do this
is to specify `localhost`, because Hydra has special logic to handle
that.  If you specify the current machine by any other hostname then
Hydra will treat it as if it is a remote machine and then get stuck
attempting to take the same lock twice (once for its own store and once
for the "remote" machine's store, which happens to be the same store).