### PR TITLE
Make website more responsive

### DIFF
--- a/nixops/index.html
+++ b/nixops/index.html
@@ -53,6 +53,10 @@
         border-bottom: 1px solid black;
       }
 
+      .scalable {
+        max-width: 100%;
+      }
+
       header {
         margin-bottom: 2rem;
       }
@@ -192,7 +196,7 @@
             <a class="nav-link" href="https://github.com/dhall-lang/dhall-lang/blob/master/README.md"><img src = "./img/github-logo.png" height="25px" alt="GitHub logo"></a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://twitter.com/dhall_lang"><img src = "./img/twitter-logo.svg" height="32px" alt="Twitter logo"></a>
+            <a class="nav-link" href="https://twitter.com/dhall_lang"><img src = "./img/twitter-logo.svg" height="25px" alt="Twitter logo"></a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="https://discourse.dhall-lang.org"><img src = "./img/discourse-logo.svg" height="25px" alt="Discourse logo"></a>
@@ -224,7 +228,7 @@
     </p>
     </div>
     <div id="editor">
-      <div id="input-pane">
+      <div id="input-pane" class="scalable">
         <ul class="nav nav-tabs example-tab">
           <li class="nav-item">
             <a id="example0" class="nav-link example-tab active" href="#" onClick="set(example0, 'example0')">Hello, world!</a>
@@ -244,7 +248,7 @@
         </ul>
         <textarea id="dhall-input"></textarea>
       </div>
-      <div id="output-pane">
+      <div id="output-pane" class="scalable">
         <ul class="nav nav-tabs">
           <li class="nav-item">
             <a id="type-tab" class="nav-link mode-tab" href="#">Type</a>
@@ -287,7 +291,14 @@
       <p>Refactoring something mission-critical?  Use Dhall's support for
       semantic hashes to guarantee that many types of refactors are
       behavior-preserving</p>
-      <img src="./img/hash.gif">
+      <div class="scalable" style="font-size: 0; line-height: 0;">
+        <div class="scalable" style="display: inline-block; overflow: hidden; width: 528px;">
+          <img src="./img/hash.gif" style="width: calc(100% * 1072 / 528);">
+        </div>
+        <div class="scalable" style="display: inline-block; overflow: hidden; width: 528px;">
+          <img src="./img/hash.gif" style="width: calc(100% * 1072 / 528); margin-left: calc(100% * -544 / 528);">
+        </div>
+      </div>
       <hr class="my-4">
       <p>What if you intend to make a change?  Use a semantic diff to verify that
       you changed what you expected to:</p>
@@ -295,7 +306,7 @@
       <hr class="my-4">
       <p>Did you inherit a messy configuration?  Use the type system and
       integrated editor support to navigate more effectively.</p>
-      <img src="./img/completion.gif">
+      <img src="./img/completion.gif" class="scalable">
       <p></p>
       <a href="https://marketplace.visualstudio.com/items?itemName=dhall.vscode-dhall-lsp-server" class="btn btn-lg btn-outline-dark bg-light">VSCode plugin <i class="fas fa-code" ></i></a>
     </div>

--- a/nixops/overlay.nix
+++ b/nixops/overlay.nix
@@ -244,7 +244,7 @@ pkgsNew: pkgsOld: {
     gitlab =
       pkgsNew.fetchurl {
         url    = "https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png";
-        sha256 = "1mxk6xxw8bzp3l4jx3jaka9n5a69jbnkw4kzpmy4hbhp7nc33z5w";
+        sha256 = "0zhh4sqxx1phgnpmbgr20hn3yl6y7yh4gcsf6639vjzsjg1xjacd";
       };
 
     golang =
@@ -288,7 +288,7 @@ pkgsNew: pkgsOld: {
     openCollective =
       pkgsNew.fetchurl {
         url    = "https://opencollective.com/static/images/opencollective-icon.svg";
-        sha256 = "0i4hngjycmrj6gk2knsxqy35sx1ksmc268lr56s1fwfdp6afsh4z";
+        sha256 = "0pfr6pb4qp1z6gimcy46mpi6gw4vvcllj1fqrn4svb068iz56vb7";
       };
 
     prometheus =
@@ -306,7 +306,7 @@ pkgsNew: pkgsOld: {
     rust =
       pkgsNew.fetchurl {
         url    = "http://rust-lang.org/logos/rust-logo-128x128-blk.png";
-        sha256 = "19ycf7ra6pn6gvavpfg1gbi9j8dsmxfm0gnczabvpspv7yaf8i71";
+        sha256 = "0x1c4x3akpd6dlblz9jk23m3wmg9qp4my3hx73kx1cs01qg1cda1";
       };
 
     slack =
@@ -316,7 +316,7 @@ pkgsNew: pkgsOld: {
         url =
           "https://brandfolder.com/slack/attachments/pl546j-7le8zk-afym5u?dl=true&resource_key=pl53se-o7edc-2zw45a&resource_type=Collection";
 
-        sha256 = "0i4yjjgkcky6zfbim17rryy23pbrsc4255jzy14lgy7ja3a5jabk";
+        sha256 = "04pg70ccd1xyryqjq11k7firxhl998wmz0lk867hbii4d3c9xpva";
 
         postFetch =
           "${pkgsNew.imagemagickBig}/bin/mogrify -format png -crop 300x300+100+100 $downloadedFile";

--- a/nixops/twitterLogo.nix
+++ b/nixops/twitterLogo.nix
@@ -5,8 +5,8 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     name = "twitter-logos.zip";
-    url = "https://about.twitter.com/content/dam/about-twitter/company/brand-resources/en_us/Twitter-Logos.zip";
-    sha256 = "1dhqmj3krhak10yrq0zm89ld40a32ndrfnl6ligaaphf5dkff5m6";
+    url = "https://about.twitter.com/content/dam/about-twitter/en/brand-toolkit/downloads/twitter-logo-01282021.zip";
+    sha256 = "18ig7krfdqv8v77kiwig7fgz77zn692l4xky4xhlgfi3py86fn59";
   };
 
   sourceRoot = ".";

--- a/nixops/website.nix
+++ b/nixops/website.nix
@@ -46,7 +46,7 @@ runCommand "try-dhall" {} ''
   ${coreutils}/bin/ln --symbolic ${logo.xml} $out/img/xml-logo.svg
   ${coreutils}/bin/ln --symbolic ${logo.yaml} $out/img/yaml-logo.png
   ${coreutils}/bin/ln --symbolic ${logo.zulip} $out/img/zulip-logo.png
-  ${coreutils}/bin/ln --symbolic '${logo.twitter}/Twitter Logos/Twitter Logos/Twitter_Logo_Blue/Twitter_Logo_Blue.svg' $out/img/twitter-logo.svg
+  ${coreutils}/bin/ln --symbolic '${logo.twitter}/Twitter logo/SVG/Logo blue.svg' $out/img/twitter-logo.svg
   ${coreutils}/bin/mkdir $out/nix-support
   ${coreutils}/bin/echo "doc none $out/index.html" > $out/nix-support/hydra-build-products
 ''


### PR DESCRIPTION
I used CSS to split up and crop the huge hash.gif image, so it can wrap on smaller screens, in addition to shrinking.

I also made the code editors shrink so they don't overflow the page.

It all works well down to about 350px width, at which point the twitter embeds stop shrinking and start overflowing. But it's good enough for my phone at least.

Also update logo hashes and use new source for twitter logo