### PR TITLE
Rotate Discourse SMTP password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-nixops/discourseSmtpPassword
 docs/_site
 .history

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -69,7 +69,7 @@ in
 
     loginAccounts = {
       "discourse@dhall-lang.org" = {
-        hashedPassword = "$6$.vCIyiyMp4/HzO$FyW1OMFpL7tmPQvfDs2wDfhn5qTZW4NePBfDsrFQxPepIISrFYyjISeZS2kAHO6F/AolD7sus2mJUXsQUgCfv0";
+        hashedPassword = "$6$WNGVf74Y7w$iMAfx7BW1KhNfyG.44ty39f5cnBP64mb.tpluV9BjCp130pc3sem5IqUe9O1w1yr0X6uwDq.pfz394oZdvNbi0";
 
         aliases = [ "postmaster@dhall-lang.org" ];
       };


### PR DESCRIPTION
In the course of debugging the issues that led to
https://github.com/dhall-lang/dhall-lang/pull/1137 I accidentally
deleted `nixops/discourseSmtpPassword` on dhall-lang.org using a
`git clean`, so I had to create a new password.  This pull request
updates the password that the SMTP mailserver expects for the
Discourse mail account.

I also removed `nixops/discourseSmtpPassword` from `.gitignore`, to
make it harder for me to make this mistake in the future (since
it will now show up in the list of untracked files which I check
before doing a `git clean`).