### PR TITLE
standardise origin-based header configuration

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -136,6 +136,10 @@ to this cache – for example, you could:
 You should make it so that the environment variable `DHALL_TEST_VAR` is set to
 the string "6 * 7". This enables testing importing from environment variables.
 
+Some test cases have a `${TestcaseName}ENV.dhall` file, containing a Text
+map, i.e. `List { mapKey: Text, mapValue: Text }`. If present, you should
+resolve the test expression with the given environment variables set.
+
 The tests should:
 - parse `A` and `B`
 - resolve the imports for both `A` and `B`, in a context with a single ancestor

--- a/tests/import/success/userHeadersA.dhall
+++ b/tests/import/success/userHeadersA.dhall
@@ -1,0 +1,1 @@
+https://httpbin.org/user-agent as Text

--- a/tests/import/success/userHeadersB.dhall
+++ b/tests/import/success/userHeadersB.dhall
@@ -1,0 +1,5 @@
+''
+{
+  "user-agent": "Dhall"
+}
+''

--- a/tests/import/success/userHeadersENV.dhall
+++ b/tests/import/success/userHeadersENV.dhall
@@ -1,0 +1,10 @@
+toMap
+  { DHALL_HEADERS =
+      ''
+      toMap {
+        `httpbin.org:443` = toMap {
+          `User-Agent` = "Dhall"
+        }
+      }
+      ''
+  }

--- a/tests/import/success/userHeadersOverrideA.dhall
+++ b/tests/import/success/userHeadersOverrideA.dhall
@@ -1,0 +1,3 @@
+https://httpbin.org/user-agent
+  using [ { mapKey = "User-Agent", mapValue = "inline-header" } ]
+  as Text

--- a/tests/import/success/userHeadersOverrideB.dhall
+++ b/tests/import/success/userHeadersOverrideB.dhall
@@ -1,0 +1,5 @@
+''
+{
+  "user-agent": "user-header"
+}
+''

--- a/tests/import/success/userHeadersOverrideENV.dhall
+++ b/tests/import/success/userHeadersOverrideENV.dhall
@@ -1,0 +1,10 @@
+toMap
+  { DHALL_HEADERS =
+      ''
+      toMap {
+        `httpbin.org:443` = toMap {
+          `User-Agent` = "user-header"
+        }
+      }
+      ''
+  }


### PR DESCRIPTION
This PR standardises support for per-host header configuration, as discussed in https://discourse.dhall-lang.org/t/supporting-transitive-imports-from-private-repositories/457.

The basic idea is that instead of headers being inline with an import (URL with toMap { Authorization = "TOKEN" }), you will be able to specify per-origin headers in a config file, e.g:

```dhall
-- ~/.config/dhall/headers.dhall
toMap {
  `raw.githubusercontent.com:443` = toMap { Authorization = "TOKEN" }
}
```

There is also a (very early) implementation in a dhall-haskell PR: https://github.com/dhall-lang/dhall-haskell/pull/2236

Unlike haskell, it's kinda hard to tell if I'm on the right track. I'm not sure how formally I need to define this (in terms of pseudo-code), feedback welcome :)