### PR TITLE
Remove mention that `dhall-to-json` could produce valid TOML documents

### DIFF
--- a/docs/howtos/How-to-integrate-Dhall.md
+++ b/docs/howtos/How-to-integrate-Dhall.md
@@ -43,12 +43,6 @@ You can convert Dhall to one of the following configuration formats if your lang
 
 * [XML](https://git.sr.ht/~singpolyma/dhall-xml-ruby) - Via the `dhall-to-xml` executable
 
-* TOML - Via the `dhall-to-json` executable
-
-  Dhall does not yet support conversion to TOML, but until then you may be able to work around this
-  by using the fact that TOML is a superset of JSON (assuming that you do not care about the appearance
-  of the intermediate configuration file).
-
 * [Bash](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall-bash/README.md) - Via the `dhall-to-bash` executable
 
   Technically not a "configuration format", but many programs are configured via Bash scripts


### PR DESCRIPTION
I don't believe that any JSON document is a valid TOML document:
The forms allowed at the top level are `key = value`, `[ table_name ]`, `[[ array_table_name ]]`. 
JSON objects (`{"a": "b"}`), arrays (`[1, 2, 3]`) or values fit neither.
Inline tables may looks similar, but they're only available in the place of `value` in the previous example, and their keys are separated from their values by `=`.

Closes #1125

Thank you