### PR TITLE
require whitespace after let-binding

### DIFF
--- a/standard/Parser.hs
+++ b/standard/Parser.hs
@@ -1696,7 +1696,7 @@ letBinding = do
 
     a <- expression
 
-    whsp
+    whsp1
 
     return (x, mA, a)
 

--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -846,7 +846,7 @@ expression =
 annotated-expression = operator-expression [ whsp ":" whsp1 expression ]
 
 ; "let x = e1"
-let-binding = let whsp1 nonreserved-label whsp [ ":" whsp1 expression whsp ] "=" whsp expression whsp
+let-binding = let whsp1 nonreserved-label whsp [ ":" whsp1 expression whsp ] "=" whsp expression whsp1
 
 ; "[] : t"
 empty-list-literal =

--- a/tests/parser/failure/spacing/LetNoSpace3.dhall
+++ b/tests/parser/failure/spacing/LetNoSpace3.dhall
@@ -1,0 +1,1 @@
+let x = NaNin x

--- a/tests/parser/failure/spacing/LetNoSpace4.dhall
+++ b/tests/parser/failure/spacing/LetNoSpace4.dhall
@@ -1,0 +1,1 @@
+let x = 3let y = x in y


### PR DESCRIPTION
The whitespace after a let-binding is currently optional, this allows expressions like the following: 
```
let x = 3let y = x in y
```
```
let x = NaNin x
```
The reference implementation accepts these expressions while the `dhall-haskell` rejects them.
Surprisingly 
```
let x = Truein x
```
is also rejected by the reference implementation. 
To avoid such inconsistencies and confusing expressions, I'd suggest changing the dhall grammar to require whitespace after the let-binding.