### PR TITLE
docs: fix grammar in "Programmable configuration files" discussion

### DIFF
--- a/docs/discussions/Programmable-configuration-files.md
+++ b/docs/discussions/Programmable-configuration-files.md
@@ -453,7 +453,7 @@ Now we can define what a "programmable configuration file" is:
 
 You might be used to thinking of configuration files as being inert data but
 a "programmable configuration file" gives you access to programming language
-features (like functions) and lets you translate the file an inert format by
+features (like functions) and lets you translate the file to an inert format by
 evaluating all of the programming language features.
 
 [JSON]: https://en.wikipedia.org/wiki/JSON


### PR DESCRIPTION
Add missing word «to» in the last sentence of docs page "Programmable configuration files" (in the [subsection of the same name](https://docs.dhall-lang.org/discussions/Programmable-configuration-files.html#programmable-configuration-files)).

(We «**translate** something ***to*** something.»)