### PR TITLE
Improve `Prelude.JSON.render` output

### DIFF
--- a/Prelude/JSON/package.dhall
+++ b/Prelude/JSON/package.dhall
@@ -1,11 +1,11 @@
   { render =
-        ./render.dhall sha256:b5e5aee66b8fc018b50e1019a76340deafe5f8176854ea3611476d79990785da
+        ./render.dhall sha256:36befdd8bb5a1c2b372709da245a8d074533b86429e137b894c08ad16fa34836
       ? ./render.dhall
   , renderCompact =
         ./renderCompact.dhall sha256:e6c8809fbe193fddd430f94350d69cefd45e7aaf8bd379e51b750fde75008562
       ? ./renderCompact.dhall
   , renderYAML =
-        ./renderYAML.dhall sha256:dad92a120956ae852be7496d1e1955bbf3f60834ab2ad32641269098f2846477
+        ./renderYAML.dhall sha256:bc71449397bbf48103c3ebbdd570cd27313115e94b2b1b96761d257d5c02d478
       ? ./renderYAML.dhall
   , omitNullFields =
         ./omitNullFields.dhall sha256:e6850e70094540b75edeb46f4d6038324a62def8d63544a1e9541f79739db6f0

--- a/Prelude/JSON/render
+++ b/Prelude/JSON/render
@@ -1,2 +1,2 @@
-  ./render.dhall sha256:b5e5aee66b8fc018b50e1019a76340deafe5f8176854ea3611476d79990785da
+  ./render.dhall sha256:36befdd8bb5a1c2b372709da245a8d074533b86429e137b894c08ad16fa34836
 ? ./render.dhall

--- a/Prelude/JSON/render.dhall
+++ b/Prelude/JSON/render.dhall
@@ -9,7 +9,7 @@ let JSON =
       ? ./core.dhall
 
 let renderAs =
-        ./renderAs.dhall sha256:5576473c02bc447d40d08bf103aaeca9637c1040367fdf07ff70032ba3e28043
+        ./renderAs.dhall sha256:c23be039c9601a33d6546fd99a8d72bee8dde5f46176d57cc96613b31a3bb471
       ? ./renderAs.dhall
 
 let Format =

--- a/Prelude/JSON/renderAs
+++ b/Prelude/JSON/renderAs
@@ -1,2 +1,2 @@
-  ./renderAs.dhall sha256:5576473c02bc447d40d08bf103aaeca9637c1040367fdf07ff70032ba3e28043
+  ./renderAs.dhall sha256:c23be039c9601a33d6546fd99a8d72bee8dde5f46176d57cc96613b31a3bb471
 ? ./renderAs.dhall

--- a/Prelude/JSON/renderYAML
+++ b/Prelude/JSON/renderYAML
@@ -1,2 +1,2 @@
-  ./renderYAML.dhall sha256:dad92a120956ae852be7496d1e1955bbf3f60834ab2ad32641269098f2846477
+  ./renderYAML.dhall sha256:bc71449397bbf48103c3ebbdd570cd27313115e94b2b1b96761d257d5c02d478
 ? ./renderYAML.dhall

--- a/Prelude/JSON/renderYAML.dhall
+++ b/Prelude/JSON/renderYAML.dhall
@@ -13,7 +13,7 @@ let JSON =
       ? ./core.dhall
 
 let renderAs =
-        ./renderAs.dhall sha256:5576473c02bc447d40d08bf103aaeca9637c1040367fdf07ff70032ba3e28043
+        ./renderAs.dhall sha256:c23be039c9601a33d6546fd99a8d72bee8dde5f46176d57cc96613b31a3bb471
       ? ./renderAs.dhall
 
 let Format =

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -32,7 +32,7 @@
       ./Optional/package.dhall sha256:37b84d6fe94c591d603d7b06527a2d3439ba83361e9326bc7b72517c7dc54d4e
     ? ./Optional/package.dhall
 , JSON =
-      ./JSON/package.dhall sha256:b7dfd33b1a313c0518c637c3b59da8526aa8020dbe125f347edbf895331dbeca
+      ./JSON/package.dhall sha256:5f98b7722fd13509ef448b075e02b9ff98312ae7a406cf53ed25012dbc9990ac
     ? ./JSON/package.dhall
 , Text =
       ./Text/package.dhall sha256:46c53957c10bd4c332a5716d6e06068cd24ae1392ca171e6da31e30b9b33c07c


### PR DESCRIPTION
Now that we have language support for `Text/replace` we don't need
to use `Text/show` any longer.  In particular, one of the limitations
of `Text/show` was that we were using it both to render valid Dhall
values and also to render valid JSON strings, which constrained it
to produce weird output for `$` (`\u0024`).  However, now that we
have `Text/replace` we can use a JSON-specific escaping strategy.

This also implies that we can make two further improvements (not
included in this pull request):

* We could standardize the behavior of `Text/show` in terms of
  `Text/replace`

  … or even remove `Text/show` as a built-in after deprecation.

* We can now improve the behavior of `Text/show` to escape `$` as
  `\$` instead of `\u0024`

  … now that it's no longer used for escaping JSON strings.