### PR TITLE
Remove top-level hydra authorization

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -128,7 +128,6 @@ in
           authorization = dhall-lang
           context = hydra
         </githubstatus>
-        github_authorization = dhall-lang
         binary_cache_secret_key_file = ${nixServe.privateKey}
       '';
 


### PR DESCRIPTION
This was breaking Hydra's support for updating GitHub statuses

The correct setting is `github_authorization.owner`, but
we don't even need this anyway and we can delete it in favor
of the authorization from the `github_status` section.