### PR TITLE
Update Getting-started_Generate-JSON-or-YAML.md

### DIFF
--- a/docs/tutorials/Getting-started_Generate-JSON-or-YAML.md
+++ b/docs/tutorials/Getting-started_Generate-JSON-or-YAML.md
@@ -100,7 +100,7 @@ the latest available version of `dhall-json`.  Then navigate to the directory wh
 downloaded the archive and run:
 
 ```console
-$ tar --extract --bzip2 --file dhall-json-*-x86_64-macos.tar.bz2
+$ tar --extract --file dhall-json-*-x86_64-macos.tar.bz2
 ```
 
 That should create a `./bin` subdirectory underneath your current directory
@@ -143,7 +143,7 @@ the latest available version of `dhall-json`.  Then navigate to the directory wh
 downloaded the archive and run:
 
 ```console
-$ tar --extract --bzip2 --file dhall-json-*-x86_64-linux.tar.bz2
+$ tar --extract --file dhall-json-*-x86_64-linux.tar.bz2
 ```
 
 That should create a `./bin` subdirectory underneath your current directory


### PR DESCRIPTION
When going through the getting started steps for Linux, I used the command for extraction:

```console
$ tar --extract --bzip2 --file dhall-json-*-x86_64-linux.tar.bz2
```

and was hit with the error:

```
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

Running the command without the explicit `--bzip2` flag was successful. 

I ran `bzip2 --test` on the file and came back with

```
bzip2: dhall-json-1.7.11-x86_64-Linux.tar.bz2: bad magic number (file not created by bzip2)
```

So it looks like the tar file isn't being compressed for the released files?

Anyways, GNU tar should automatically handle the decompression without the explicit flag.