### PR TITLE
Add List/mapWithIndex

### DIFF
--- a/Prelude/List/WithIndex
+++ b/Prelude/List/WithIndex
@@ -1,0 +1,3 @@
+  ./WithIndex.dhall
+    sha256:fd62c3fb18b64bde754288b7e1243115a51dd3b6ab2294b1c99fc7207f53fc78
+? ./WithIndex.dhall

--- a/Prelude/List/WithIndex.dhall
+++ b/Prelude/List/WithIndex.dhall
@@ -1,0 +1,6 @@
+--| Tag a type with an index, supporting indexed list operations
+let List/WithIndex
+    : ∀(a : Type) → Type
+    = λ(a : Type) → { index : Natural, value : a }
+
+in  List/WithIndex

--- a/Prelude/List/indexed.dhall
+++ b/Prelude/List/indexed.dhall
@@ -1,6 +1,8 @@
 --| Tag each element of the list with its index
+let List/WithIndex = ./WithIndex.dhall
+
 let indexed
-    : ∀(a : Type) → List a → List { index : Natural, value : a }
+    : ∀(a : Type) → List a → List (List/WithIndex a)
     = List/indexed
 
 let example0 =
@@ -12,8 +14,6 @@ let example0 =
           ]
 
 let example1 =
-        assert
-      :   indexed Bool ([] : List Bool)
-        ≡ ([] : List { index : Natural, value : Bool })
+      assert : indexed Bool ([] : List Bool) ≡ ([] : List (List/WithIndex Bool))
 
 in  indexed

--- a/Prelude/List/mapWithIndex
+++ b/Prelude/List/mapWithIndex
@@ -1,0 +1,3 @@
+  ./mapWithIndex.dhall
+    sha256:2de1664cd344e0709921fc1ee193ea834494bb07ae7dcf046e3fa7f7148a68e3
+? ./mapWithIndex.dhall

--- a/Prelude/List/mapWithIndex.dhall
+++ b/Prelude/List/mapWithIndex.dhall
@@ -1,0 +1,29 @@
+--| Transform a list by applying a function to each element with its index
+let List/map = ./map.dhall
+
+let List/WithIndex = ./WithIndex.dhall
+
+let List/mapWithIndex
+    : ∀(a : Type) → ∀(b : Type) → (List/WithIndex a → b) → List a → List b
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : List/WithIndex a → b) →
+      λ(list : List a) →
+        List/map (List/WithIndex a) b f (List/indexed a list)
+
+let List/empty = ./empty.dhall
+
+let List/replicate = ./replicate.dhall
+
+let example0 =
+        assert
+      :   List/mapWithIndex
+            Text
+            (List Text)
+            ( λ(indexedText : List/WithIndex Text) →
+                List/replicate indexedText.index Text indexedText.value
+            )
+            [ "A", "B", "C" ]
+        ≡ [ List/empty Text, [ "B" ], [ "C", "C" ] ]
+
+in  List/mapWithIndex

--- a/Prelude/List/package.dhall
+++ b/Prelude/List/package.dhall
@@ -78,6 +78,10 @@
       ./map.dhall
         sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
     ? ./map.dhall
+, mapWithIndex =
+      ./mapWithIndex.dhall
+        sha256:2de1664cd344e0709921fc1ee193ea834494bb07ae7dcf046e3fa7f7148a68e3
+    ? ./mapWithIndex.dhall
 , null =
       ./null.dhall
         sha256:2338e39637e9a50d66ae1482c0ed559bbcc11e9442bfca8f8c176bbcd9c4fc80
@@ -114,4 +118,8 @@
       ./zip.dhall
         sha256:85ed955eabf3998767f4ad2a28e57d40cd4c68a95519d79e9b622f1d26d979da
     ? ./zip.dhall
+, WithIndex =
+      ./WithIndex.dhall
+        sha256:fd62c3fb18b64bde754288b7e1243115a51dd3b6ab2294b1c99fc7207f53fc78
+    ? ./WithIndex.dhall
 }


### PR DESCRIPTION
A couple of times we've had to build an indexed list and then map over it to build some other structure. Figured it might be worth adding to Prelude since there is already `Prelude.List.indexed`.

This adds a supporting type function `WithIndex` and uses it in `indexed` and `mapWithIndex`.
