### PR TITLE
Use cache.nixos.org for Hydra builds

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -138,6 +138,8 @@ in
       notificationSender = "noreply@dhall-lang.org";
 
       package = pkgs.hydra-unstable;
+
+      useSubstitutes = true;
     };
 
     journald.extraConfig = ''


### PR DESCRIPTION
By default, Hydra does not use the public Nix cache (mainly to
lock down the "chain of custody" for built products), but for our
use case I feel confident trusting cache products built by
cache.nixos.org.