### PR TITLE
Add Prelude v21.0.0 package to store

### DIFF
--- a/nixops/packages/Prelude_21_0_0.nix
+++ b/nixops/packages/Prelude_21_0_0.nix
@@ -1,0 +1,15 @@
+{ buildDhallGitHubPackage }:
+  buildDhallGitHubPackage {
+    name = "Prelude";
+    githubBase = "github.com";
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    rev = "v21.0.0";
+    fetchSubmodules = false;
+    sha256 = "1v7p0vfr5dlbs4xak4699azv6b14qzfnbm8j8n5idv698zybmyis";
+    directory = "Prelude";
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [];
+    }

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -45,6 +45,7 @@ let
     Prelude_20_0_0
     Prelude_20_1_0
     Prelude_20_2_0
+    Prelude_21_0_0
   ];
 
   toListItem =


### PR DESCRIPTION
v21.0.0 didn't get added to store.dhall-lang.org  IDK if someone much, much better at CI than I am can ensure we check for this in the future?  :rofl: 