### PR TITLE
Fix broken links in TOCs

### DIFF
--- a/standard/beta-normalization.md
+++ b/standard/beta-normalization.md
@@ -74,7 +74,7 @@ is the same.
 * [Unions](#unions)
 * [`Integer`](#integer)
 * [`Double`](#double)
-* [`Date`/`Time`/`TimeZone`](#date-time-timezone)
+* [`Date`/`Time`/`TimeZone`](#date--time--timezone)
 * [Functions](#functions)
 * [`let` expressions](#let-expressions)
 * [Type annotations](#type-annotations)

--- a/standard/type-inference.md
+++ b/standard/type-inference.md
@@ -30,7 +30,7 @@ normalize.
 * [`Bool`](#bool)
 * [`Natural`](#natural)
 * [`Text`](#text)
-* [`Date` / `Time` / `TimeZone`](#date-time-timezone)
+* [`Date` / `Time` / `TimeZone`](#date--time--timezone)
 * [`List`](#list)
 * [`Optional`](#optional)
 * [Records](#records)


### PR DESCRIPTION
GitHub decided that the link needs double hyphens, probably because of the slashes.

I verified that the rest of the links in these documents work.