### PR TITLE
Minor fixes in howtos

### DIFF
--- a/docs/howtos/How-to-translate-recursive-code-to-Dhall.md
+++ b/docs/howtos/How-to-translate-recursive-code-to-Dhall.md
@@ -983,11 +983,11 @@ examine the first element of the list. If `headOptional` is called repeatedly, e
 
 The functions `concatNEL` and `reverseNEL` shown previously are quadratic in the length of the list because they use `foldNEL` twice nested.
 
-# Examples
+## Examples
 
 We will now illustrate the general recipe on more examples, showing how to translate recursive Haskell code into non-recursive Dhall definitions.
 
-## Recursive record
+### Recursive record
 
 Consider the following recursive Haskell code:
 
@@ -1137,7 +1137,7 @@ List Text
 [ "John", "Mary", "Jane" ]
 ```
 
-## Recursive union types
+### Recursive union types
 
 Recursive union types are covered by the same Church encoding recipe, except that their recursion schemes `F` will be union types.
 Instead of writing lots of `merge` expressions, it is more convenient to replace the type of functions `F r → r` by a curried function type.
@@ -1212,7 +1212,7 @@ Natural
 3
 ```
 
-## Mutually recursive types
+### Mutually recursive types
 
 The above pattern generalizes to mutually recursive types, too. For example,
 this Haskell code:
@@ -1294,7 +1294,7 @@ both of the Haskell `evenToNatural` and `oddToNatural` functions. You can
 define a separate `Even` and `evenToNatural` in Dhall, too, but they would not
 reuse any of the logic from `Odd` or `oddToNatural`.
 
-## Smart constructors
+### Smart constructors
 
 The `build` function shown earlier is, in principle, equivalent to all possible constructors that one may need when building values of a recursive type.
 When working with recursive union types, however, using the `build` function requires writing lots of `merge` expressions.
@@ -1545,12 +1545,12 @@ let SuccEven
          -- Here: ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
 ```
 
-## JSON
+### JSON
 
 You can see a real example of this pattern in the Prelude's support for
 [`JSON`](https://github.com/dhall-lang/dhall-lang/blob/master/Prelude/JSON/Type.dhall)
 
-## Conclusion
+### Conclusion
 
 The general algorithm for translating recursive code to non-recursive code is
 known as the Boehm-Berarducci encoding and is shown in this paper:

--- a/docs/howtos/Text-editor-configuration.md
+++ b/docs/howtos/Text-editor-configuration.md
@@ -1,10 +1,10 @@
-# Text Editor Configuration
+# Text editor configuration
 
 You can use the language server protocol `dhall-lsp-server` with different editors:
 
-* [Vim](#VIM)
-* [Emacs](#EMACS)
-* [Visual Studio Code](#vscode)
+* [Vim](#vim)
+* [Emacs](#emacs)
+* [Visual Studio Code](#visual-studio-code)
 
 The current LSP implementation features the following extensions:
 
@@ -18,7 +18,7 @@ to download the `dhall-lsp-server`. Make sure the command is in your search `PAT
 [installation]: <tutorials/Getting-started_Generate-JSON-or-YAML:installation>
 
 
-## VIM
+## Vim
 
 Using [LanguageClient](https://github.com/autozimu/LanguageClient-neovim):
 
@@ -87,7 +87,7 @@ Keys | Action
 `F5` | show all lsp client functions
 
 
-## EMACS
+## Emacs
 
 Using [lsp-mode](https://github.com/emacs-lsp/lsp-mode):
 
@@ -172,7 +172,7 @@ Here are the commands you need to know:
 [lsp-mode-configuration]: https://github.com/emacs-lsp/lsp-mode#configure-lsp-mode
 
 
-## vscode
+## Visual Studio Code
 
 Using [PanAeon/vscode-dhall-lsp-server][vscode-dhall]:
 

--- a/docs/howtos/index.md
+++ b/docs/howtos/index.md
@@ -8,7 +8,7 @@ These cookbooks teach you how to solve specific tasks:
    :maxdepth: 2
 
    How-to-integrate-Dhall
-   Text-Editor-Configuration
+   Text-editor-configuration
    Cheatsheet
    FAQ
    How-to-translate-recursive-code-to-Dhall

--- a/nixops/index.html
+++ b/nixops/index.html
@@ -120,6 +120,8 @@
             <div class="dropdown-menu" aria-labelledby="howtoDropdown">
               <a class="nav-link" href="https://docs.dhall-lang.org/howtos/How-to-integrate-Dhall.html">How to integrate Dhall</a>
               <div class="dropdown-divider"></div>
+              <a class="nav-link" href="https://docs.dhall-lang.org/howtos/Text-editor-configuration.html">Text editor configuration</a>
+              <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://docs.dhall-lang.org/howtos/Cheatsheet.html">Cheatsheet</a>
               <div class="dropdown-divider"></div>
               <a class="nav-link" href="https://docs.dhall-lang.org/howtos/FAQ.html">Frequently Asked Questions (FAQ)</a>


### PR DESCRIPTION
* add *Text editor configuration* to the Howtos dropdown menu on dhall-lang.org;
* change capitalization of section titles in the *Text editor configuration* howto;
* fix links in the *Text editor configuration* howto;
* increase header levels of the *Examples* section and its subsections in the *How to translate recursive code to Dhall* howto (becasue the *Examples* appeared as a separate howto in the table of contents):
![image](https://github.com/user-attachments/assets/24ec9b9f-ab64-4272-811f-feba4570a24e)
