### PR TITLE
Fix IPv6 support for Linode

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -80,6 +80,8 @@ in
     '';
   };
 
+  networking.tempAddresses = "disabled";
+
   networking.firewall.allowedTCPPorts = [ 22 80 443 ];
 
   nix = {
@@ -178,18 +180,6 @@ in
 
       recommendedTlsSettings = true;
 
-      # For some reason nginx fails to forward HTTP requests to GitHub when
-      # using IPv6.  See:
-      #
-      #     https://github.com/dhall-lang/dhall-lang/issues/1268
-      #
-      # Perhaps a better solution would have been to ensure that the local
-      # `nscd` service only returns IPv6 addresses, but I can't find any
-      # documentation specifying how to do that.
-      appendHttpConfig = ''
-        resolver 127.0.0.1 ipv6=off;
-      '';
-
       virtualHosts =
         let
           latestRelease = "v21.1.0";
@@ -220,15 +210,9 @@ in
                 rewrite ^/(v[^/]+)$ https://github.com/dhall-lang/dhall-lang/tree/$1/Prelude redirect;
                 rewrite ^/(v[^/]+)/(.*)$ /dhall-lang/dhall-lang/$1/Prelude/$2 break;
                 rewrite ^/(.*)$ /dhall-lang/dhall-lang/${latestRelease}/Prelude/$1 break;
-                # Even though we set the resolver to disable IPv6 above, that
-                # still only affects dynamic DNS resolution and nginx (as far as
-                # I know) doesn't have an option to disable IPv6 when resolving
-                # DNS addresses at startup time.  See:
-                #
-                #     https://serverfault.com/a/1006465
-                set $empty "";
-                proxy_pass https://raw.githubusercontent.com$empty;
               '';
+
+              proxyPass = "https://raw.githubusercontent.com";
             };
           };
 


### PR DESCRIPTION
Fixes https://github.com/dhall-lang/dhall-lang/issues/1268

The root cause behind the recent IPv6-related issues was due to this
requirement from Linode's documentation:

> If your Linode does not have the correct IPv6 address or any IPv6
> address at all, you should verify that you have router
> advertisements enabled and **IPv6 privacy extensions disabled**.

Emphasis mine

That is what the `networking.tempAddresses = "disabled"` option does,
and setting that option + a reboot fixed everything.