### PR TITLE
Remove Unicode char `±` from ABNF (again)

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -529,17 +529,17 @@ integer-literal = ( "+" / "-" ) natural-literal
 ; seconds field is always 0-59.
 ;
 temporal-literal =
-    ; "YYYY-MM-DDThh:mm:ss±HH:MM", parsed as a `{ date : Date, time : Time, timeZone : TimeZone }`
+    ; "YYYY-MM-DDThh:mm:ss[+-]HH:MM", parsed as a `{ date : Date, time : Time, timeZone : TimeZone }`
       full-date "T" partial-time time-offset
     ; "YYYY-MM-DDThh:mm:ss", parsed as a `{ date : Date, time : Time }`
     / full-date "T" partial-time
-    ; "hh:mm:ss±HH:MM", parsed as a `{ time : Time, timeZone, TimeZone }`
+    ; "hh:mm:ss[+-]HH:MM", parsed as a `{ time : Time, timeZone, TimeZone }`
     / partial-time time-offset
     ; "YYYY-MM-DD", parsed as a `Date`
     / full-date
     ; "hh:mm:ss", parsed as a `Time`
     / partial-time
-    ; "±HH:MM", parsed as a `TimeZone`
+    ; "[+-]HH:MM", parsed as a `TimeZone`
     ;
     ; Carefully note that this `time-numoffset` and not `time-offset`, meaning
     ; that a standalone `Z` is not a valid Dhall literal for a `TimeZone`


### PR DESCRIPTION
This was a regression for issue #1003 introduced by the comments included in #1191.  (#1004 previously removed Unicode.)

I've used `[+-]` in lieu of the `±` char, but obviously if people feel there is a better way to indicate this choice (e.g. the ABNF-y `( "+" / "-" )` it could be changed.