### PR TITLE
Include schema in the Access-Control-Allow-Origin header value

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -390,9 +390,9 @@ in
 
                 in {
                   locations."/cors/AllowedAll.dhall".extraConfig = cors-endpoint "*" "42";
-                  locations."/cors/OnlyGithub.dhall".extraConfig = cors-endpoint "raw.githubusercontent.com" "42";
-                  locations."/cors/OnlySelf.dhall".extraConfig = cors-endpoint "test.dhall-lang.org" "42";
-                  locations."/cors/OnlyOther.dhall".extraConfig = cors-endpoint "example.com" "42";
+                  locations."/cors/OnlyGithub.dhall".extraConfig = cors-endpoint "https://raw.githubusercontent.com" "42";
+                  locations."/cors/OnlySelf.dhall".extraConfig = cors-endpoint "https://test.dhall-lang.org" "42";
+                  locations."/cors/OnlyOther.dhall".extraConfig = cors-endpoint "https://example.com" "42";
                   locations."/cors/Empty.dhall".extraConfig = cors-endpoint "" "42";
                   locations."/cors/NoCORS.dhall".extraConfig = cors-endpoint null "42";
                   # Included because some clients apparently sometimes misparse "null" in CORS.


### PR DESCRIPTION
The deployment of https://github.com/dhall-lang/dhall-lang/pull/1265 fixed 3 of the import/success/cors tests 🎉, but I found another issue in the configuration for test.dhall-lang.org. 
The cors headers for specific domains currently don't include the "https://" prefix, which is required by the fetch spec and also the dhall import spec (https://github.com/dhall-lang/dhall-lang/blob/master/standard/imports.md#cors)

```
$ curl -v https://test.dhall-lang.org/cors/OnlyGithub.dhall
...
< HTTP/2 200
< server: nginx
< date: Tue, 25 Jan 2022 22:10:36 GMT
< content-type: application/octet-stream
< access-control-allow-origin: raw.githubusercontent.com