### PR TITLE
Re-enable self-deploy

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -543,9 +543,7 @@ in
         build = "${repositoryDirectory}/result";
 
       in
-        { enable = false;
-
-          wantedBy = [ "multi-user.target" ];
+        { wantedBy = [ "multi-user.target" ];
 
           after = [ "network-online.target" ];
 


### PR DESCRIPTION
In #1300 I accidentally disabled `self-deploy`.  This
change re-renables it.