### PR TITLE
Fix header forwarding test

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -319,14 +319,19 @@ in
             pkgs.lib.mkMerge
               [ prelude
 
-                # Same as `prelude.dhall-lang.org` except requires a header named
-                # `Test` to be present to authorize requests.  This is used to test
-                # support for header forwarding for the test suite.
-                { locations."/".extraConfig = ''
-                    if ($http_test = "") {
-                      return 403;
-                    }
-                  '';
+                # This is used to test support for header forwarding for the
+                # test suite.
+                { locations = {
+                    "/foo".extraConfig = ''
+                      if ($http_test = "") {
+                        return 403;
+                      }
+                      return 200 './bar';
+                    '';
+
+                    "/bar".extraConfig = ''
+                      return 200 'True';
+                    '';
                 }
 
                 # A random string to test caching behavior

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -332,6 +332,7 @@ in
                     "/bar".extraConfig = ''
                       return 200 'True';
                     '';
+                  };
                 }
 
                 # A random string to test caching behavior

--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -330,6 +330,9 @@ in
                     '';
 
                     "/bar".extraConfig = ''
+                      if ($http_test = "") {
+                        return 403;
+                      }
                       return 200 'True';
                     '';
                   };

--- a/tests/import/success/headerForwardingA.dhall
+++ b/tests/import/success/headerForwardingA.dhall
@@ -1,16 +1,12 @@
 {- This test verifies that header-forwarding works correctly for relative
    imports within the same domain
 
-   `test.dhall-lang.org` is the same as `prelude.dhall-lang.org` except that
-   `test.dhall-lang.org` rejects all requests without a `Test` header.
+   `test.dhall-lang.org/foo` returns `./bar` and `test.dhall-lang.org/foo`
+   returns `True`, and both URLs reject all requests without a `Test` header.
 
    This test requires that the initial import to
    `https://test.dhall-lang.org/Bool/package.dhall` forwards the `Test` header
    to the transitive relative imports of `https://test.dhall-lang.org/Bool/*` in
    order to succeed.
-
-   Note: You will need to update this test whenever the `Bool` package in the
-   Prelude changes (sorry)
 -}
-https://test.dhall-lang.org/Bool/package.dhall
-  using [ { mapKey = "Test", mapValue = "Example" } ]
+https://test.dhall-lang.org/foo using (toMap { Test = "" })

--- a/tests/import/success/headerForwardingA.dhall
+++ b/tests/import/success/headerForwardingA.dhall
@@ -5,8 +5,8 @@
    returns `True`, and both URLs reject all requests without a `Test` header.
 
    This test requires that the initial import to
-   `https://test.dhall-lang.org/Bool/package.dhall` forwards the `Test` header
-   to the transitive relative imports of `https://test.dhall-lang.org/Bool/*` in
+   `https://test.dhall-lang.org/foo` forwards the `Test` header
+   to the transitive relative import of `https://test.dhall-lang.org/bar` in
    order to succeed.
 -}
 https://test.dhall-lang.org/foo using (toMap { Test = "Example" })

--- a/tests/import/success/headerForwardingA.dhall
+++ b/tests/import/success/headerForwardingA.dhall
@@ -9,4 +9,4 @@
    to the transitive relative imports of `https://test.dhall-lang.org/Bool/*` in
    order to succeed.
 -}
-https://test.dhall-lang.org/foo using (toMap { Test = "" })
+https://test.dhall-lang.org/foo using (toMap { Test = "Example" })

--- a/tests/import/success/headerForwardingB.dhall
+++ b/tests/import/success/headerForwardingB.dhall
@@ -1,18 +1,1 @@
-{ and =
-    λ(_ : List Bool) →
-      List/fold Bool _ Bool (λ(_ : Bool) → λ(_ : Bool) → _@1 && _) True
-, build = λ(_ : Type → _ → _@1 → _@2) → _ Bool True False
-, even =
-    λ(_ : List Bool) →
-      List/fold Bool _ Bool (λ(_ : Bool) → λ(_ : Bool) → _@1 == _) True
-, fold =
-    λ(_ : Bool) → λ(_ : Type) → λ(_ : _) → λ(_ : _@1) → if _@3 then _@1 else _
-, not = λ(_ : Bool) → _ == False
-, odd =
-    λ(_ : List Bool) →
-      List/fold Bool _ Bool (λ(_ : Bool) → λ(_ : Bool) → _@1 != _) False
-, or =
-    λ(_ : List Bool) →
-      List/fold Bool _ Bool (λ(_ : Bool) → λ(_ : Bool) → _@1 || _) False
-, show = λ(_ : Bool) → if _ then "True" else "False"
-}
+True


### PR DESCRIPTION
Partial fix for #1260

The `nginx` configuration for `test.dhall-lang.org` wasn't correctly
checking the headers because the fully materialized configuration
looked like this:

```
server {
        …
        server_name test.dhall-lang.org ;
        …
        location / {
                proxy_pass https://raw.githubusercontent.com;
                …
                rewrite ^/?$ https://store.dhall-lang.org/Prelude-v21.1.0 redire
ct;
                rewrite ^/(v[^/]+)$ https://github.com/dhall-lang/dhall-lang/tre
e/$1/Prelude redirect;
                rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 br
eak;
                rewrite ^/(.*)$ /dhall-lang/dhall-lang/v21.1.0/Prelude/$1 break;
                if ($http_test = "") {
                        return 403;
                }
        }
```

… and the `rewrite` rules were taking precedence over the `http_test` check.

This change fixes that by redoing the test such that only
`test.dhall-lang.org/{foo,bar}` require the `Test` header and those two
imports are used for the test instead.  A side benefit of this change is
that the test is now not as brittle (since it won't break if we
change `Prelude/Bool/package.dhall`)