### PR TITLE
Fix relative links introduced in #1436

### DIFF
--- a/docs/discussions/Safety-guarantees.md
+++ b/docs/discussions/Safety-guarantees.md
@@ -545,8 +545,8 @@ expansion to this document.
 [hcl]: https://www.terraform.io/docs/configuration/syntax.html
 [jsonnet]: https://jsonnet.org/
 [json-schema]: https://json-schema.org/
-[json-tutorial]: <tutorials/Getting-started_Generate-JSON-or-YAML>
-[programmable]: <discussions/Programmable-configuration-files>
+[json-tutorial]: <../tutorials/Getting-started_Generate-JSON-or-YAML>
+[programmable]: <../discussions/Programmable-configuration-files>
 [sass]: https://sass-lang.com/
 [sbt]: https://www.scala-sbt.org/
 [webpack]: https://webpack.js.org/configuration/configuration-languages/

--- a/docs/tutorials/Language-Tour.md
+++ b/docs/tutorials/Language-Tour.md
@@ -3791,5 +3791,5 @@ an issue here:
 We do our best to keep the tutorial up-to-date as the language evolves, but we
 sometimes miss things.
 
-[recursion]: <howtos/How-to-translate-recursive-code-to-Dhall>
+[recursion]: <../howtos/How-to-translate-recursive-code-to-Dhall>
 [debruijn]: https://en.wikipedia.org/wiki/De_Bruijn_index


### PR DESCRIPTION
The links introduced in #1436 are broken.

I fix this the same way it was done in the past:
https://github.com/dhall-lang/dhall-lang/blob/61d79c18c9c8f05c64c6806c2aa40820451fc78d/docs/howtos/FAQ.md?plain=1#L155
https://github.com/dhall-lang/dhall-lang/blob/61d79c18c9c8f05c64c6806c2aa40820451fc78d/docs/discussions/Core-language-features.md?plain=1#L933