### PR TITLE
change tests to use local http servers

### DIFF
--- a/tests/import/data/cors/AllowedAll.dhall
+++ b/tests/import/data/cors/AllowedAll.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/AllowedAll.dhall
+http://127.0.0.1:18080/cors/AllowedAll.dhall

--- a/tests/import/data/cors/Empty.dhall
+++ b/tests/import/data/cors/Empty.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/Empty.dhall
+http://127.0.0.1:18080/cors/Empty.dhall

--- a/tests/import/data/cors/NoCORS.dhall
+++ b/tests/import/data/cors/NoCORS.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/NoCORS.dhall
+http://127.0.0.1:18080/cors/NoCORS.dhall

--- a/tests/import/data/cors/Null.dhall
+++ b/tests/import/data/cors/Null.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/Null.dhall
+http://127.0.0.1:18080/cors/Null.dhall

--- a/tests/import/data/cors/OnlyGithub.dhall
+++ b/tests/import/data/cors/OnlyGithub.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/OnlyGithub.dhall
+http://127.0.0.1:18080/cors/OnlyGithub.dhall

--- a/tests/import/data/cors/OnlyOther.dhall
+++ b/tests/import/data/cors/OnlyOther.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/OnlyOther.dhall
+http://127.0.0.1:18080/cors/OnlyOther.dhall

--- a/tests/import/data/cors/OnlySelf.dhall
+++ b/tests/import/data/cors/OnlySelf.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/OnlySelf.dhall
+http://127.0.0.1:18080/cors/OnlySelf.dhall

--- a/tests/import/data/cors/Prelude.dhall
+++ b/tests/import/data/cors/Prelude.dhall
@@ -1,1 +1,1 @@
-https://127.0.0.1:18080/Prelude/List/length
+http://127.0.0.1:18080/Prelude/List/length

--- a/tests/import/data/cors/Prelude.dhall
+++ b/tests/import/data/cors/Prelude.dhall
@@ -1,1 +1,1 @@
-https://prelude.dhall-lang.org/List/length
+https://127.0.0.1:18080/Prelude/List/length

--- a/tests/import/data/cors/SelfImportAbsolute.dhall
+++ b/tests/import/data/cors/SelfImportAbsolute.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/SelfImportAbsolute.dhall
+http://127.0.0.1:18080/cors/SelfImportAbsolute.dhall

--- a/tests/import/data/cors/SelfImportRelative.dhall
+++ b/tests/import/data/cors/SelfImportRelative.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/SelfImportRelative.dhall
+http://127.0.0.1:18080/cors/SelfImportRelative.dhall

--- a/tests/import/failure/customHeadersUsingBoundVariable.dhall
+++ b/tests/import/failure/customHeadersUsingBoundVariable.dhall
@@ -5,11 +5,9 @@
    * we also don't want custom headers to leak program state anyway
 
    This should fail due to the `x` within the custom header being an unbound
-   variable
+   variable. The actual http URL is irrelevant in this test.
 -}
-
 let x = "Bar"
 
-in http://localhost:18080/headers
-     using [ { mapKey = "Foo", mapValue = x } ]
-     as Text
+in  http://localhost:18080/user-agent using ([ { mapKey = "Foo", mapValue = x }
+                                             ]) as Text

--- a/tests/import/failure/customHeadersUsingBoundVariable.dhall
+++ b/tests/import/failure/customHeadersUsingBoundVariable.dhall
@@ -10,6 +10,6 @@
 
 let x = "Bar"
 
-in https://httpbin.org/headers
+in http://localhost:18080/headers
      using [ { mapKey = "Foo", mapValue = x } ]
      as Text

--- a/tests/import/failure/originHeadersFromRemote.dhall
+++ b/tests/import/failure/originHeadersFromRemote.dhall
@@ -1,1 +1,1 @@
-https://httpbin.org/user-agent as Text
+http://localhost:18080/user-agent as Text

--- a/tests/import/failure/originHeadersFromRemoteENV.dhall
+++ b/tests/import/failure/originHeadersFromRemoteENV.dhall
@@ -3,7 +3,7 @@ toMap
   { DHALL_HEADERS =
       ''
       toMap {
-        `httpbin.org:443` = toMap {
+        `localhost:18080` = toMap {
           `User-Agent` = http://example.com as Text
         }
       }

--- a/tests/import/failure/unit/404.dhall
+++ b/tests/import/failure/unit/404.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/nonexistent-file.dhall
+http://localhost:18080/nonexistent-file.dhall

--- a/tests/import/failure/unit/EnvFromRemote.dhall
+++ b/tests/import/failure/unit/EnvFromRemote.dhall
@@ -10,4 +10,4 @@
    referentially transparent.  Or in other words, any import that is globally
    addressable must have a meaning that is not context-sensitive.
 -}
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/tests/import/data/referentiallyOpaque.dhall
+http://localhost:18080/tests/import/data/referentiallyOpaque.dhall

--- a/tests/import/failure/unit/cors/Empty.dhall
+++ b/tests/import/failure/unit/cors/Empty.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/Empty.dhall
+http://localhost:18080/tests/import/data/cors/Empty.dhall

--- a/tests/import/failure/unit/cors/NoCORS.dhall
+++ b/tests/import/failure/unit/cors/NoCORS.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/NoCORS.dhall
+http://localhost:18080/tests/import/data/cors/NoCORS.dhall

--- a/tests/import/failure/unit/cors/Null.dhall
+++ b/tests/import/failure/unit/cors/Null.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/Null.dhall
+http://localhost:18080/tests/import/data/cors/Null.dhall

--- a/tests/import/failure/unit/cors/OnlyOther.dhall
+++ b/tests/import/failure/unit/cors/OnlyOther.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/OnlyOther.dhall
+http://localhost:18080/tests/import/data/cors/OnlyOther.dhall

--- a/tests/import/failure/unit/cors/OnlySelf.dhall
+++ b/tests/import/failure/unit/cors/OnlySelf.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/OnlySelf.dhall
+http://localhost:18080/tests/import/data/cors/OnlySelf.dhall

--- a/tests/import/failure/unit/cors/TwoHops.dhall
+++ b/tests/import/failure/unit/cors/TwoHops.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/TwoHopsFail.dhall
+http://127.0.0.1:18080/cors/TwoHopsFail.dhall

--- a/tests/import/success/customHeadersA.dhall
+++ b/tests/import/success/customHeadersA.dhall
@@ -1,3 +1,3 @@
-https://httpbin.org/user-agent
+http://localhost:18080/user-agent
   using [ { mapKey = "User-Agent", mapValue = "Dhall" } ]
   as Text

--- a/tests/import/success/headerForwardingA.dhall
+++ b/tests/import/success/headerForwardingA.dhall
@@ -5,8 +5,8 @@
    returns `True`, and both URLs reject all requests without a `Test` header.
 
    This test requires that the initial import to
-   `https://test.dhall-lang.org/foo` forwards the `Test` header
-   to the transitive relative import of `https://test.dhall-lang.org/bar` in
+   `http://localhost:18080/foo` forwards the `Test` header
+   to the transitive relative import of `http://localhost:18080/bar` in
    order to succeed.
 -}
-https://test.dhall-lang.org/foo using (toMap { Test = "Example" })
+http://localhost:18080/foo using (toMap { Test = "Example" })

--- a/tests/import/success/noHeaderForwardingA.dhall
+++ b/tests/import/success/noHeaderForwardingA.dhall
@@ -1,6 +1,6 @@
 {- The purpose of this test is to verify that the custom headers supplied to
    this import are not forwarded to the transitive import of
-   https://httpbin.org/user-agent
+   http://localhost:18080/user-agent
 -}
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/master/tests/import/success/customHeadersA.dhall
+http://localhost:18080/tests/import/success/customHeadersA.dhall
   using [ { mapKey = "User-Agent", mapValue = "Secret" } ]

--- a/tests/import/success/originHeadersA.dhall
+++ b/tests/import/success/originHeadersA.dhall
@@ -1,1 +1,1 @@
-https://httpbin.org/user-agent as Text
+http://localhost:18080/user-agent as Text

--- a/tests/import/success/originHeadersENV.dhall
+++ b/tests/import/success/originHeadersENV.dhall
@@ -2,7 +2,7 @@ toMap
   { DHALL_HEADERS =
       ''
       toMap {
-        `httpbin.org:443` = toMap {
+        `localhost:18080` = toMap {
           `User-Agent` = "Dhall"
         }
       }

--- a/tests/import/success/originHeadersImportA.dhall
+++ b/tests/import/success/originHeadersImportA.dhall
@@ -1,1 +1,1 @@
-https://httpbin.org/user-agent as Text
+http://localhost:18080/user-agent as Text

--- a/tests/import/success/originHeadersImportENV.dhall
+++ b/tests/import/success/originHeadersImportENV.dhall
@@ -2,7 +2,7 @@ toMap
   { DHALL_HEADERS =
       ''
       toMap {
-        `httpbin.org:443` = toMap {
+        `localhost:18080` = toMap {
           `User-Agent` = ./dhall-lang/tests/import/data/userAgent.dhall
         }
       }

--- a/tests/import/success/originHeadersImportFromEnvA.dhall
+++ b/tests/import/success/originHeadersImportFromEnvA.dhall
@@ -1,1 +1,1 @@
-https://httpbin.org/user-agent as Text
+http://localhost:18080/user-agent as Text

--- a/tests/import/success/originHeadersImportFromEnvENV.dhall
+++ b/tests/import/success/originHeadersImportFromEnvENV.dhall
@@ -2,7 +2,7 @@ toMap
   { DHALL_HEADERS =
       ''
       toMap {
-        `httpbin.org:443` = toMap {
+        `localhost:18080` = toMap {
           `User-Agent` = env:USER_AGENT as Text
         }
       }

--- a/tests/import/success/originHeadersOverrideA.dhall
+++ b/tests/import/success/originHeadersOverrideA.dhall
@@ -1,3 +1,3 @@
-https://httpbin.org/user-agent
+http://localhost:18080/user-agent
   using [ { mapKey = "User-Agent", mapValue = "inline-header" } ]
   as Text

--- a/tests/import/success/originHeadersOverrideENV.dhall
+++ b/tests/import/success/originHeadersOverrideENV.dhall
@@ -2,7 +2,7 @@ toMap
   { DHALL_HEADERS =
       ''
       toMap {
-        `httpbin.org:443` = toMap {
+        `localhost:18080` = toMap {
           `User-Agent` = "user-header"
         }
       }

--- a/tests/import/success/unit/RemoteAsTextA.dhall
+++ b/tests/import/success/unit/RemoteAsTextA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/0b983b92aa2222dc3e292c20550ee37dea3f41df/tests/import/data/example.txt as Text
+http://localhost:18080/tests/import/data/example.txt as Text

--- a/tests/import/success/unit/SimpleRemoteA.dhall
+++ b/tests/import/success/unit/SimpleRemoteA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/0b983b92aa2222dc3e292c20550ee37dea3f41df/tests/import/data/simple.dhall
+http://localhost:18080/tests/import/data/simple.dhall

--- a/tests/import/success/unit/asLocation/RemoteChain1A.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain1A.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/0b983b92aa2222dc3e292c20550ee37dea3f41df/tests/import/data/simpleLocation.dhall
+http://localhost:18080/tests/import/data/simpleLocation.dhall

--- a/tests/import/success/unit/asLocation/RemoteChain1B.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain1B.dhall
@@ -1,2 +1,2 @@
 < Environment : Text | Local : Text | Missing | Remote : Text >.Remote
-  "https://raw.githubusercontent.com/dhall-lang/dhall-lang/0b983b92aa2222dc3e292c20550ee37dea3f41df/tests/import/data/simple.dhall"
+  "http://localhost:18080/tests/import/data/simple.dhall"

--- a/tests/import/success/unit/asLocation/RemoteChain2A.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain2A.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/asLocation/Canonicalize3A.dhall
+http://localhost:18080/nadrieril/dhall/tests/import/success/unit/asLocation/Canonicalize3A.dhall

--- a/tests/import/success/unit/asLocation/RemoteChain2B.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain2B.dhall
@@ -1,2 +1,2 @@
 < Environment : Text | Local : Text | Missing | Remote : Text >.Remote
-  "https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/bar/import.dhall"
+  "http://localhost:18080/nadrieril/dhall/tests/import/success/unit/bar/import.dhall"

--- a/tests/import/success/unit/asLocation/RemoteChain3A.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain3A.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/asLocation/Canonicalize5A.dhall
+http://localhost:18080/nadrieril/dhall/tests/import/success/unit/asLocation/Canonicalize5A.dhall

--- a/tests/import/success/unit/asLocation/RemoteChain3B.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChain3B.dhall
@@ -1,2 +1,2 @@
 < Environment : Text | Local : Text | Missing | Remote : Text >.Remote
-  "https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/bar/import.dhall"
+  "http://localhost:18080/nadrieril/dhall/tests/import/success/unit/bar/import.dhall"

--- a/tests/import/success/unit/asLocation/RemoteChainEnvA.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChainEnvA.dhall
@@ -2,4 +2,4 @@
     This test verifies that `env:VAR as Location` isn't rejected as referentially opaque,
     as `env:VAR` on its own would.
 -}
-https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/asLocation/EnvA.dhall
+http://localhost:18080/nadrieril/dhall/tests/import/success/unit/asLocation/EnvA.dhall

--- a/tests/import/success/unit/asLocation/RemoteChainMissingA.dhall
+++ b/tests/import/success/unit/asLocation/RemoteChainMissingA.dhall
@@ -3,4 +3,4 @@
    * The `missing` should be treated as referentially transparent (and therefore
      be a valid transitive dependency of a remote import)
 -}
-https://raw.githubusercontent.com/Nadrieril/dhall-rust/f7d8c64a9799f139ad65427c2518376adb9e2e2f/dhall/tests/import/success/unit/asLocation/MissingA.dhall
+http://localhost:18080/nadrieril/dhall/tests/import/success/unit/asLocation/MissingA.dhall

--- a/tests/import/success/unit/cors/AllowedAllA.dhall
+++ b/tests/import/success/unit/cors/AllowedAllA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/AllowedAll.dhall
+http://localhost:18080/tests/import/data/cors/AllowedAll.dhall

--- a/tests/import/success/unit/cors/NoCORSFromLocalA.dhall
+++ b/tests/import/success/unit/cors/NoCORSFromLocalA.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/NoCORS.dhall
+http://127.0.0.1:18080/cors/NoCORS.dhall

--- a/tests/import/success/unit/cors/OnlyGithubA.dhall
+++ b/tests/import/success/unit/cors/OnlyGithubA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/OnlyGithub.dhall
+http://localhost:18080/tests/import/data/cors/OnlyGithub.dhall

--- a/tests/import/success/unit/cors/PreludeA.dhall
+++ b/tests/import/success/unit/cors/PreludeA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/acee30866a179c9e9bb3fc02ec8be2883685eb14/tests/import/data/cors/Prelude.dhall
+http://localhost:18080/tests/import/data/cors/Prelude.dhall

--- a/tests/import/success/unit/cors/SelfImportAbsolute2A.dhall
+++ b/tests/import/success/unit/cors/SelfImportAbsolute2A.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/SelfImportAbsolute.dhall
+http://127.0.0.1:18080/cors/SelfImportAbsolute.dhall

--- a/tests/import/success/unit/cors/SelfImportAbsoluteA.dhall
+++ b/tests/import/success/unit/cors/SelfImportAbsoluteA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/SelfImportAbsolute.dhall
+http://localhost:18080/tests/import/data/cors/SelfImportAbsolute.dhall

--- a/tests/import/success/unit/cors/SelfImportRelative2A.dhall
+++ b/tests/import/success/unit/cors/SelfImportRelative2A.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/SelfImportRelative.dhall
+http://127.0.0.1:18080/cors/SelfImportRelative.dhall

--- a/tests/import/success/unit/cors/SelfImportRelativeA.dhall
+++ b/tests/import/success/unit/cors/SelfImportRelativeA.dhall
@@ -1,1 +1,1 @@
-https://raw.githubusercontent.com/dhall-lang/dhall-lang/5ff7ecd2411894dd9ce307dc23020987361d2d43/tests/import/data/cors/SelfImportRelative.dhall
+http://localhost:18080/tests/import/data/cors/SelfImportRelative.dhall

--- a/tests/import/success/unit/cors/TwoHopsA.dhall
+++ b/tests/import/success/unit/cors/TwoHopsA.dhall
@@ -1,1 +1,1 @@
-https://test.dhall-lang.org/cors/TwoHopsSuccess.dhall
+http://127.0.0.1:18080/cors/TwoHopsSuccess.dhall

--- a/tests/type-inference/success/CacheImportsA.dhall
+++ b/tests/type-inference/success/CacheImportsA.dhall
@@ -5,7 +5,7 @@
 -}
 let _ =
 		assert
-	  :   https://test.dhall-lang.org/random-string as Text
-		≡ https://test.dhall-lang.org/random-string as Text
+	  :   http://localhost:18080/random-string as Text
+		≡ http://localhost:18080/random-string as Text
 
 in  0

--- a/tests/type-inference/success/CacheImportsCanonicalizeA.dhall
+++ b/tests/type-inference/success/CacheImportsCanonicalizeA.dhall
@@ -4,7 +4,7 @@
 -}
 let _ =
 		assert
-	  :   https://test.dhall-lang.org/random-string as Text
-		≡ https://test.dhall-lang.org/foo/../random-string as Text
+	  :   http://localhost:18080/random-string as Text
+		≡ http://localhost:18080/foo/../random-string as Text
 
 in  0


### PR DESCRIPTION
Tests in CI often fail intermittently due to httpbin.org failing or returning code 503, and more rarely due to failures of test.dhall-lang.org.

It is not really necessary to use external servers for tests. The required functionality (Web imports, headers, CORS compliance) can be tested with servers running on localhost.

The PR https://github.com/dhall-lang/dhall-haskell/pull/2767 adds a new Haskell package dhall-test-server that implements the required functionality and test fixtures for the standard tests. It runs local http servers during tests.

This  PR changes the standard tests to use the localhost servers rather than external servers.