### PR TITLE
Fix `prelude.dhall-lang.org`

### DIFF
--- a/nixops/packages/Prelude_23_0_0.nix
+++ b/nixops/packages/Prelude_23_0_0.nix
@@ -1,0 +1,15 @@
+{ buildDhallGitHubPackage }:
+  buildDhallGitHubPackage {
+    name = "Prelude";
+    githubBase = "github.com";
+    owner = "dhall-lang";
+    repo = "dhall-lang";
+    rev = "v23.0.0";
+    fetchSubmodules = false;
+    sha256 = "00dkysbyhmrbsflqz4lddsqmx7ns0gg8i5j86vadbrz14w33jih0";
+    directory = "Prelude";
+    file = "package.dhall";
+    source = false;
+    document = false;
+    dependencies = [];
+    }

--- a/nixops/store.nix
+++ b/nixops/store.nix
@@ -71,6 +71,7 @@ let
     Prelude_21_0_0
     Prelude_21_1_0
     Prelude_22_0_0
+    Prelude_23_0_0
   ];
 
   toListItem =


### PR DESCRIPTION
Right now the URL is broken due to the Prelude being missing from `store.dhall-lang.org`