### PR TITLE
Upgrade discourse again

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -424,7 +424,7 @@ in
 
               db_work_mem: "40MB"
 
-              version: 25097fa0af9927d4fb43a5b195951c8c533acf02
+              version: ae91818c194a79b9a5216f2a2709a331f3509207
 
             env:
               LANG: en_US.UTF-8


### PR DESCRIPTION
This is to pull in discourse/discourse@010309d1084d5ac54d9f62eefa7ef100721fd1c8 which is a
security fix.  There was an announcement here:
https://meta.discourse.org/t/2-7-9-security-release/206588

The vulnerability is RCE and the exploit is documented here:
https://0day.click/recipe/discourse-sns-rce/