### PR TITLE
Fix prelude.dhall-lang.org

### DIFF
--- a/nixops/packages/Prelude_21_1_0.nix
+++ b/nixops/packages/Prelude_21_1_0.nix
@@ -1,0 +1,15 @@
+{ buildDhallGitHubPackage }:
+  buildDhallGitHubPackage {
+    name = "Prelude";
+    githubBase = "github.com";
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    rev = "v21.1.0";
+    fetchSubmodules = false;
+    sha256 = "0ml2hv934lj3fl07mfkir6387z9sz5n62mm1k46sx5mbs6nhmcpd";
+    directory = "Prelude";
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [];
+    }

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -46,6 +46,7 @@ let
     Prelude_20_1_0
     Prelude_20_2_0
     Prelude_21_0_0
+    Prelude_21_1_0
   ];
 
   toListItem =


### PR DESCRIPTION
I accidentally bumped the Prelude version in #1236 before the package
was available