### PR TITLE
typo. Update Programmable-configuration-files.md

### DIFF
--- a/docs/discussions/Programmable-configuration-files.md
+++ b/docs/discussions/Programmable-configuration-files.md
@@ -169,7 +169,7 @@ in  [ ordinaryUser "john"
 ```
 
 The above configuration has factored out the part that `john`, `jane`, and
-`alice` shared in common by creating a helper function named `ordinaryUser`.
+`chad` shared in common by creating a helper function named `ordinaryUser`.
 This function takes a single argument named `user` and computes the record for
 that user, including the public and private key paths.
 


### PR DESCRIPTION
seems that the example is talking about "chad" here, not "alice".