### PR TITLE
Update Dhall

### DIFF
--- a/nixops/dhall-haskell-old.json
+++ b/nixops/dhall-haskell-old.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/dhall-lang/dhall-haskell.git",
+  "rev": "8f62fdf6b267d98273ec701b3079e80305b83ce1",
+  "date": "2021-08-23T16:51:31-07:00",
+  "path": "/nix/store/wakyniph1sh5jpydry9gr2i6fkn4i99v-dhall-haskell-8f62fdf",
+  "sha256": "08izvsccnz8asaj1yhd9f9f2i27h0xls629gnp01lgdi4hk6h0hb",
+  "fetchSubmodules": true,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "8f62fdf6b267d98273ec701b3079e80305b83ce1",
-  "date": "2021-08-23T16:51:31-07:00",
-  "path": "/nix/store/wakyniph1sh5jpydry9gr2i6fkn4i99v-dhall-haskell-8f62fdf",
-  "sha256": "08izvsccnz8asaj1yhd9f9f2i27h0xls629gnp01lgdi4hk6h0hb",
+  "rev": "97f0cd8e9c25ff1dfed92597457bc985033c2f1f",
+  "date": "2021-09-14T17:39:40-07:00",
+  "path": "/nix/store/asis2v1yvzm28wgkhbjjlxbys1mnlhgl-dhall-haskell",
+  "sha256": "0c1nvwgnqqnmqf8rhmgr96zk8g0wfpx2n8js0n8fdl0xh4sllndb",
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false

--- a/nixops/overlay.nix
+++ b/nixops/overlay.nix
@@ -17,7 +17,8 @@ pkgsNew: pkgsOld: {
       '';
 
   dhall =
-    pkgsNew.haskell.lib.dontCheck pkgsNew.dhall-haskell-derivations.dhall;
+    pkgsNew.haskell.lib.dontCheck
+      (pkgsNew.dhall-haskell-derivations ./dhall-haskell.json).dhall;
 
   dhall-docs =
     pkgsNew.dhall-haskell-derivations.dhall-docs;
@@ -41,9 +42,9 @@ pkgsNew: pkgsOld: {
         touch $out
       '';
 
-  dhall-haskell-derivations =
+  dhall-haskell-derivations = file:
     let
-      json = builtins.fromJSON (builtins.readFile ./dhall-haskell.json);
+      json = builtins.fromJSON (builtins.readFile file);
 
       dhall-haskell =
         pkgsNew.fetchFromGitHub {
@@ -57,7 +58,9 @@ pkgsNew: pkgsOld: {
     in
       import "${dhall-haskell}/default.nix";
 
-  inherit (pkgsNew.dhall-haskell-derivations) dhall-try;
+  # We have to use an older build of Dhall since the latest version doesn't
+  # support GHCJS
+  inherit (pkgsNew.dhall-haskell-derivations ./dhall-haskell-old.json) dhall-try;
 
   dhallPackages = pkgsOld.dhallPackages.override (old: {
       overrides =

--- a/nixops/overlay.nix
+++ b/nixops/overlay.nix
@@ -21,7 +21,7 @@ pkgsNew: pkgsOld: {
       (pkgsNew.dhall-haskell-derivations ./dhall-haskell.json).dhall;
 
   dhall-docs =
-    pkgsNew.dhall-haskell-derivations.dhall-docs;
+    (pkgsNew.dhall-haskell-derivations ./dhall-haskell.json).dhall-docs;
 
   dhall-grammar =
     pkgsNew.runCommand


### PR DESCRIPTION
The main motivation for this change is so that Mac users can run
`./scripts/{generate-test-files,lint-prelude}.sh`.  The reason this
fixes things is that the latest version of `dhall-haskell` supports
Big Sur because it upgrades its Nixpkgs pin.

We have to use an older version of Dhall for dhall-lang.org, though,
until Nixpkgs supports GHCJS again.  However, that shouldn't be too
big of a deal since the website examples are stable and don't require
newer language features.