### PR TITLE
Alpha-normalize expected results in Prelude tests

### DIFF
--- a/tests/type-inference/success/prelude/Monoid/00B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/00B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Bool) → Bool
+List Bool → Bool

--- a/tests/type-inference/success/prelude/Monoid/01B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/01B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Bool) → Bool
+List Bool → Bool

--- a/tests/type-inference/success/prelude/Monoid/02B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/02B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Bool) → Bool
+List Bool → Bool

--- a/tests/type-inference/success/prelude/Monoid/03B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/03B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Bool) → Bool
+List Bool → Bool

--- a/tests/type-inference/success/prelude/Monoid/04B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/04B.dhall
@@ -1,1 +1,1 @@
-∀(a : Type) → ∀(xss : List (List a)) → List a
+Type → List (List _) → List _@1

--- a/tests/type-inference/success/prelude/Monoid/05B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/05B.dhall
@@ -1,3 +1,3 @@
-  ∀(a : Type)
-→ ∀(kvss : List (List { index : Natural, value : a }))
-→ List { index : Natural, value : a }
+  Type
+→ List (List { index : Natural, value : _ })
+→ List { index : Natural, value : _@1 }

--- a/tests/type-inference/success/prelude/Monoid/06B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/06B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Natural) → Natural
+List Natural → Natural

--- a/tests/type-inference/success/prelude/Monoid/07B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/07B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Natural) → Natural
+List Natural → Natural

--- a/tests/type-inference/success/prelude/Monoid/08B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/08B.dhall
@@ -1,1 +1,1 @@
-∀(a : Type) → ∀(xs : List (Optional a)) → Optional a
+Type → List (Optional _) → Optional _@1

--- a/tests/type-inference/success/prelude/Monoid/09B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/09B.dhall
@@ -1,1 +1,1 @@
-∀(a : Type) → ∀(xs : List (Optional a)) → Optional a
+Type → List (Optional _) → Optional _@1

--- a/tests/type-inference/success/prelude/Monoid/10B.dhall
+++ b/tests/type-inference/success/prelude/Monoid/10B.dhall
@@ -1,1 +1,1 @@
-∀(xs : List Text) → Text
+List Text → Text


### PR DESCRIPTION
This is a follow-up to #1190, where `import/success/headerForwardingB.dhall` is changed to indicate that import resolution should alpha-normalize when there's an integrity check. When I updated Dhall for Java to fix this test failure, it turned up some new failures in the Prelude tests that need the same change (confirmed by @MonoidMusician [here](https://github.com/dhall-lang/dhall-lang/pull/1190#issuecomment-887945780)). This PR alpha-normalizes the expected results for these tests so that they're consistent with the `import` ones.