### PR TITLE
Add JSON.field to prelude

### DIFF
--- a/Prelude/JSON/field
+++ b/Prelude/JSON/field
@@ -1,0 +1,2 @@
+  ./field.dhall sha256:bc4f2896ef609f346057f8652d85ae06c8138660638a007a2a6fa4a49fce01ee
+? ./field.dhall

--- a/Prelude/JSON/field.dhall
+++ b/Prelude/JSON/field.dhall
@@ -1,0 +1,27 @@
+{-|
+Create a JSON field for a JSON object from a Dhall `Text` key and a JSON value
+
+```
+let JSON = ./package.dhall
+in  JSON.render
+      ( JSON.object
+          [ JSON.field "foo" (JSON.double 1.0)
+          , JSON.field "bar" (JSON.bool True)
+          ]
+      )
+= "{ \"foo\": 1.0, \"bar\": true }"
+```
+-}
+let JSON =
+        ./Type.dhall sha256:40edbc9371979426df63e064333b02689b969c4cfbbccfa481216d2d1a6e9759
+      ? ./Type.dhall
+
+let Map/keyValue =
+        ../Map/keyValue.dhall sha256:a0a97199d280c4cce72ffcbbf93b7ceda0a569cf4d173ac98e0aaaa78034b98c
+      ? ../Map/keyValue.dhall
+
+let field
+    : Text → JSON → { mapKey : Text, mapValue : JSON }
+    = λ(mapKey : Text) → λ(mapValue : JSON) → Map/keyValue JSON mapKey mapValue
+
+in  field

--- a/Prelude/JSON/package.dhall
+++ b/Prelude/JSON/package.dhall
@@ -1,4 +1,7 @@
-  { render =
+  { field =
+        ./field.dhall sha256:bc4f2896ef609f346057f8652d85ae06c8138660638a007a2a6fa4a49fce01ee
+      ? ./field.dhall
+  , render =
         ./render.dhall sha256:36befdd8bb5a1c2b372709da245a8d074533b86429e137b894c08ad16fa34836
       ? ./render.dhall
   , renderCompact =

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -32,7 +32,7 @@
       ./Optional/package.dhall sha256:37b84d6fe94c591d603d7b06527a2d3439ba83361e9326bc7b72517c7dc54d4e
     ? ./Optional/package.dhall
 , JSON =
-      ./JSON/package.dhall sha256:5f98b7722fd13509ef448b075e02b9ff98312ae7a406cf53ed25012dbc9990ac
+      ./JSON/package.dhall sha256:a06ce5233d290afebb54a6268be172d384b84bef47b4705850a2683edb1ee68a
     ? ./JSON/package.dhall
 , Text =
       ./Text/package.dhall sha256:46c53957c10bd4c332a5716d6e06068cd24ae1392ca171e6da31e30b9b33c07c

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -103,6 +103,37 @@
             }
           ) →
           JSON
+    , field :
+        ∀(mapKey : Text) →
+        ∀ ( mapValue
+          : ∀(JSON : Type) →
+            ∀ ( json
+              : { array : List JSON → JSON
+                , bool : Bool → JSON
+                , double : Double → JSON
+                , integer : Integer → JSON
+                , null : JSON
+                , object : List { mapKey : Text, mapValue : JSON } → JSON
+                , string : Text → JSON
+                }
+              ) →
+              JSON
+          ) →
+          { mapKey : Text
+          , mapValue :
+              ∀(JSON : Type) →
+              ∀ ( json
+                : { array : List JSON → JSON
+                  , bool : Bool → JSON
+                  , double : Double → JSON
+                  , integer : Integer → JSON
+                  , null : JSON
+                  , object : List { mapKey : Text, mapValue : JSON } → JSON
+                  , string : Text → JSON
+                  }
+                ) →
+                JSON
+          }
     , integer :
         ∀(x : Integer) →
         ∀(JSON : Type) →


### PR DESCRIPTION
JSON.field is a helper function for making `JSON.object` entries, a simple convenience that helps with constructing basically any JSON in Dhall.  This function is in every JSON interface I've made in Dhall and seems reasonable for inclusion in the prelude.

Since the map value is *always* `JSON.Type` for JSON objects, it's more convenient to have this function that having to write `JSON.keyValue JSON.Type` every single time you construct a field for an object (or to write out the map entry by hand).

For example, the basic example object goes from

```
let JSON = ./package.dhall

in  JSON.render
      ( JSON.object
          [ { mapKey = "foo", mapValue = JSON.double 1.0 }
          , { mapKey = "bar", mapValue = JSON.bool True }
          ]
      )
```

to

```
let JSON = ./package.dhall

in  JSON.render
      ( JSON.object
          [ JSON.field "foo" (JSON.double 1.0)
          , JSON.field "bar" (JSON.bool True)
          ]
      )
```

with this new function.