### PR TITLE
Fix logrotate for `nginx`

### DIFF
--- a/nixops/logical.nix
+++ b/nixops/logical.nix
@@ -150,7 +150,7 @@ in
       enable = true;
 
       configFile = pkgs.writeText "logrotate.conf" ''
-        /var/spool/nginx/logs/*.log {
+        /var/log/nginx/*.log  {
           create 0644 nginx nginx
           daily
           rotate 7
@@ -159,7 +159,7 @@ in
           compress
           sharedscripts
           postrotate
-            kill -USR1 "$(${pkgs.coreutils}/bin/cat /run/nginx/nginx.pid 2>/dev/null)" > /dev/null || true
+            systemctl reload nginx
           endscript
         }
       '';


### PR DESCRIPTION
Roughly four years ago the default log directory for `nginx` changed from `/var/spool/nginx/logs` to `/var/log/nginx`:

https://github.com/NixOS/nixpkgs/pull/85862

This caused `/var/log/nginx/access.log` to accumulate four years worth of logs (currently ≈27 GB at the time of this writing).

The fix is to update the `logrotate` script to point to the new log directory.

I also went ahead and simplified the `postrotate` script