### PR TITLE
Fix comment formatting according to dhall-docs warnings

### DIFF
--- a/Prelude/Function/composeList.dhall
+++ b/Prelude/Function/composeList.dhall
@@ -1,5 +1,5 @@
-{-| Composes a list of functions starting from the left
-
+{-|
+Composes a list of functions starting from the left.
 -}
 let compose =
         missing

--- a/Prelude/Map/mapMaybe.dhall
+++ b/Prelude/Map/mapMaybe.dhall
@@ -1,5 +1,5 @@
 --| Apply a function across the values of a `Map k v`, dropping
--- entries whose values return `None`.
+--  entries whose values return `None`.
 let Map/empty =
         missing
           sha256:4c612558b8bbe8f955550ed3fb295d57b1b864c85cd52615b52d0ee0e9682e52


### PR DESCRIPTION
Ideally these should be detected by CI.