### PR TITLE
Update `store.dhall-lang.org`

### DIFF
--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "eb0327c858509a91fa58f0148b3f68ac15fe06ac",
-  "date": "2020-10-20T21:12:39-07:00",
-  "path": "/nix/store/qx95jag4fil98gl6q1h80r4ycb9anqkb-dhall-haskell",
-  "sha256": "1p5s3hbrb1sakymd8mvx8mspqfrw9d83kj54m02db65gwi43cp1p",
+  "rev": "85eabc24cf6c2a355df281cfaca17a7f750ae624",
+  "date": "2020-12-16T20:31:40-08:00",
+  "path": "/nix/store/21sl76mlv1sfi9mwbnykzsjipqqrisjm-dhall-haskell-85eabc2",
+  "sha256": "1h30z6vm6y62mjia9bmxda9p0fli5qgj29jr5pk5riqsna6xhw0m",
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -351,6 +351,27 @@ in
                   rev = "v19.0.0";
                   sha256 = "04m29f5xlks6rarv1gy909j68bsflwl18l9bg7kyy1vpwap0avkp";
                 })
+                (pkgs.dhallPackages.Prelude.overridePackage {
+                  name = "Prelude-20.0.0";
+                  rev = "v20.0.0";
+                  sha256 = "1smk57xki1cj24xpp0s3gv85radl6ry76ybsjkqak8h13s79lwla";
+                })
+
+                (pkgs.dhallPackages.dhall-kubernetes.overridePackage {
+                  name = "dhall-kubernetes-3.0.0";
+                  rev = "v3.0.0";
+                  sha256 = "1r4awh770ghsrwabh5ddy3jpmrbigakk0h32542n1kh71w3cdq1h";
+                })
+                (pkgs.dhallPackages.dhall-kubernetes.overridePackage {
+                  name = "dhall-kubernetes-4.0.0";
+                  rev = "v4.0.0";
+                  sha256 = "0j5d9rdiwa0zajmqak1ddlmbq2lrkcsc89aa70bhlkq33d1adwyh";
+                })
+                (pkgs.dhallPackages.dhall-kubernetes.overridePackage {
+                  name = "dhall-kubernetes-5.0.0";
+                  rev = "v5.0.0";
+                  sha256 = "0irqv44nh6fp3nyal48rzp5ir0y82r897aaw2nnc4yrfh9rd8w0y";
+                })
               ];
 
               store = pkgs.runCommand "store" { inherit packages; } ''


### PR DESCRIPTION
… to add the latest version of the Prelude and also
`dhall-kubernetes` releases

This also updates the `dhall-haskell` implementation along the way