### PR TITLE
Add test for changing type of field inside `Optional`

### DIFF
--- a/tests/type-inference/failure/unit/WithOptionalRecordTypeChanged.dhall
+++ b/tests/type-inference/failure/unit/WithOptionalRecordTypeChanged.dhall
@@ -1,0 +1,1 @@
+(None { x : Natural }) with ?.x = True


### PR DESCRIPTION
The Haskell implementation of Dhall had a bug where it permitted this update, leading to an invalid inferred type:

```dhall
⊢ (None { x : Natural }) with ?.x = True

None { x : Natural }
```