### PR TITLE
Prelude: Add List/mapMaybe and Map/mapMaybe

### DIFF
--- a/Prelude/List/mapMaybe.dhall
+++ b/Prelude/List/mapMaybe.dhall
@@ -1,0 +1,37 @@
+--| Apply a function across a list, keeping only the `Some` results.
+let List/unpackOptionals =
+        ./unpackOptionals.dhall
+          sha256:0cbaa920f429cf7fc3907f8a9143203fe948883913560e6e1043223e6b3d05e4
+      ? ./unpackOptionals.dhall
+
+let List/map =
+        ./map.dhall
+          sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
+      ? ./map.dhall
+
+let mapMaybe
+    : ∀(a : Type) → ∀(b : Type) → (a → Optional b) → List a → List b
+    = λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → Optional b) →
+      λ(xs : List a) →
+        List/unpackOptionals b (List/map a (Optional b) f xs)
+
+let property =
+      λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → Optional b) →
+        assert : mapMaybe a b f ([] : List a) ≡ ([] : List b)
+
+let example0 =
+        assert
+      :   mapMaybe
+            Natural
+            Text
+            ( λ(n : Natural) →
+                if Natural/isZero n then None Text else Some (Natural/show n)
+            )
+            [ 0, 1, 2, 3 ]
+        ≡ [ "1", "2", "3" ]
+
+in  mapMaybe

--- a/Prelude/List/package.dhall
+++ b/Prelude/List/package.dhall
@@ -78,6 +78,10 @@
       ./map.dhall
         sha256:dd845ffb4568d40327f2a817eb42d1c6138b929ca758d50bc33112ef3c885680
     ? ./map.dhall
+, mapMaybe =
+      ./mapMaybe.dhall
+        sha256:6f3c4f8c94577b46e7d30f8df7e82a269b0ad0a7e18c0f0370f243fd1127e77f
+    ? ./mapMaybe.dhall
 , mapWithIndex =
       ./mapWithIndex.dhall
         sha256:98599e0b55c5d3ae75264ba90657c6f68c7ce32834bd12b215acaea711eed6eb

--- a/Prelude/Map/mapMaybe.dhall
+++ b/Prelude/Map/mapMaybe.dhall
@@ -1,0 +1,56 @@
+--| Apply a function across the values of a `Map k v`, dropping
+-- entries whose values return `None`.
+let Map/empty =
+        ./empty.dhall
+          sha256:4c612558b8bbe8f955550ed3fb295d57b1b864c85cd52615b52d0ee0e9682e52
+      ? ./empty.dhall
+
+let Map/unpackOptionals =
+        ./unpackOptionals.dhall
+          sha256:66c3e6f6f81418cf99342e1dba739617c01af4b27c1ca5e2e1d7bce64a522e22
+      ? ./unpackOptionals.dhall
+
+let Map/map =
+        ./map.dhall
+          sha256:23e09b0b9f08649797dfe1ca39755d5e1c7cad2d0944bdd36c7a0bf804bde8d0
+      ? ./map.dhall
+
+let Map/Type =
+        ./Type.dhall
+          sha256:210c7a9eba71efbb0f7a66b3dcf8b9d3976ffc2bc0e907aadfb6aa29c333e8ed
+      ? ./Type.dhall
+
+let mapMaybe
+    : ∀(k : Type) →
+      ∀(a : Type) →
+      ∀(b : Type) →
+      (a → Optional b) →
+      Map/Type k a →
+        Map/Type k b
+    = λ(k : Type) →
+      λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → Optional b) →
+      λ(m : Map/Type k a) →
+        Map/unpackOptionals k b (Map/map k a (Optional b) f m)
+
+let property =
+      λ(k : Type) →
+      λ(a : Type) →
+      λ(b : Type) →
+      λ(f : a → Optional b) →
+        assert : mapMaybe k a b f (Map/empty k a) ≡ Map/empty k b
+
+let example0 =
+        assert
+      :   mapMaybe
+            Text
+            Natural
+            Text
+            ( λ(n : Natural) →
+                if Natural/isZero n then None Text else Some (Natural/show n)
+            )
+            (toMap { foo = 2, bar = 0 })
+        ≡ toMap { foo = "2" }
+
+in  mapMaybe

--- a/Prelude/Map/package.dhall
+++ b/Prelude/Map/package.dhall
@@ -26,6 +26,10 @@
       ./map
         sha256:23e09b0b9f08649797dfe1ca39755d5e1c7cad2d0944bdd36c7a0bf804bde8d0
     ? ./map
+, mapMaybe =
+      ./mapMaybe.dhall
+        sha256:4ea58b720d7af38cef3ef07bef36e476caeed21032cd4a9dc733868a74d9a521
+    ? ./mapMaybe.dhall
 , unpackOptionals =
       ./unpackOptionals.dhall
         sha256:66c3e6f6f81418cf99342e1dba739617c01af4b27c1ca5e2e1d7bce64a522e22

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -16,7 +16,7 @@
     ? ./Integer/package.dhall
 , List =
       ./List/package.dhall
-        sha256:1dc1520710a70c857e27d12fc8656060c31a06aac7db738664fdc238c40f5717
+        sha256:26d1b4cd800219d8b67043c638926aa6e5517ea74a0bd3e371974514621bca04
     ? ./List/package.dhall
 , Location =
       ./Location/package.dhall
@@ -24,7 +24,7 @@
     ? ./Location/package.dhall
 , Map =
       ./Map/package.dhall
-        sha256:c6602939eb75ddaf43e75a37e1f27ace97e03685ceb9d77605b4372547f7cfa8
+        sha256:c5e79a9de642644a09b96a2ec3147c5d8662b7926f09610e751c0c0f6ed0b30a
     ? ./Map/package.dhall
 , Monoid =
       ./Monoid.dhall

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -341,6 +341,12 @@
     , last : ∀(a : Type) → List a → Optional a
     , length : ∀(a : Type) → List a → Natural
     , map : ∀(a : Type) → ∀(b : Type) → ∀(f : a → b) → ∀(xs : List a) → List b
+    , mapMaybe :
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(f : a → Optional b) →
+        ∀(xs : List a) →
+          List b
     , mapWithIndex :
         ∀(a : Type) →
         ∀(b : Type) →
@@ -395,6 +401,13 @@
         ∀(a : Type) →
         ∀(b : Type) →
         ∀(f : a → b) →
+        ∀(m : List { mapKey : k, mapValue : a }) →
+          List { mapKey : k, mapValue : b }
+    , mapMaybe :
+        ∀(k : Type) →
+        ∀(a : Type) →
+        ∀(b : Type) →
+        ∀(f : a → Optional b) →
         ∀(m : List { mapKey : k, mapValue : a }) →
           List { mapKey : k, mapValue : b }
     , unpackOptionals :


### PR DESCRIPTION
`Map/mapMaybe` has proven useful when filtering maps into JSON, and wanting to discard keys instead of generating empty arrays. Added `List/mapMaybe` for symmetry.