### PR TITLE
Fix: remove double minus sign

### DIFF
--- a/standard/beta-normalization.md
+++ b/standard/beta-normalization.md
@@ -2406,7 +2406,7 @@ betaNormalize (Application f a)
   where
     renderInteger n
         | 0 <= n    = "+" <> Text.pack (show n)
-        | otherwise = "-" <> Text.pack (show n)
+        | otherwise = Text.pack (show n)
 ```
 
 Note that the `Text` representation of the rendered `Integer` should include


### PR DESCRIPTION
I am not 100% sure what I am doing, but this looks like a bug, because for negative integers `show n` already contains the leading `-` sign.

On the other hand, perhaps `"-" <> Text.pack (show $ abs n)` would be more explicit?