### PR TITLE
Remove unused `date-time` & `full-time` abnf rules

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -557,9 +557,6 @@ time-offset     = "Z" / time-numoffset  ; "Z" desugars to "+00:00"
 partial-time    = time-hour ":" time-minute ":" time-second
                   [time-secfrac]
 full-date       = date-fullyear "-" date-month "-" date-mday
-full-time       = partial-time time-offset
-
-date-time       = full-date "T" full-time
 
 ; If the identifier matches one of the names in the `builtin` rule, then it is a
 ; builtin, and should be treated as the corresponding item in the list of


### PR DESCRIPTION
Looks like some unused rules got left in the ABNF from #1191; there is no reason to leave these unused rules in since they were included more explicitly in `temporal-literal`.