### PR TITLE
Point prelude.dhall-lang.org to store.dhall-lang.org

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -204,7 +204,7 @@ in
                   add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
                 }
 
-                rewrite ^/?$ https://github.com/dhall-lang/dhall-lang/tree/${latestRelease}/Prelude redirect;
+                rewrite ^/?$ https://store.dhall-lang.org/Prelude-${latestRelease} redirect;
                 rewrite ^/(v[^/]+)$ https://github.com/dhall-lang/dhall-lang/tree/$1/Prelude redirect;
                 rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 break;
                 rewrite ^/(.*)$ /dhall-lang/dhall-lang/${latestRelease}/Prelude/$1 break;

--- a/nixops/packages/Prelude_20_1_0.nix
+++ b/nixops/packages/Prelude_20_1_0.nix
@@ -1,0 +1,15 @@
+{ buildDhallGitHubPackage }:
+  buildDhallGitHubPackage {
+    name = "Prelude";
+    githubBase = "github.com";
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    rev = "v20.1.0";
+    fetchSubmodules = false;
+    sha256 = "04r1w7wqydmwm9mh3lz4y96a87k5kkvzsmrhbdrf0izcy5bqqv5y";
+    directory = "Prelude";
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [];
+    }

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -34,6 +34,7 @@ let
     Prelude_18_0_0
     Prelude_19_0_0
     Prelude_20_0_0
+    Prelude_20_1_0
   ];
 
   toListItem =


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/pull/1148

This changes the top-level prelude.dhall-lang.org to now point to
the latest Prelude package on store.dhall-lang.org.