### PR TITLE
CORS tests: add Access-Control-Allow-Origin header to GET requests on test.dhall-lang.com

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -352,6 +352,9 @@ in
                       return 204;
                     }
                     if ($request_method = 'GET') {
+                      ${lib.optionalString (cors != null) ''
+                        add_header 'Access-Control-Allow-Origin' "${cors}";
+                      ''}
                       add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
                     }
                     echo "${contents}";


### PR DESCRIPTION
The import/success tests related to CORS are failing for dhall-unison, because for the resources on test.dhall-lang.org that are accessed in these tests, the CORS header `Access-Control-Allow-Origin` is only set for OPTIONS requests, not for GET requests.

If I understood the code correctly, these tests are also excluded from the dhall-haskell test suite: https://github.com/dhall-lang/dhall-haskell/blob/master/dhall/tests/Dhall/Test/Import.hs#L87

The dhall import spec does not require preflight requests for cross-domain calls. And even if we would follow the fetch specification, a GET request without additional headers would still not require a preflight request. 
Only if custom or Authorization headers come into play it gets more interesting. 

But as a first step, checking the response headers as described in the import spec and testing this behavior would be an improvement.

This PR adds the same Access-Control-Allow-Origin header to GET as for OPTIONS requests. Unfortunately, I don't have a linux box available at the moment where I could verify the change.
