### PR TITLE
Fix logrotate configuration

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -149,7 +149,7 @@ in
     logrotate = {
       enable = true;
 
-      configFile = ''
+      configFile = pkgs.writeText "logrotate.conf" ''
         /var/spool/nginx/logs/*.log {
           create 0644 nginx nginx
           daily


### PR DESCRIPTION
This fixes breakage introduced by #1300 with respect to log
rotation.

The `services.logrotate.configFile` option is supposed to be
a file and not the contents of the file.   Wrapping the option
in `pkgs.writeText` fixes this.