### PR TITLE
apply type on None to make a valid dhall expression

### DIFF
--- a/tests/normalization/success/unit/WithOnOptionalNoneA.dhall
+++ b/tests/normalization/success/unit/WithOnOptionalNoneA.dhall
@@ -1,1 +1,1 @@
-None with ? = 1
+(None Natural) with ? = 1

--- a/tests/normalization/success/unit/WithOnOptionalNoneB.dhall
+++ b/tests/normalization/success/unit/WithOnOptionalNoneB.dhall
@@ -1,1 +1,1 @@
-None
+None Natural


### PR DESCRIPTION
While upgrading the dhall-unison implementation to dhall version 22, I couldn't get the `normalization/success/unit/WithOnOptionalNone` test case to pass and actually think that the test is not correct.

Applying a type to None makes the source expression type-check and also matches the deduction rules in https://github.com/dhall-lang/dhall-lang/blob/master/standard/beta-normalization.md#with-expressions
