### PR TITLE
Remove use of --inplace

### DIFF
--- a/docs/discussions/Safety-guarantees.md
+++ b/docs/discussions/Safety-guarantees.md
@@ -156,7 +156,7 @@ You can also automatically freeze all imports within a file using
 the following command:
 
 ```console
-$ dhall freeze --inplace ./example.dhall
+$ dhall freeze ./example.dhall
 ```
 
 An import frozen in this way can never successfully return a different

--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3028,7 +3028,7 @@ There are two main ways you can obtain the hash:
 * Recommended: Use `dhall freeze`
 
   ```bash
-  $ dhall freeze --inplace ./example.dhall
+  $ dhall freeze ./example.dhall
   ```
 
 * Use `dhall hash` from the command line or the `:hash` command in the REPL

--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,9 +1,9 @@
 {
-  "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "85eabc24cf6c2a355df281cfaca17a7f750ae624",
-  "date": "2020-12-16T20:31:40-08:00",
-  "path": "/nix/store/21sl76mlv1sfi9mwbnykzsjipqqrisjm-dhall-haskell-85eabc2",
-  "sha256": "1h30z6vm6y62mjia9bmxda9p0fli5qgj29jr5pk5riqsna6xhw0m",
+  "url": "https://github.com/dhall-lang/dhall-haskell",
+  "rev": "5a93d5f70601bb596616df3a583d7d984ec6ea94",
+  "date": "2021-05-02T20:14:30+02:00",
+  "path": "/nix/store/9z0nb4lmqklzf4ds8j3c5glvpycgyb1z-dhall-haskell",
+  "sha256": "04dw8pisjx95985qxa195s396c2w2q67hqi9kc1myrp999ajvyws",
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false

--- a/nixops/overlay.nix
+++ b/nixops/overlay.nix
@@ -113,10 +113,9 @@ pkgsNew: pkgsOld: {
 
     ${pkgsNew.coreutils}/bin/chmod --recursive u+w "$out"
 
-    for FILE in $(${pkgsNew.findutils}/bin/find "$out" -type f ! -name README.md); do
-      ${pkgsNew.dhall}/bin/dhall lint --inplace "$FILE"
-      XDG_CACHE_HOME=/var/empty ${pkgsNew.dhall}/bin/dhall freeze --all --cache --inplace "$FILE"
-    done
+    FILES=$(${pkgsNew.findutils}/bin/find "$out" -type f ! -name README.md)
+    ${pkgsNew.dhall}/bin/dhall lint $FILES
+    XDG_CACHE_HOME=/var/empty ${pkgsNew.dhall}/bin/dhall freeze --all --cache $FILES
   '';
 
   expected-test-files =

--- a/nixops/overlay.nix
+++ b/nixops/overlay.nix
@@ -128,7 +128,7 @@ pkgsNew: pkgsOld: {
         ${pkgsNew.cbor-diag}/bin/cbor2diag.rb "$FILE" > "''${FILE%.dhallb}.diag"
       done
 
-      ${pkgsNew.dhall}/bin/dhall type --file "${../.}/tests/type-inference/success/preludeA.dhall" > "$out/type-inference/success/preludeB.dhall"
+      ${pkgsNew.dhall}/bin/dhall --unicode type --file "${../.}/tests/type-inference/success/preludeA.dhall" > "$out/type-inference/success/preludeB.dhall"
     '';
 
   haskellPackages = pkgsOld.haskellPackages.override (old: {

--- a/nixops/packages/dhall-aws-cloudformation_0_4_21.nix
+++ b/nixops/packages/dhall-aws-cloudformation_0_4_21.nix
@@ -8,7 +8,7 @@
     fetchSubmodules = false;
     sha256 = "0jksaqvny2a7l0l3xcsi7gpx53krfv9lmd8n6bsmqwbh17xsa3rw";
     directory = "";
-    file = "version.dhall";
+    file = "config.dhall";
     source = false;
     document = false;
     dependencies = [];

--- a/nixops/packages/dhall-aws-cloudformation_0_4_21.nix
+++ b/nixops/packages/dhall-aws-cloudformation_0_4_21.nix
@@ -8,7 +8,7 @@
     fetchSubmodules = false;
     sha256 = "0jksaqvny2a7l0l3xcsi7gpx53krfv9lmd8n6bsmqwbh17xsa3rw";
     directory = "";
-    file = "config.dhall";
+    file = "version.dhall";
     source = false;
     document = false;
     dependencies = [];

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -5,7 +5,9 @@ let
     dhall-ansible_0_1_0
     dhall-ansible_0_2_1
 
-    dhall-aws-cloudformation_0_4_21
+    # This is currently too expensive for CI to build
+    # TODO: fix performance issues
+    # dhall-aws-cloudformation_0_4_21
 
     dhall-concourse_0_4_1
     dhall-concourse_0_5_0


### PR DESCRIPTION
Once https://github.com/dhall-lang/dhall-haskell/pull/2169 is merged (and maybe a new release of `dhall-haskell` is cut), we should update the documentation to remove the use of `--inplace` in the CLI (what this PR does).
That `--inplace` flag will only be deprecated instead of removed for a while to make the transition easier.