### PR TITLE
Menu scrolling on screens with low height

### DIFF
--- a/nixops/index.html
+++ b/nixops/index.html
@@ -60,6 +60,13 @@
       header {
         margin-bottom: 2rem;
       }
+
+      @media (min-width: 992px) {
+        .dropdown-menu {
+          max-height: calc(100vh - 85px);
+          overflow-y:auto;
+        }
+      }     
     </style>
     <link rel="stylesheet" href="./css/codemirror.css">
     <link rel="stylesheet" href="./css/bootstrap.min.css">


### PR DESCRIPTION
Currently when the browser window has small height (in particular on screens of low height) long dropdown menus (like "How-to guides") extend beyond the lower edge of the browser window (I don't know how to describe this precisely I'm not a frontend dev). To see the last items in the menu (at least on my Firefox browser on Linux) I have to scroll to the very bottom of the page, which is rather annoying.

To reproduce this, open https://dhall-lang.org/, open the "How-to guides" dropdown menu and then resize the browser window reducing its height below the height of the menu.

In this PR I modify this behavior: when the screen height is low, a dropdown menu that is long enough (i.e. longer than view height minus `85px`) gets a vertical scrollbar. (The value `85px` was found by experiment; it works for me. I don't know how frontend devs find such values.) For low width screens, when bootstrap hides the menu under a button (`min-width: 992px`, this value comes from bootstrap's documentation), I preserve the present behavior. 