### PR TITLE
Remove `kick-hydra` service on dhall-lang.org

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -509,16 +509,6 @@ in
           wants = [ "docker.service" ];
         };
 
-    kick-hydra-evaluator = {
-      script = ''
-        ${pkgs.systemd}/bin/systemctl restart hydra-evaluator
-      '';
-
-      startAt = "*:0/5";
-
-      wantedBy = [ "multi-user.target" ];
-    };
-
     nix-serve-keys = {
       script = ''
         if [ ! -e ${nixServe.keyDirectory} ]; then


### PR DESCRIPTION
This was a workaround for an older version of `hydra` which appears to
no longer be necessary.