### PR TITLE
Add missing +'s in hexadecimal Integer literals

### DIFF
--- a/docs/howtos/Cheatsheet.md
+++ b/docs/howtos/Cheatsheet.md
@@ -70,7 +70,7 @@
     ```dhall
     …, -2, -1, +0, +1, +2, … : Integer
 
-    …, -0x10, -0xF, -0xE, …, 0xE, 0xF, 0x10, … : Integer  -- Hexadecimal notation
+    …, -0x10, -0xF, -0xE, …, +0xE, +0xF, +0x10, … : Integer  -- Hexadecimal notation
 
     Integer/negate +2 = -2
 


### PR DESCRIPTION
Otherwise they're parsed as Naturals.