### PR TITLE
Don't link to outdated GitHub wiki copies of pages

### DIFF
--- a/docs/discussions/Safety-guarantees.md
+++ b/docs/discussions/Safety-guarantees.md
@@ -545,8 +545,8 @@ expansion to this document.
 [hcl]: https://www.terraform.io/docs/configuration/syntax.html
 [jsonnet]: https://jsonnet.org/
 [json-schema]: https://json-schema.org/
-[json-tutorial]: https://github.com/dhall-lang/dhall-lang/wiki/Getting-started:-Generate-JSON-or-YAML
-[programmable]: https://github.com/dhall-lang/dhall-lang/wiki/Programmable-configuration-files
+[json-tutorial]: <tutorials/Getting-started_Generate-JSON-or-YAML>
+[programmable]: <discussions/Programmable-configuration-files>
 [sass]: https://sass-lang.com/
 [sbt]: https://www.scala-sbt.org/
 [webpack]: https://webpack.js.org/configuration/configuration-languages/

--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3791,5 +3791,5 @@ an issue here:
 We do our best to keep the tutorial up-to-date as the language evolves, but we
 sometimes miss things.
 
-[recursion]: https://github.com/dhall-lang/dhall-lang/wiki/How-to-translate-recursive-code-to-Dhall
+[recursion]: <howtos/How-to-translate-recursive-code-to-Dhall>
 [debruijn]: https://en.wikipedia.org/wiki/De_Bruijn_index


### PR DESCRIPTION
Currently some links still point to the GitHub wiki, even though the content has been moved to docs.dhall-lang.org. Change them to use relative links, so that they correctly point to the current versions of the pages.