### PR TITLE
Prelude/CBOR

### DIFF
--- a/Prelude/CBOR/Type.dhall
+++ b/Prelude/CBOR/Type.dhall
@@ -1,4 +1,4 @@
-{-
+{-|
 Dhall encoding of an arbitrary CBOR value
 -}
 let CBOR/Type

--- a/Prelude/CBOR/Type.dhall
+++ b/Prelude/CBOR/Type.dhall
@@ -1,0 +1,22 @@
+{-
+Dhall encoding of an arbitrary CBOR value
+-}
+let CBOR/Type
+    : Type
+    = ∀(CBOR : Type) →
+      ∀ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        CBOR
+
+in  CBOR/Type

--- a/Prelude/CBOR/array.dhall
+++ b/Prelude/CBOR/array.dhall
@@ -1,0 +1,30 @@
+{-|
+Create a CBOR array item from a `List` of `CBOR` values
+
+See ./toArray.dhall for an example.
+-}
+let List/map = ../List/map.dhall
+
+let CBOR = ./Type.dhall
+
+let array
+    : List CBOR → CBOR
+    = λ(x : List CBOR) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.array
+          (List/map CBOR@1 CBOR (λ(cbor : CBOR@1) → cbor CBOR cbor@1) x)
+
+in  array

--- a/Prelude/CBOR/arrayOf.dhall
+++ b/Prelude/CBOR/arrayOf.dhall
@@ -10,11 +10,11 @@ let CBOR = ./Type.dhall
 
 let CBOR/array = ./array.dhall
 
-let toArray
+let arrayOf
     : ∀(a : Type) → (a → CBOR) → List a → CBOR
     = λ(a : Type) →
       λ(f : a → CBOR) →
       λ(xs : List a) →
         CBOR/array (List/map a CBOR f xs)
 
-in  toArray
+in  arrayOf

--- a/Prelude/CBOR/base64.dhall
+++ b/Prelude/CBOR/base64.dhall
@@ -4,10 +4,14 @@ Create a tagged CBOR item from a base64 `Text` value
 A Dhall to CBOR encoder should decode the text into a CBOR byte string,
 see RFC7049 section 2.4.4.2 and 2.4.4.3 for more information.
 -}
+let CBOR = ./Type.dhall
+
 let tag = ./tag.dhall
 
 let text = ./text.dhall
 
-let base64 = λ(b64 : Text) → tag 34 (text b64)
+let base64
+    : Text → CBOR
+    = λ(b64 : Text) → tag 34 (text b64)
 
 in  base64

--- a/Prelude/CBOR/base64.dhall
+++ b/Prelude/CBOR/base64.dhall
@@ -1,0 +1,13 @@
+{-|
+Create a tagged CBOR item from a base64 `Text` value
+
+A Dhall to CBOR encoder should decode the text into a CBOR byte string,
+see RFC7049 section 2.4.4.2 and 2.4.4.3 for more information.
+-}
+let tag = ./tag.dhall
+
+let text = ./text.dhall
+
+let base64 = λ(b64 : Text) → tag 34 (text b64)
+
+in  base64

--- a/Prelude/CBOR/base64url.dhall
+++ b/Prelude/CBOR/base64url.dhall
@@ -1,0 +1,13 @@
+{-|
+Create a tagged CBOR item from a base64url `Text` value
+
+A Dhall to CBOR encoder should decode the text into a CBOR byte string,
+see RFC7049 section 2.4.4.2 and 2.4.4.3 for more information.
+-}
+let tag = ./tag.dhall
+
+let text = ./text.dhall
+
+let base64url = λ(b64u : Text) → tag 33 (text b64u)
+
+in  base64url

--- a/Prelude/CBOR/base64url.dhall
+++ b/Prelude/CBOR/base64url.dhall
@@ -4,10 +4,14 @@ Create a tagged CBOR item from a base64url `Text` value
 A Dhall to CBOR encoder should decode the text into a CBOR byte string,
 see RFC7049 section 2.4.4.2 and 2.4.4.3 for more information.
 -}
+let CBOR = ./Type.dhall
+
 let tag = ./tag.dhall
 
 let text = ./text.dhall
 
-let base64url = λ(b64u : Text) → tag 33 (text b64u)
+let base64url
+    : Text → CBOR
+    = λ(b64u : Text) → tag 33 (text b64u)
 
 in  base64url

--- a/Prelude/CBOR/bool.dhall
+++ b/Prelude/CBOR/bool.dhall
@@ -1,0 +1,25 @@
+{-|
+Create a CBOR boolean item from a `Bool` value
+-}
+let CBOR/Type = ./Type.dhall
+
+let bool
+    : Bool → CBOR/Type
+    = λ(x : Bool) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.bool x
+
+in  bool

--- a/Prelude/CBOR/bool.dhall
+++ b/Prelude/CBOR/bool.dhall
@@ -1,10 +1,10 @@
 {-|
 Create a CBOR boolean item from a `Bool` value
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let bool
-    : Bool → CBOR/Type
+    : Bool → CBOR
     = λ(x : Bool) →
       λ(CBOR : Type) →
       λ ( cbor

--- a/Prelude/CBOR/data.dhall
+++ b/Prelude/CBOR/data.dhall
@@ -1,0 +1,9 @@
+{-|
+Create a CBOR item that incapsulates CBOR data
+
+A Dhall to CBOR encoder should convert the inner item to a byte string
+and tag it as enclosed CBOR data. This is for the benefit of a decoding
+process that is not concerned with the semantics of the inner data.
+See RFC7049 section 2.4.4.1 for more information.
+-}
+let tag = ./tag.dhall let data = tag 24 in data

--- a/Prelude/CBOR/data.dhall
+++ b/Prelude/CBOR/data.dhall
@@ -6,4 +6,12 @@ and tag it as enclosed CBOR data. This is for the benefit of a decoding
 process that is not concerned with the semantics of the inner data.
 See RFC7049 section 2.4.4.1 for more information.
 -}
-let tag = ./tag.dhall let data = tag 24 in data
+let CBOR = ./Type.dhall
+
+let tag = ./tag.dhall
+
+let data
+    : CBOR → CBOR
+    = tag 24
+
+in  data

--- a/Prelude/CBOR/diagnostic.dhall
+++ b/Prelude/CBOR/diagnostic.dhall
@@ -1,0 +1,71 @@
+{-|
+Render a `CBOR` value to a diagnostic `Text` value
+
+The diagnostic format is not formally defined and should not be parsed.
+-}
+let CBOR/Type = ./Type.dhall
+
+let Map/Type = ../Map/Type.dhall
+
+let Text/concatSep = ../Text/concatSep.dhall
+
+let Text/concatMapSep = ../Text/concatMapSep.dhall
+
+let renderDiag
+    : CBOR/Type → Text
+    = λ(cbor : CBOR/Type) →
+        cbor
+          Text
+          { array = λ(xs : List Text) → "[ " ++ Text/concatSep ", " xs ++ " ]"
+          , bool = λ(x : Bool) → if x then "true" else "false"
+          , double = Double/show
+          , integer = Integer/show
+          , map =
+              λ(m : Map/Type Text Text) →
+                    "{ "
+                ++  Text/concatMapSep
+                      ", "
+                      { mapKey : Text, mapValue : Text }
+                      ( λ(e : { mapKey : Text, mapValue : Text }) →
+                          "${e.mapKey}: ${e.mapValue}"
+                      )
+                      m
+                ++  " }"
+          , null = "null"
+          , simple = λ(x : Natural) → "simple(${Natural/show x})"
+          , tag = λ(x : Natural) → λ(y : Text) → "${Natural/show x}(${y})"
+          , text = Text/show
+          , undefined = "undefined"
+          }
+
+let CBOR/base64 = ./base64.dhall
+
+let CBOR/data = ./data.dhall
+
+let CBOR/integer = ./integer.dhall
+
+let CBOR/toArray = ./toArray.dhall
+
+let CBOR/textMap = ./textMap.dhall
+
+let CBOR/null = ./null.dhall
+
+let example0 =
+        assert
+      :   ''
+          ${renderDiag
+              ( CBOR/textMap
+                  ( toMap
+                      { a = CBOR/integer +1
+                      , b = CBOR/toArray Integer CBOR/integer [ +2, +3 ]
+                      , c = CBOR/base64 "EjRWeA"
+                      , d = CBOR/data CBOR/null
+                      }
+                  )
+              )}
+          ''
+        ≡ ''
+          { "a": +1, "b": [ +2, +3 ], "c": 34("EjRWeA"), "d": 24(null) }
+          ''
+
+in  renderDiag

--- a/Prelude/CBOR/diagnostic.dhall
+++ b/Prelude/CBOR/diagnostic.dhall
@@ -3,7 +3,7 @@ Render a `CBOR` value to a diagnostic `Text` value
 
 The diagnostic format is not formally defined and should not be parsed.
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let Map/Type = ../Map/Type.dhall
 
@@ -12,8 +12,8 @@ let Text/concatSep = ../Text/concatSep.dhall
 let Text/concatMapSep = ../Text/concatMapSep.dhall
 
 let renderDiag
-    : CBOR/Type → Text
-    = λ(cbor : CBOR/Type) →
+    : CBOR → Text
+    = λ(cbor : CBOR) →
         cbor
           Text
           { array = λ(xs : List Text) → "[ " ++ Text/concatSep ", " xs ++ " ]"
@@ -44,7 +44,7 @@ let CBOR/data = ./data.dhall
 
 let CBOR/integer = ./integer.dhall
 
-let CBOR/toArray = ./toArray.dhall
+let CBOR/arrayOf = ./arrayOf.dhall
 
 let CBOR/textMap = ./textMap.dhall
 
@@ -57,7 +57,7 @@ let example0 =
               ( CBOR/textMap
                   ( toMap
                       { a = CBOR/integer +1
-                      , b = CBOR/toArray Integer CBOR/integer [ +2, +3 ]
+                      , b = CBOR/arrayOf Integer CBOR/integer [ +2, +3 ]
                       , c = CBOR/base64 "EjRWeA"
                       , d = CBOR/data CBOR/null
                       }

--- a/Prelude/CBOR/double.dhall
+++ b/Prelude/CBOR/double.dhall
@@ -1,0 +1,25 @@
+{-|
+Create a CBOR floating-point number item from a `Double` value
+-}
+let CBOR/Type = ./Type.dhall
+
+let double
+    : Double → CBOR/Type
+    = λ(x : Double) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.double x
+
+in  double

--- a/Prelude/CBOR/double.dhall
+++ b/Prelude/CBOR/double.dhall
@@ -1,10 +1,10 @@
 {-|
 Create a CBOR floating-point number item from a `Double` value
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let double
-    : Double → CBOR/Type
+    : Double → CBOR
     = λ(x : Double) →
       λ(CBOR : Type) →
       λ ( cbor

--- a/Prelude/CBOR/fromJSON.dhall
+++ b/Prelude/CBOR/fromJSON.dhall
@@ -1,0 +1,49 @@
+{-|
+Translate a `JSON` value to a `CBOR` value
+-}
+
+let List/map = ../List/map.dhall
+
+let JSON = ../JSON/Type.dhall
+
+let CBOR = ./Type.dhall
+
+let fromJSON
+    : JSON → CBOR
+    = λ(json : JSON) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        json
+          CBOR
+          { array = cbor.array
+          , bool = cbor.bool
+          , double = cbor.double
+          , integer = cbor.integer
+          , null = cbor.null
+          , object =
+              let Entry = { mapKey : Text, mapValue : CBOR }
+
+              in  λ(m : List Entry) →
+                    cbor.map
+                      ( List/map
+                          Entry
+                          { mapKey : CBOR, mapValue : CBOR }
+                          (λ(e : Entry) → e with mapKey = cbor.text e.mapKey)
+                          m
+                      )
+          , string = cbor.text
+          }
+
+in  fromJSON

--- a/Prelude/CBOR/integer.dhall
+++ b/Prelude/CBOR/integer.dhall
@@ -1,0 +1,29 @@
+{-|
+Create a CBOR integer item from an `Integer` value
+
+Note that Dhall integers can be arbitrary size. For integers
+that exceed the capacity of a CBOR integer item a Dhall to CBOR
+converter may produce a CBOR bignum byte string instead.
+-}
+let CBOR/Type = ./Type.dhall
+
+let integer
+    : Integer → CBOR/Type
+    = λ(x : Integer) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.integer x
+
+in  integer

--- a/Prelude/CBOR/integer.dhall
+++ b/Prelude/CBOR/integer.dhall
@@ -5,10 +5,10 @@ Note that Dhall integers can be arbitrary size. For integers
 that exceed the capacity of a CBOR integer item a Dhall to CBOR
 converter may produce a CBOR bignum byte string instead.
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let integer
-    : Integer → CBOR/Type
+    : Integer → CBOR
     = λ(x : Integer) →
       λ(CBOR : Type) →
       λ ( cbor

--- a/Prelude/CBOR/map.dhall
+++ b/Prelude/CBOR/map.dhall
@@ -1,0 +1,47 @@
+{-|
+Create a CBOR map item from a Dhall `Map` of `CBOR` values
+
+See ./textMap.dhall for an example.
+-}
+
+let List/map = ../List/map.dhall
+
+let Map/Entry = ../Map/Entry.dhall
+
+let CBOR = ./Type.dhall
+
+let CBOR/Entry = Map/Entry CBOR CBOR
+
+let CBOR/Map = List CBOR/Entry
+
+let map =
+      λ(x : CBOR/Map) →
+      λ(CBOR : Type) →
+        let CBOR/Entry = Map/Entry CBOR CBOR
+
+        in  λ ( cbor
+              : { array : List CBOR → CBOR
+                , bool : Bool → CBOR
+                , double : Double → CBOR
+                , integer : Integer → CBOR
+                , map : List CBOR/Entry → CBOR
+                , null : CBOR
+                , simple : Natural → CBOR
+                , tag : Natural → CBOR → CBOR
+                , text : Text → CBOR
+                , undefined : CBOR
+                }
+              ) →
+              cbor.map
+                ( List/map
+                    CBOR/Entry@1
+                    CBOR/Entry
+                    ( λ(e : CBOR/Entry@1) →
+                        { mapKey = e.mapKey CBOR cbor
+                        , mapValue = e.mapValue CBOR cbor
+                        }
+                    )
+                    x
+                )
+
+in  map

--- a/Prelude/CBOR/map.dhall
+++ b/Prelude/CBOR/map.dhall
@@ -14,8 +14,9 @@ let CBOR/Entry = Map/Entry CBOR CBOR
 
 let CBOR/Map = List CBOR/Entry
 
-let map =
-      λ(x : CBOR/Map) →
+let map
+    : CBOR/Map → CBOR
+    = λ(x : CBOR/Map) →
       λ(CBOR : Type) →
         let CBOR/Entry = Map/Entry CBOR CBOR
 

--- a/Prelude/CBOR/null.dhall
+++ b/Prelude/CBOR/null.dhall
@@ -1,0 +1,24 @@
+{-|
+Create a CBOR null item
+-}
+let CBOR/Type = ./Type.dhall
+
+let null
+    : CBOR/Type
+    = λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.null
+
+in  null

--- a/Prelude/CBOR/null.dhall
+++ b/Prelude/CBOR/null.dhall
@@ -1,10 +1,10 @@
 {-|
 Create a CBOR null item
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let null
-    : CBOR/Type
+    : CBOR
     = λ(CBOR : Type) →
       λ ( cbor
         : { array : List CBOR → CBOR

--- a/Prelude/CBOR/package.dhall
+++ b/Prelude/CBOR/package.dhall
@@ -1,5 +1,6 @@
 { Type = ./Type.dhall
 , array = ./array.dhall
+, arrayOf = ./arrayOf.dhall
 , base64 = ./base64.dhall
 , base64url = ./base64url.dhall
 , bool = ./bool.dhall
@@ -11,7 +12,6 @@
 , map = ./map.dhall
 , null = ./null.dhall
 , tag = ./tag.dhall
-, toArray = ./toArray.dhall
 , text = ./text.dhall
 , textMap = ./textMap.dhall
 }

--- a/Prelude/CBOR/package.dhall
+++ b/Prelude/CBOR/package.dhall
@@ -1,0 +1,17 @@
+{ Type = ./Type.dhall
+, array = ./array.dhall
+, base64 = ./base64.dhall
+, base64url = ./base64url.dhall
+, bool = ./bool.dhall
+, data = ./data.dhall
+, diagnostic = ./diagnostic.dhall
+, double = ./double.dhall
+, fromJSON = ./fromJSON.dhall
+, integer = ./integer.dhall
+, map = ./map.dhall
+, null = ./null.dhall
+, tag = ./tag.dhall
+, toArray = ./toArray.dhall
+, text = ./text.dhall
+, textMap = ./textMap.dhall
+}

--- a/Prelude/CBOR/tag.dhall
+++ b/Prelude/CBOR/tag.dhall
@@ -5,8 +5,9 @@ See ./base64.dhall as an example, see RFC7049 section 2.4 for more information.
 -}
 let CBOR = ./Type.dhall
 
-let tag =
-      λ(tag : Natural) →
+let tag
+    : Natural → CBOR → CBOR
+    = λ(tag : Natural) →
       λ(value : CBOR) →
       λ(CBOR : Type) →
       λ ( cbor

--- a/Prelude/CBOR/tag.dhall
+++ b/Prelude/CBOR/tag.dhall
@@ -1,0 +1,27 @@
+{-|
+Create a CBOR tagged item from a `Natural` tag value and a `CBOR` value
+
+See ./base64.dhall as an example, see RFC7049 section 2.4 for more information.
+-}
+let CBOR = ./Type.dhall
+
+let tag =
+      λ(tag : Natural) →
+      λ(value : CBOR) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.tag tag (value CBOR cbor)
+
+in  tag

--- a/Prelude/CBOR/text.dhall
+++ b/Prelude/CBOR/text.dhall
@@ -1,0 +1,25 @@
+{-|
+Create a CBOR byte string from a `Text` value
+-}
+let CBOR/Type = ./Type.dhall
+
+let text
+    : Text → CBOR/Type
+    = λ(x : Text) →
+      λ(CBOR : Type) →
+      λ ( cbor
+        : { array : List CBOR → CBOR
+          , bool : Bool → CBOR
+          , double : Double → CBOR
+          , integer : Integer → CBOR
+          , map : List { mapKey : CBOR, mapValue : CBOR } → CBOR
+          , null : CBOR
+          , simple : Natural → CBOR
+          , tag : Natural → CBOR → CBOR
+          , text : Text → CBOR
+          , undefined : CBOR
+          }
+        ) →
+        cbor.text x
+
+in  text

--- a/Prelude/CBOR/text.dhall
+++ b/Prelude/CBOR/text.dhall
@@ -1,10 +1,10 @@
 {-|
 Create a CBOR byte string from a `Text` value
 -}
-let CBOR/Type = ./Type.dhall
+let CBOR = ./Type.dhall
 
 let text
-    : Text → CBOR/Type
+    : Text → CBOR
     = λ(x : Text) →
       λ(CBOR : Type) →
       λ ( cbor

--- a/Prelude/CBOR/textMap.dhall
+++ b/Prelude/CBOR/textMap.dhall
@@ -14,7 +14,7 @@ let CBOR/text = ./text.dhall
 
 let TextEntry = { mapKey : Text, mapValue : CBOR }
 
-let mapText
+let textMap
     : List TextEntry → CBOR
     = λ(xs : List TextEntry) →
         CBOR/map
@@ -25,4 +25,4 @@ let mapText
               xs
           )
 
-in  mapText
+in  textMap

--- a/Prelude/CBOR/textMap.dhall
+++ b/Prelude/CBOR/textMap.dhall
@@ -1,0 +1,28 @@
+{-|
+Create a CBOR map item from a Dhall `Map` of `CBOR` values
+
+See ./diagnostic.dhall for an example.
+-}
+
+let List/map = ../List/map.dhall
+
+let CBOR = ./Type.dhall
+
+let CBOR/map = ./map.dhall
+
+let CBOR/text = ./text.dhall
+
+let TextEntry = { mapKey : Text, mapValue : CBOR }
+
+let mapText
+    : List TextEntry → CBOR
+    = λ(xs : List TextEntry) →
+        CBOR/map
+          ( List/map
+              TextEntry
+              { mapKey : CBOR, mapValue : CBOR }
+              (λ(x : TextEntry) → x with mapKey = CBOR/text x.mapKey)
+              xs
+          )
+
+in  mapText

--- a/Prelude/CBOR/toArray.dhall
+++ b/Prelude/CBOR/toArray.dhall
@@ -1,0 +1,20 @@
+{-|
+Create a CBOR array item from a `List` of values and a conversion function
+
+See ./diagnostic.dhall for an example.
+-}
+
+let List/map = ../List/map.dhall
+
+let CBOR = ./Type.dhall
+
+let CBOR/array = ./array.dhall
+
+let toArray
+    : ∀(a : Type) → (a → CBOR) → List a → CBOR
+    = λ(a : Type) →
+      λ(f : a → CBOR) →
+      λ(xs : List a) →
+        CBOR/array (List/map a CBOR f xs)
+
+in  toArray

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -1,6 +1,7 @@
 { Bool =
       ./Bool/package.dhall sha256:7ee950e7c2142be5923f76d00263e536b71d96cb9c190d7743c1679501ddeb0a
     ? ./Bool/package.dhall
+, CBOR = ./CBOR/package.dhall
 , Double =
       ./Double/package.dhall sha256:b8d20ab3216083622ae371fb42a6732bc67bb2d66e84989c8ddba7556a336cf7
     ? ./Double/package.dhall


### PR DESCRIPTION
Package for working with CBOR items.

---

There is no support for binary items, but I think there there is a reasonable workaround here. If a `Text` value is tagged as base64 (`CBOR/base64 : Text -> CBOR`) then a utility that converts Dhall to CBOR would be able to decode the base64 into a byte string as it encodes the CBOR binary stream. This converter could also tag the bytes string as encodable to base64, so the CBOR binary could then be transparently converted back to Dhall. See https://tools.ietf.org/html/rfc7049#section-2.4.4 for more information.

Ref #1121 