### PR TITLE
Fix prelude.dhall-lang.org

### DIFF
--- a/nixops/packages/Prelude_20_2_0.nix
+++ b/nixops/packages/Prelude_20_2_0.nix
@@ -1,0 +1,15 @@
+{ buildDhallGitHubPackage }:
+  buildDhallGitHubPackage {
+    name = "Prelude";
+    githubBase = "github.com";
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    rev = "v20.2.0";
+    fetchSubmodules = false;
+    sha256 = "0wqcj5w4x24j3p73qrc5x5gci2mxkvli3kphg53qwis4b8g703zp";
+    directory = "Prelude";
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [];
+    }

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -41,6 +41,7 @@ let
     Prelude_19_0_0
     Prelude_20_0_0
     Prelude_20_1_0
+    Prelude_20_2_0
   ];
 
   toListItem =


### PR DESCRIPTION
Currently the site 404s because we don't have a package for
v20.2.0 of the Prelude