### PR TITLE
Add Prelude and cached package doc links

### DIFF
--- a/docs/references/Prelude.md
+++ b/docs/references/Prelude.md
@@ -1,6 +1,0 @@
-# Prelude
-
-> The latest release of the Dhall Prelde available [https://prelude.dhall-lang.org/](https://prelude.dhall-lang.org/)
-
-```note:: prelude doc generation to be defined here
-```

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -10,5 +10,6 @@ These comprehensive resources cover details that other texts will gloss over:
    Machine-readable specification of the Dhall grammar <https://github.com/dhall-lang/dhall-lang/blob/master/standard/dhall.abnf>
    Full specification of the language semantics <https://github.com/dhall-lang/dhall-lang/blob/master/standard#semantics>
    Built-in-types
-   Prelude
+   Prelude <https://store.dhall-lang.org/Prelude-v20.0.0>
+   Other cached packages <https://store.dhall-lang.org>
 ```

--- a/docs/references/index.md
+++ b/docs/references/index.md
@@ -10,6 +10,6 @@ These comprehensive resources cover details that other texts will gloss over:
    Machine-readable specification of the Dhall grammar <https://github.com/dhall-lang/dhall-lang/blob/master/standard/dhall.abnf>
    Full specification of the language semantics <https://github.com/dhall-lang/dhall-lang/blob/master/standard#semantics>
    Built-in-types
-   Prelude <https://store.dhall-lang.org/Prelude-v20.0.0>
+   Prelude <https://prelude.dhall-lang.org>
    Other cached packages <https://store.dhall-lang.org>
 ```


### PR DESCRIPTION
Currently the [docs for the Prelude](https://docs.dhall-lang.org/references/Prelude.html) link to essentially nothing but placeholder text.  Since the actual `dhall-docs` are hosted at store.dhall-lang, we can link to those instead.  This also adds a link to the full package cache there, since discoverability of store.dhall-lang is perhaps a bit low at the moment.

If someone smarter than me knows how to auto-generate a link to the *latest* prelude docs, rather than this having to be manually updated, please make/suggest changes.  :smile:

Also I would welcome ideas for a more suggestive link name to the other cached packages than "Other cached packages".