### PR TITLE
Expand tests of reference implementation

### DIFF
--- a/standard/standard.cabal
+++ b/standard/standard.cabal
@@ -65,3 +65,4 @@ test-suite tasty
   default-extensions:  OverloadedStrings
   default-language:    Haskell2010
   ghc-options:         -Wall
+  other-modules: Test.Parser, Test.Util, Test.AlphaNormalization

--- a/standard/syntax.md
+++ b/standard/syntax.md
@@ -254,7 +254,7 @@ data Expression
       -- ^ > Some s
     | Builtin Builtin
     | Constant Constant
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | Associative binary operators
 data Operator
@@ -271,7 +271,7 @@ data Operator
     | NotEqual            -- ^ > !=
     | Equivalent          -- ^ > ===
     | Alternative         -- ^ > ?
-    deriving (Show)
+    deriving (Show, Eq)
 
 {-| Data structure used to represent an interpolated @Text@ literal
 
@@ -286,7 +286,7 @@ data Operator
     > TextLiteral [("foo", Variable "x" 0), ("bar", Variable "y" 0)] "baz"
 -}
 data TextLiteral = Chunks [(Text, Expression)] Text
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | This instance comes in handy for implementing @Text@-related operations
 instance Semigroup TextLiteral where
@@ -336,7 +336,7 @@ data Builtin
     | Date
     | Time
     | TimeZone
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | Type-checking constants
 data Constant
@@ -351,7 +351,7 @@ data ImportMode
     | RawText   -- ^ @as Text@: import the path as raw text
     | Location  -- ^ @as Location@: don't import and instead represent the path
                 --   as a Dhall expression
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | Where to locate the import
 data ImportType
@@ -366,7 +366,7 @@ data ImportType
         --   > ~/directory/file
     | Env Text
         -- ^ > env:x
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | Structured representation of an HTTP(S) URL
 data URL = URL
@@ -375,13 +375,13 @@ data URL = URL
     , path      :: File
     , query     :: Maybe Text
     }
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | The URL scheme
 data Scheme
     = HTTP  -- ^ > http:\/\/
     | HTTPS -- ^ > https:\/\/
-    deriving (Show)
+    deriving (Show, Eq)
 
 -- | The anchor for a local filepath
 data FilePrefix
@@ -389,7 +389,7 @@ data FilePrefix
     | Here      -- ^ @.@, a path relative to the current working directory
     | Parent    -- ^ @..@, a path relative to the parent working directory
     | Home      -- ^ @~@, a path relative to the user's home directory
-    deriving (Show)
+    deriving (Show, Eq)
 
 {-| Structured representation of a file path
 
@@ -402,10 +402,10 @@ data File = File
     { directory :: [Text]  -- ^ Directory path components (in reverse order)
     , file :: Text         -- ^ File name
     }
-    deriving (Show)
+    deriving (Show, Eq)
 
 data PathComponent
     = Label Text
     | DescendOptional
-    deriving (Show)
+    deriving (Show, Eq)
 ```

--- a/standard/tasty/Main.hs
+++ b/standard/tasty/Main.hs
@@ -1,96 +1,17 @@
-{-# LANGUAGE BlockArguments #-}
-
 module Main where
 
-import Codec.CBOR.Term (Term(..))
-import System.FilePath ((</>))
-import Test.Tasty (TestTree)
-
-import qualified Binary
-import qualified Codec.Serialise           as Serialise
-import qualified Data.Text                 as Text
-import qualified Data.Text.IO              as Text.IO
-import qualified Parser
-import qualified System.Directory          as Directory
-import qualified System.Environment        as Environment
-import qualified System.FilePath           as FilePath
-import qualified Text.Megaparsec           as Megaparsec
-import qualified Test.Tasty.HUnit          as HUnit
-import qualified Test.Tasty                as Tasty
-
-fileToTestTree :: FilePath -> TestTree
-fileToTestTree prefix = do
-    let inputFile  = prefix <> "A.dhall"
-    let outputFile = prefix <> "B.dhallb"
-
-    let name = FilePath.takeBaseName inputFile
-
-    HUnit.testCase name do
-
-        input <- Text.IO.readFile inputFile
-
-        let parser = Parser.unParser do
-                e <- Parser.completeExpression
-
-                Megaparsec.eof
-
-                return e
-
-        expression <- case Megaparsec.runParser parser inputFile input of
-           Left  errors     -> fail (Megaparsec.errorBundlePretty errors)
-           Right expression -> return expression
-
-        expectedTerm <- Serialise.readFileDeserialise outputFile
-
-        let actualTerm = Binary.encode expression
-
-        assertEqualIncludingNaN "Parsing test failure" expectedTerm actualTerm
-
--- | We need this because `NaN /= NaN`.  Grr…
-assertEqualIncludingNaN :: String -> Term -> Term -> IO ()
-assertEqualIncludingNaN _ (THalf l) (THalf r)
-    | isNaN l && isNaN r =
-        return ()
-assertEqualIncludingNaN message expected actual =
-    HUnit.assertEqual message expected actual
-
-inputFileToPrefix :: FilePath -> Maybe FilePath
-inputFileToPrefix inputFile =
-    fmap Text.unpack (Text.stripSuffix "A.dhall" (Text.pack inputFile))
-
-directoryToTestTree :: FilePath -> IO TestTree
-directoryToTestTree directory = do
-    let name = FilePath.takeBaseName directory
-
-    children <- Directory.listDirectory directory
-
-    let process child = do
-            let childPath = directory </> child
-
-            isDirectory <- Directory.doesDirectoryExist childPath
-
-            if isDirectory
-                then do
-                    testTree <- directoryToTestTree childPath
-
-                    return [ testTree ]
-
-                else do
-                    case inputFileToPrefix childPath of
-                        Just prefix -> do
-                            return [ fileToTestTree prefix ]
-
-                        Nothing -> do
-                            return [ ]
-
-    testTreess <- traverse process children
-
-    return (Tasty.testGroup name (concat testTreess))
+import qualified System.Environment      as Environment
+import qualified Test.AlphaNormalization
+import qualified Test.Parser
+import qualified Test.Tasty              as Tasty
 
 main :: IO ()
 main = do
     Environment.setEnv "TASTY_HIDE_SUCCESSES" "true"
 
-    testTree <- directoryToTestTree "../tests/parser/success"
+    parserTests <- Test.Parser.parserTests
+    alphaNormalizationTests <- Test.AlphaNormalization.alphaNormalizationTests
 
-    Tasty.defaultMain testTree
+    let tests = Tasty.testGroup "tests" [ parserTests, alphaNormalizationTests ]
+
+    Tasty.defaultMain tests

--- a/standard/tasty/Test/AlphaNormalization.hs
+++ b/standard/tasty/Test/AlphaNormalization.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Test.AlphaNormalization (alphaNormalizationTests) where
+import           AlphaNormalization (alphaNormalize)
+import qualified Data.Text.IO       as Text.IO
+import           Test.Tasty         (TestTree)
+import qualified Test.Tasty         as Tasty
+import qualified Test.Tasty.HUnit   as HUnit
+import           Test.Util          (TestFileType (Dhall),
+                                     directoryToSuccessTestTree,
+                                     parseDhallOrFail)
+
+successTests :: IO TestTree
+successTests = directoryToSuccessTestTree "../tests/alpha-normalization/success" Dhall Dhall \inputFile outputFile -> do
+  output <- Text.IO.readFile outputFile
+  input <- Text.IO.readFile inputFile
+
+  outputExpression <- parseDhallOrFail outputFile output
+  inputExpression <- parseDhallOrFail inputFile input
+
+  let expectedExpression = alphaNormalize outputExpression
+  let actualExpression   = alphaNormalize inputExpression
+
+  HUnit.assertEqual "Alpha normalization test failure" expectedExpression actualExpression
+
+alphaNormalizationTests :: IO TestTree
+alphaNormalizationTests = Tasty.testGroup "alpha normalization" <$> sequence [ successTests ]

--- a/standard/tasty/Test/Parser.hs
+++ b/standard/tasty/Test/Parser.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE BlockArguments #-}
+
+module Test.Parser where
+
+import qualified Binary
+import           Codec.CBOR.Term  (Term (..))
+import qualified Codec.Serialise  as Serialise
+import qualified Data.Text.IO     as Text.IO
+import           Test.Tasty       (TestTree)
+import qualified Test.Tasty       as Tasty
+import qualified Test.Tasty.HUnit as HUnit
+import           Test.Util        (TestFileType (..),
+                                   directoryToFailureTestTree,
+                                   directoryToSuccessTestTree, parseDhall,
+                                   parseDhallOrFail)
+
+-- | We need this because `NaN /= NaN`.  Grr…
+assertEqualIncludingNaN :: String -> Term -> Term -> IO ()
+assertEqualIncludingNaN _ (THalf l) (THalf r)
+    | isNaN l && isNaN r =
+        return ()
+assertEqualIncludingNaN message expected actual =
+    HUnit.assertEqual message expected actual
+
+successTests :: IO TestTree
+successTests = directoryToSuccessTestTree "../tests/parser/success" Dhall Dhallb \inputFile outputFile -> do
+  input <- Text.IO.readFile inputFile
+
+  expression <- parseDhallOrFail inputFile input
+
+  expectedTerm <- Serialise.readFileDeserialise outputFile
+
+  let actualTerm = Binary.encode expression
+
+  assertEqualIncludingNaN "Parsing test failure" expectedTerm actualTerm
+
+failureTests :: IO TestTree
+failureTests = directoryToFailureTestTree "../tests/parser/failure" Dhall \inputFile -> do
+  input <- Text.IO.readFile inputFile
+
+  case parseDhall inputFile input of
+      Left  _ -> return ()
+      Right _ -> HUnit.assertFailure "Unexpected successful parse"
+
+parserTests :: IO TestTree
+parserTests = Tasty.testGroup "parser" <$> sequence [ successTests, failureTests ]

--- a/standard/tasty/Test/Util.hs
+++ b/standard/tasty/Test/Util.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE BlockArguments #-}
+module Test.Util (directoryToSuccessTestTree, directoryToFailureTestTree, TestFileType(..), parseDhall, parseDhallOrFail) where
+
+import           Data.Text        (Text)
+import qualified Data.Text        as Text
+import           Data.Void        (Void)
+import qualified Parser
+import           Syntax           (Expression)
+import qualified System.Directory as Directory
+import           System.FilePath  (takeBaseName, (</>))
+import qualified System.FilePath  as FilePath
+import           Test.Tasty       (TestTree)
+import qualified Test.Tasty       as Tasty
+import           Test.Tasty.HUnit (Assertion)
+import qualified Test.Tasty.HUnit as HUnit
+import qualified Text.Megaparsec  as Megaparsec
+
+parseDhall :: FilePath -> Text -> Either (Megaparsec.ParseErrorBundle Text Void) Expression
+parseDhall = Megaparsec.runParser (Parser.unParser (Parser.completeExpression <* Megaparsec.eof))
+
+parseDhallOrFail :: MonadFail m => FilePath -> Text -> m Expression
+parseDhallOrFail inputFile input =
+  case parseDhall inputFile input of
+    Left  errors     -> fail (Megaparsec.errorBundlePretty errors)
+    Right expression -> return expression
+
+inputFileToPrefix :: FilePath -> Text -> Maybe FilePath
+inputFileToPrefix inputFile suffix =
+    fmap Text.unpack (Text.stripSuffix suffix (Text.pack inputFile))
+
+data TestFileType = Dhall | Dhallb
+
+directoryToSuccessTestTree :: FilePath -> TestFileType -> TestFileType -> (FilePath -> FilePath -> Assertion) -> IO TestTree
+directoryToSuccessTestTree directory inputType outputType fileToTestTree = do
+    let name = FilePath.takeBaseName directory
+
+    children <- Directory.listDirectory directory
+
+    let process child = do
+            let childPath = directory </> child
+
+            isDirectory <- Directory.doesDirectoryExist childPath
+
+            if isDirectory
+                then do
+                    testTree <- directoryToSuccessTestTree childPath inputType outputType fileToTestTree
+
+                    return [ testTree ]
+
+                else do
+                    let inputSuffix = case inputType of
+                          Dhall  -> "A.dhall"
+                          Dhallb -> "A.dhallb"
+
+                    let outputSuffix = case outputType of
+                          Dhall  -> "B.dhall"
+                          Dhallb -> "B.dhallb"
+
+                    case inputFileToPrefix childPath inputSuffix of
+                        Just prefix ->
+                          return [ HUnit.testCase (takeBaseName prefix) (fileToTestTree childPath (prefix ++ outputSuffix)) ]
+
+                        Nothing -> do
+                            return [ ]
+
+    testTreess <- traverse process children
+
+    return (Tasty.testGroup name (concat testTreess))
+
+directoryToFailureTestTree :: FilePath -> TestFileType -> (FilePath -> Assertion) -> IO TestTree
+directoryToFailureTestTree directory inputType fileToTestTree = do
+    let name = FilePath.takeBaseName directory
+
+    children <- Directory.listDirectory directory
+
+    let process child = do
+            let childPath = directory </> child
+
+            isDirectory <- Directory.doesDirectoryExist childPath
+
+            if isDirectory
+                then do
+                    testTree <- directoryToFailureTestTree childPath inputType fileToTestTree
+
+                    return [ testTree ]
+
+                else do
+                    return [ HUnit.testCase (takeBaseName childPath) (fileToTestTree childPath) ]
+
+
+    testTreess <- traverse process children
+
+    return (Tasty.testGroup name (concat testTreess))


### PR DESCRIPTION
As part of the effort to mechanize the standard (https://github.com/dhall-lang/dhall-lang/issues/959), expand the tasty tests run against the Haskell reference implementation. In particular:
* Generalize the current test code which only runs the parser success tests
* Run parser failure tests
* Run alpha normalization tests

A few notes:
* I'm not satisfied with the quality/duplication of `directoryToSuccessTestTree` and `directoryToFailureTestTree`, so feel free to suggest/push improvements there.
* I added an `Eq` instance for `Expression` which may not be desirable (since it's purely syntactic equality, which may be misleading)
* Five of the tests fail! I _think_ that all but one uncover actual issues in the reference impl. Let me know if you would like those to be fixed in this PR or separately.