### PR TITLE
Fix parent imports when resolving `headers.dhall`

### DIFF
--- a/standard/imports.md
+++ b/standard/imports.md
@@ -619,7 +619,7 @@ resolve imports within the retrieved expression:
 
     headersPath = env:DHALL_HEADERS ? "${XDG_CONFIG_HOME}/dhall/headers.dhall" ? ~/.config/dhall/headers.dhall ? []
     Γ(headersPath) = userHeadersExpr
-    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
+    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁
     getKey(userHeaders, origin, []) = headers  ; Extract the first `mapValue` from `userHeaders`
                                                ; with a `mapValue` equal to `origin`,
                                                ; falling back to `[]` if no such key is found.
@@ -780,7 +780,7 @@ the resolved expression as additional headers supplied to the HTTP request:
 
     headersPath = env:DHALL_HEADERS ? "${XDG_CONFIG_HOME}/dhall/headers.dhall" ? ~/.config/dhall/headers.dhall ? []
     Γ(headersPath) = userHeadersExpr
-    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
+    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁
     getKey(userHeaders, origin, []) = headers  ; Extract the first `mapValue` from `userHeaders`
                                                ; with a `mapValue` equal to `origin`,
                                                ; falling back to `[]` if no such key is found.

--- a/standard/imports.md
+++ b/standard/imports.md
@@ -619,7 +619,7 @@ resolve imports within the retrieved expression:
 
     headersPath = env:DHALL_HEADERS ? "${XDG_CONFIG_HOME}/dhall/headers.dhall" ? ~/.config/dhall/headers.dhall ? []
     Γ(headersPath) = userHeadersExpr
-    (ε, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
+    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
     getKey(userHeaders, origin, []) = headers  ; Extract the first `mapValue` from `userHeaders`
                                                ; with a `mapValue` equal to `origin`,
                                                ; falling back to `[]` if no such key is found.
@@ -780,7 +780,7 @@ the resolved expression as additional headers supplied to the HTTP request:
 
     headersPath = env:DHALL_HEADERS ? "${XDG_CONFIG_HOME}/dhall/headers.dhall" ? ~/.config/dhall/headers.dhall ? []
     Γ(headersPath) = userHeadersExpr
-    (ε, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
+    (Δ, parent, headersPath) × Γ₀ ⊢ userHeadersExpr ⇒ userHeaders ⊢ Γ₁  ; Resolve userHeadersExpr with an empty import context
     getKey(userHeaders, origin, []) = headers  ; Extract the first `mapValue` from `userHeaders`
                                                ; with a `mapValue` equal to `origin`,
                                                ; falling back to `[]` if no such key is found.


### PR DESCRIPTION
The motivation for this change is the discussion here:

https://github.com/dhall-lang/dhall-haskell/pull/2236#discussion_r712321118

If we correctly set the parent import for the `headers.dhall`
expression then the cyclic import detection will correctly reject
loops induced by `headers.dhall` having transitive remote imports
of its own.